### PR TITLE
Test first touch

### DIFF
--- a/README-dtq.md
+++ b/README-dtq.md
@@ -91,6 +91,14 @@ DSpace uses GitHub to track issues:
 By default, in DSpace, Unit Tests and Integration Tests are disabled. However, they are
 run automatically by [GitHub Actions](https://github.com/DSpace/DSpace/actions?query=workflow%3ABuild) for all Pull Requests and code commits.
 
+* Necessary parameters for running every Unit Test command to pass JVM memory flags: `test.argLine`, `surefireJacoco`. Example:
+  ```
+  mvn <ARGS> -Dtest.argLine=-Xmx1024m -DsurefireJacoco=-XX:MaxPermSize=256m
+  ```
+* Necessary parameters for running every Integration Test command to pass JVM memory flags: `test.argLine`, `failsafeJacoco`. Example:
+  ```
+  mvn <ARGS> -Dtest.argLine=-Xmx1024m -DfailsafeJacoco=-XX:MaxPermSize=256m
+  ```
 * How to run both Unit Tests (via `maven-surefire-plugin`) and Integration Tests (via `maven-failsafe-plugin`):
   ```
   mvn install -DskipUnitTests=false -DskipIntegrationTests=false
@@ -104,6 +112,8 @@ run automatically by [GitHub Actions](https://github.com/DSpace/DSpace/actions?q
   # Run all tests in a specific test class
   # NOTE: failIfNoTests=false is required to skip tests in other modules
   mvn test -DskipUnitTests=false -Dtest=[full.package.testClassName] -DfailIfNoTests=false
+  
+  # Example: mvn test -DskipUnitTests=false -Dtest=org.dspace.content.ItemTest.java -DfailIfNoTests=false -Dtest.argLine=-Xmx1024m -DsurefireJacoco=-XX:MaxPermSize=256m
 
   # Run one test method in a specific test class
   mvn test -DskipUnitTests=false -Dtest=[full.package.testClassName]#[testMethodName] -DfailIfNoTests=false
@@ -117,6 +127,9 @@ run automatically by [GitHub Actions](https://github.com/DSpace/DSpace/actions?q
   # Run all integration tests in a specific test class
   # NOTE: failIfNoTests=false is required to skip tests in other modules
   mvn install -DskipIntegrationTests=false -Dit.test=[full.package.testClassName] -DfailIfNoTests=false
+  
+  # Example:
+  mvn install -DskipIntegrationTests=false -Dit.test=org.dspace.content.ItemIT.java#dtqExampleTest -Dtest.argLine=-Xmx1024m -DfailsafeJacoco=-XX:MaxPermSize=256m
 
   # Run one test method in a specific test class
   mvn install -DskipIntegrationTests=false -Dit.test=[full.package.testClassName]#[testMethodName] -DfailIfNoTests=false

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ run automatically by [GitHub Actions](https://github.com/DSpace/DSpace/actions?q
   # Run all integration tests in a specific test class
   # NOTE: failIfNoTests=false is required to skip tests in other modules
   mvn install -DskipIntegrationTests=false -Dit.test=[full.package.testClassName] -DfailIfNoTests=false
+  
+  # Example:
+  mvn install -DskipIntegrationTests=false -Dit.test=org.dspace.content.ItemIT.java#dtqExampleTest -Dtest.argLine=-Xmx1024m -DfailsafeJacoco=-XX:MaxPermSize=256m
 
   # Run one test method in a specific test class
   mvn install -DskipIntegrationTests=false -Dit.test=[full.package.testClassName]#[testMethodName] -DfailIfNoTests=false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more information, visit http://www.dspace.org/
 DSpace consists of both a Java-based backend and an Angular-based frontend.
 
 * Backend (this codebase) provides a REST API, along with other machine-based interfaces (e.g. OAI-PMH, SWORD, etc)
-    * The REST Contract is at https://github.com/DSpace/RestContract
+  * The REST Contract is at https://github.com/DSpace/RestContract
 * Frontend (https://github.com/DSpace/dspace-angular/) is the User Interface built on the REST API
 
 Prior versions of DSpace (v6.x and below) used two different UIs (XMLUI and JSPUI). Those UIs are no longer supported in v7 (and above).
@@ -91,6 +91,14 @@ DSpace uses GitHub to track issues:
 By default, in DSpace, Unit Tests and Integration Tests are disabled. However, they are
 run automatically by [GitHub Actions](https://github.com/DSpace/DSpace/actions?query=workflow%3ABuild) for all Pull Requests and code commits.
 
+* Necessary parameters for running every Unit Test command to pass JVM memory flags: `test.argLine`, `surefireJacoco`. Example:
+  ```
+  mvn <ARGS> -Dtest.argLine=-Xmx1024m -DsurefireJacoco=-XX:MaxPermSize=256m
+  ```
+* Necessary parameters for running every Integration Test command to pass JVM memory flags: `test.argLine`, `failsafeJacoco`. Example:
+  ```
+  mvn <ARGS> -Dtest.argLine=-Xmx1024m -DfailsafeJacoco=-XX:MaxPermSize=256m
+  ```
 * How to run both Unit Tests (via `maven-surefire-plugin`) and Integration Tests (via `maven-failsafe-plugin`):
   ```
   mvn install -DskipUnitTests=false -DskipIntegrationTests=false
@@ -104,6 +112,8 @@ run automatically by [GitHub Actions](https://github.com/DSpace/DSpace/actions?q
   # Run all tests in a specific test class
   # NOTE: failIfNoTests=false is required to skip tests in other modules
   mvn test -DskipUnitTests=false -Dtest=[full.package.testClassName] -DfailIfNoTests=false
+  
+  # Example: mvn test -DskipUnitTests=false -Dtest=org.dspace.content.ItemTest.java -DfailIfNoTests=false -Dtest.argLine=-Xmx1024m -DsurefireJacoco=-XX:MaxPermSize=256m
 
   # Run one test method in a specific test class
   mvn test -DskipUnitTests=false -Dtest=[full.package.testClassName]#[testMethodName] -DfailIfNoTests=false

--- a/dspace-api/src/test/java/org/dspace/content/ItemIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemIT.java
@@ -1,0 +1,86 @@
+package org.dspace.content;
+
+import org.apache.logging.log4j.Logger;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.*;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ItemIT extends AbstractIntegrationTestWithDatabase {
+
+    /**
+     * log4j category
+     */
+    protected static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ItemTest.class);
+
+    /**
+     * Item instance for the tests
+     */
+    protected Item it;
+
+    protected ItemService itemService = ContentServiceFactory.getInstance()
+            .getItemService();
+    protected CommunityService communityService = ContentServiceFactory.getInstance()
+            .getCommunityService();
+    protected CollectionService collectionService = ContentServiceFactory.getInstance()
+            .getCollectionService();
+    protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance()
+            .getWorkspaceItemService();
+    protected InstallItemService installItemService = ContentServiceFactory.getInstance()
+            .getInstallItemService();
+
+
+    protected Collection collection;
+    protected Community owningCommunity;
+
+    /**
+     * Spy of AuthorizeService to use for tests
+     * (initialized / setup in @Before method)
+     */
+    private AuthorizeService authorizeServiceSpy;
+
+    /**
+     * Test of find method, of class Item.
+     */
+    @Test
+    public void dtqExampleTest() throws Exception {
+        // create item
+        //we have to create a new community in the database
+        context.turnOffAuthorisationSystem();
+        this.owningCommunity = communityService.create(null, context);
+        this.collection = collectionService.create(context, owningCommunity);
+        WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, true);
+        this.it = installItemService.installItem(context, workspaceItem);
+        context.restoreAuthSystemState();
+
+        // Find by id
+        // Get ID of item created in init()
+        UUID id = it.getID();
+        // Make sure we can find it via its ID
+        Item found = itemService.find(context, id);
+        assertThat("dtqExampleTest 0", found.getID(), equalTo(id));
+
+        // default discoverable should be true
+        assertThat("dtqExampleTest 1", found.isDiscoverable(), equalTo(true));
+
+        context.turnOffAuthorisationSystem();
+        // set discoverable and update
+        found.setDiscoverable(false);
+        itemService.update(context, found);
+        context.restoreAuthSystemState();
+
+
+        // find by id
+        Item foundAfterUpdate = itemService.find(context, id);
+        assertThat("dtqExampleTest 2", foundAfterUpdate.getID(), equalTo(id));
+
+        // check if discoverable changed
+        assertThat("dtqExampleTest 1", foundAfterUpdate.isDiscoverable(), equalTo(false));
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -188,29 +188,8 @@ public class ItemTest extends AbstractDSpaceObjectTest {
      */
     @Test
     public void dtqExampleTest() throws Exception {
-        // Find by id
-        // Get ID of item created in init()
-        UUID id = it.getID();
-        // Make sure we can find it via its ID
-        Item found = itemService.find(context, id);
-        assertThat("dtqExampleTest 0", found.getID(), equalTo(id));
-
-        // default discoverable should be true
-        assertThat("dtqExampleTest 1", found.isDiscoverable(), equalTo(true));
-
-        context.turnOffAuthorisationSystem();
-        // set discoverable and update
-        found.setDiscoverable(false);
-        itemService.update(context, found);
-        context.restoreAuthSystemState();
-
-
-        // find by id
-        Item foundAfterUpdate = itemService.find(context, id);
-        assertThat("dtqExampleTest 2", foundAfterUpdate.getID(), equalTo(id));
-
-        // check if discoverable changed
-        assertThat("dtqExampleTest 1", foundAfterUpdate.isDiscoverable(), equalTo(false));
+        // check if it is not null
+        assertThat("dtqExampleTest 0", this.it, notNullValue());
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -184,6 +184,36 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     }
 
     /**
+     * Test of find method, of class Item.
+     */
+    @Test
+    public void dtqExampleTest() throws Exception {
+        // Find by id
+        // Get ID of item created in init()
+        UUID id = it.getID();
+        // Make sure we can find it via its ID
+        Item found = itemService.find(context, id);
+        assertThat("dtqExampleTest 0", found.getID(), equalTo(id));
+
+        // default discoverable should be true
+        assertThat("dtqExampleTest 1", found.isDiscoverable(), equalTo(true));
+
+        context.turnOffAuthorisationSystem();
+        // set discoverable and update
+        found.setDiscoverable(false);
+        itemService.update(context, found);
+        context.restoreAuthSystemState();
+
+
+        // find by id
+        Item foundAfterUpdate = itemService.find(context, id);
+        assertThat("dtqExampleTest 2", foundAfterUpdate.getID(), equalTo(id));
+
+        // check if discoverable changed
+        assertThat("dtqExampleTest 1", foundAfterUpdate.isDiscoverable(), equalTo(false));
+    }
+
+    /**
      * Test of create method, of class Item.
      */
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityExampleIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityExampleIT.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class CommunityExampleTestIT extends AbstractControllerIntegrationTest {
+public class CommunityExampleIT extends AbstractControllerIntegrationTest {
 
     @Autowired
     AuthorizeService authorizeService;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityExampleTestIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityExampleTestIT.java
@@ -1,0 +1,85 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.MetadataRest;
+import org.dspace.app.rest.model.MetadataValueRest;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.core.Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CommunityExampleTestIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    AuthorizeService authorizeService;
+
+    private ObjectMapper mapper;
+    private CommunityRest comm;
+    private String authToken;
+
+    @Before
+    public void createStructure() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // Create a parent community
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        // ADD authorization on parent community
+        context.setCurrentUser(eperson);
+        authorizeService.addPolicy(context, parentCommunity, Constants.ADD, eperson);
+        context.restoreAuthSystemState();
+
+        this.authToken = getAuthToken(eperson.getEmail(), password);
+
+        this.mapper = new ObjectMapper();
+        this.comm = new CommunityRest();
+        // We send a name but the created community should set this to the title
+        this.comm.setName("Test Parent Community");
+        this.comm.setMetadata(new MetadataRest()
+                .put("dc.description",
+                        new MetadataValueRest("<p>Some cool HTML code here</p>"))
+                .put("dc.description.abstract",
+                        new MetadataValueRest("Sample top-level community created via the REST API"))
+                .put("dc.description.tableofcontents",
+                        new MetadataValueRest("<p>HTML News</p>"))
+                .put("dc.rights",
+                        new MetadataValueRest("Custom Copyright Text"))
+                .put("dc.title",
+                        new MetadataValueRest("Title Text")));
+    }
+
+    @Test
+    public void shouldCreateCommunity() throws Exception {
+        AtomicReference<UUID> idRef = new AtomicReference<>();
+        try {
+            getClient(authToken).perform(post("/api/core/communities")
+                            .content(mapper.writeValueAsBytes(comm))
+                            .param("parent", parentCommunity.getID().toString())
+                            .contentType(contentType))
+                    .andExpect(status().isCreated());
+        } finally {
+            // Delete the created community (cleanup after ourselves!)
+            CommunityBuilder.deleteCommunity(idRef.get());
+        }
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoverResultExampleTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoverResultExampleTest.java
@@ -1,0 +1,29 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.junit.Assert.assertSame;
+
+import org.dspace.discovery.DiscoverResult;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiscoverResultExampleTest {
+
+    @InjectMocks
+    private DiscoverResult discoverResult;
+
+    @Test
+    public void testBuildCommunity() throws Exception {
+        discoverResult.setSearchTime(120);
+        assertSame(120, discoverResult.getSearchTime());
+    }
+}


### PR DESCRIPTION
| Phases            | MM  | MB  | Total  |
|-----------------|----:|----:|-------:|
| ETA                  |  4  |    0 |        0 |
| Developing      |  4  |    0 |         0 |
| Review             |  0  |    0 |         0 |
| Total                |   -  |  -   |         0 |
| ETA est.             |      |      |         0 |
| ETA cust.           |   -  |  -   |        0 |
## Problem description
### Reported issues
### Not-reported issues
## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
