### PR TITLE
feature/se-5-handleDate

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -46,6 +46,15 @@ public class ItemConverter
 
     @Override
     public ItemRest convert(Item obj, Projection projection) {
+        List<MetadataValue> approximatedDates =
+                itemService.getMetadata(obj, "local", "approximateDate", "issued", Item.ANY, false);
+        if (CollectionUtils.isNotEmpty(approximatedDates) &&
+                StringUtils.isNotBlank(approximatedDates.get(0).getValue())) {
+            List<MetadataValue> issuedDates =
+                    itemService.getMetadata(obj, "dc", "date", "issued", Item.ANY, false);
+            issuedDates.forEach(metadataValue -> metadataValue.setValue(approximatedDates.get(0).getValue()));
+        }
+
         ItemRest item = super.convert(obj, projection);
         item.setInArchive(obj.isArchived());
         item.setDiscoverable(obj.isDiscoverable());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
@@ -45,6 +45,23 @@ public class ItemMatcher {
         );
     }
 
+    public static Matcher<? super Object> matchItemWithTitleAndApproximateDateIssued(Item item, String title,
+                                                                                     String approximateDateIssued) {
+        return allOf(
+                //Check item properties
+                matchItemProperties(item),
+
+                //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
+                hasJsonPath("$.metadata", allOf(
+                        matchMetadata("dc.title", title),
+                        matchMetadata("local.approximateDate.issued", approximateDateIssued),
+                        matchMetadata("dc.date.issued", approximateDateIssued))),
+
+                //Check links
+                matchLinks(item.getID())
+        );
+    }
+
     /**
      * Gets a matcher for all expected embeds when the full projection is requested.
      */


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  9.6  |    0 |     0 |      0 |        0 |
| Developing      |  2  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
For some items the date of creation is unknown or in date range. This information is stored in the approximateDate metadata. If approximateDate metadata is not null -> show value from this metadata instead of date issued.
