### PR TITLE
Created approximateDate local metadata type.

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -184,6 +184,22 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     }
 
     /**
+     * Test of find method, of class Item.
+     */
+    @Test
+    public void dtqExampleTest() throws Exception {
+        assertThat("dtqExampleTest 0", this.it, notNullValue());
+
+        context.turnOffAuthorisationSystem();
+        itemService.update(context, it);
+        context.restoreAuthSystemState();
+        MetadataSchema dspaceSchema = metadataSchemaService.find(context, "local");
+        MetadataField field = metadataFieldService.findByString(context, "local.approximateDate", '.');
+
+        assertThat("dtqExampleTest 1", field, nullValue());
+    }
+
+    /**
      * Test of create method, of class Item.
      */
     @Test

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -184,22 +184,6 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     }
 
     /**
-     * Test of find method, of class Item.
-     */
-    @Test
-    public void dtqExampleTest() throws Exception {
-        assertThat("dtqExampleTest 0", this.it, notNullValue());
-
-        context.turnOffAuthorisationSystem();
-        itemService.update(context, it);
-        context.restoreAuthSystemState();
-        MetadataSchema dspaceSchema = metadataSchemaService.find(context, "local");
-        MetadataField field = metadataFieldService.findByString(context, "local.approximateDate", '.');
-
-        assertThat("dtqExampleTest 1", field, nullValue());
-    }
-
-    /**
      * Test of create method, of class Item.
      */
     @Test

--- a/dspace-api/src/test/java/org/dspace/content/LocalMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/LocalMetadataTest.java
@@ -1,0 +1,38 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataFieldService;
+import org.junit.Test;
+
+/**
+ * Unit Tests for class MetadataFieldTest
+ *
+ * @author milanmajchrak
+ */
+public class LocalMetadataTest extends AbstractUnitTest {
+
+    private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
+
+    /**
+     * Test of existing custom metadata field `local.approximateDate.issued`
+     */
+    @Test
+    public void existApproximateData() throws Exception {
+        MetadataField field = metadataFieldService.findByString(context, "local.approximateDate.issued",
+                '.');
+
+        assertThat("existApproximateData 0", field, notNullValue());
+    }
+
+}

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -23,13 +23,11 @@
     <namespace>http://dspace.org/namespace/local/</namespace>
   </dc-schema>
 
-<!--
   <dc-type>
     <schema>local</schema>
-    <element></element>
-    <qualifier></qualifier>
-    <scope_note>Description of example metadata field.</scope_note>
+    <element>approximateDate</element>
+    <qualifier>issued</qualifier>
+    <scope_note>Date issued used where the point in time is uncertain; eg. a range.</scope_note>
   </dc-type>
--->
 
 </dspace-dc-types>


### PR DESCRIPTION
| Phases            | MM  | MB  | Total  |
|-----------------|----:|----:|-------:|
| ETA                  |  4.8  |    0 |        0 |
| Developing      |  12  |    0 |         0 |
| Review             |  0  |    0 |         0 |
| Total                |   -  |  -   |         0 |
| ETA est.             |      |      |         0 |
| ETA cust.           |   -  |  -   |        0 |
## Problem description
Some of the new items have unknown dates or date range. Is necessary to keep information about approximate date. If is a date approximated show that information in the Item view.

### Reported issues
### Not-reported issues
## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
1. Every change of the dspace in the configuration should be observed in the test environment. In our case when the file _local-types.xml_ was updated the changes wasn't observed in the test environment. 
Problem was that after generating a new sources (targer folder) the test environment was loaded from the local _.m2_ repository and wasn't created a new test environment. After deleting _testEnvironment.zip_ from the _.m2_ repository the changes was observed in the generated sources.

2. After running the test, the test data are created to the h2 database based on the dspace definition, e.g. metadata fields are created based on the _registries_. 
After creating a new local metadata type with not null tag <issued> you MUST find by string the metadata with issued in the tests. 
Example: 
Wrong: metadataFieldService.findByString(context, "local.approximateDate"
Right: metadataFieldService.findByString(context, "local.approximateDate.issued"
