### PR TITLE
Type bind from the submission-forms.xml is returned to the FE.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -562,6 +562,15 @@ public class DCInput {
     }
 
     /**
+     * Get the type bind list for use in determining whether
+     * to display this field in angular dynamic form building
+     * @return list of bound types
+     */
+    public List<String> getTypeBindList() {
+        return typeBind;
+    }
+
+    /**
      * Verify whether the current field contains an entity relationship
      * This also implies a relationship type is defined for this field
      * The field can contain both an entity relationship and a metadata field simultaneously

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -155,6 +155,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         inputField.setInput(inputRest);
         if (dcinput.isMetadataField()) {
             inputField.setSelectableMetadata(selectableMetadata);
+            inputField.setTypeBind(dcinput.getTypeBindList());
         }
         if (dcinput.isRelationshipField()) {
             selectableRelationship = getSelectableRelationships(dcinput);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
@@ -84,6 +84,11 @@ public class SubmissionFormFieldRest {
     private List<LanguageFormField> languageCodes;
 
     /**
+     * The list of type bind value
+     */
+    private List<String> typeBind;
+
+    /**
      * Getter for {@link #selectableMetadata}
      * 
      * @return {@link #selectableMetadata}
@@ -264,6 +269,14 @@ public class SubmissionFormFieldRest {
         if (visibility != null && (visibility.getMain() != null || visibility.getOther() != null)) {
             this.visibility = visibility;
         }
+    }
+
+    public List<String> getTypeBind() {
+        return typeBind;
+    }
+
+    public void setTypeBind(List<String> typeBind) {
+        this.typeBind = typeBind;
     }
 
     public SelectableRelationship getSelectableRelationship() {

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -95,8 +95,9 @@
                     <repeatable>false</repeatable>
                     <label>Date of Issue</label>
                     <style>col-sm-4</style>
+                    <type-bind>example</type-bind>
                     <input-type>date</input-type>
-                    <hint>Please give the date of previous publication or public distribution.
+                    <hint>Please give something date of previous publication or public distribution.
                         You can leave out the day and/or month if they aren't applicable.
                     </hint>
                     <required>You must enter at least the year.</required>


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  16  |    0 |     0 |      0 |        0 |
| Developing      |  2.5  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
Analysis: https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.wiki/tab::e772b310-ab05-4c06-969b-0fe5c1eb0490?context=%7B%22subEntityId%22%3A%22%7B%5C%22pageId%5C%22%3A17%2C%5C%22sectionId%5C%22%3A18%2C%5C%22origin%5C%22%3A2%7D%22%2C%22channelId%22%3A%2219%3A7JFvXzBjZ9zsmJbF-pwhHHq8YXh_180Po5WETFTcUSE1%40thread.tacv2%22%7D&tenantId=92195125-171e-4b93-a95a-73f79a3fd609

Specific input fields must be visible only for specific types of the submission. This visibility is defined in the _submission-forms.xml_ by tag `<type-bind>Submission type1</type-bind>`. The forms definition is returned to the FE by _SubmissionFormConverter.java_
### Reported issues
### Not-reported issues

