### PR TITLE
Separated config files, reverted dspace.cfg to original:

### DIFF
--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -9,8 +9,6 @@ spring.servlet.multipart.max-file-size = 4GB
 # Maximum size of a multipart request (i.e. max total size of all files in one request)
 spring.servlet.multipart.max-request-size = 4GB
 
-
-
-
-dspace.name = Dataquest+ Dspace 7.2.BETA
+# if its called differently, tests fail
+dspace.name = DSpace at My University
 

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -1,4 +1,7 @@
 ## File for changes to dspace.cfg - separated from original configuration file to see what we changed
+# one day similar to this
+# https://github.com/ufal/clarin-dspace/blob/clarin/utilities/project_helpers/config/local.conf.dist
+
 
 
 # Maximum size of a single uploaded file
@@ -8,7 +11,3 @@ spring.servlet.multipart.max-file-size = 4GB
 
 # Maximum size of a multipart request (i.e. max total size of all files in one request)
 spring.servlet.multipart.max-request-size = 4GB
-
-# if its called differently, tests fail
-dspace.name = DSpace at My University
-

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -1,0 +1,16 @@
+## File for changes to dspace.cfg - separated from original configuration file to see what we changed
+
+
+# Maximum size of a single uploaded file
+# The file bigger than maximum upload size could be uploaded by adding file URL to the
+# `local.bitstream.redirecToURL` metadata in the submission UI process.
+spring.servlet.multipart.max-file-size = 4GB
+
+# Maximum size of a multipart request (i.e. max total size of all files in one request)
+spring.servlet.multipart.max-request-size = 4GB
+
+
+
+
+dspace.name = Dataquest+ Dspace 7.2.BETA
+

--- a/dspace/config/config-definition.xml
+++ b/dspace/config/config-definition.xml
@@ -42,6 +42,11 @@
         <properties fileName="local.cfg" throwExceptionOnMissing="false" config-name="local" config-optional="true"
                     encoding="UTF-8" config-reload="true" reloadingRefreshDelay="5000"/>
 
+        <!-- Separate our changes from original dspace source -->
+        <!-- Overrides everything in modules and dspace.cfg, but not local.cfg -->
+        <properties fileName="clarin-dspace.cfg" throwExceptionOnMissing="true" config-name="clarin"
+                    encoding="UTF-8" config-reload="true" reloadingRefreshDelay="5000"/>
+
         <!-- Load our dspace.cfg (which in turn loads all module configs via "include=" statements) -->
         <!-- Check for reload every 5 seconds (5,000ms) -->
         <properties fileName="dspace.cfg" throwExceptionOnMissing="true" encoding="UTF-8" config-reload="true"

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -885,13 +885,10 @@ metadata.hide.dc.description.provenance = true
 # Defaults to true; If set to 'false', submitter has option to skip upload
 #webui.submit.upload.required = true
 
-# Maximum size of a single uploaded file
-# The file bigger than maximum upload size could be uploaded by adding file URL to the
-# `local.bitstream.redirecToURL` metadata in the submission UI process.
-spring.servlet.multipart.max-file-size = 4GB
-
-# Maximum size of a multipart request (i.e. max total size of all files in one request)
-spring.servlet.multipart.max-request-size = 4GB
+# Which field should be used for type-bind
+# Defaults to 'dc.type'; If changing this value, you must also update the related
+# dspace-angular environment configuration property submission.typeBind.field
+#submit.type-bind.field = dc.type
 
 #### Creative Commons settings ######
 
@@ -1559,6 +1556,12 @@ mail.helpdesk = ${mail.admin}
 mail.helpdesk.name = Help Desk
 # Should all Request Copy emails go to the helpdesk instead of the item submitter?
 request.item.helpdesk.override = false
+
+#------------------------------------------------------------------#
+#------------------SUBMISSION CONFIGURATION------------------------#
+#------------------------------------------------------------------#
+# Field to use for type binding, default dc.type
+submit.type-bind.field = dc.type
 
 
 #------------------------------------------------------------------#


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |    2 |     0 |      0 |        0 |
| Developing      |  0  |    2 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Separate our config changes
## Analysis
We need clarin-dspace.cfg (the new one) to take precedence over everything BUT local.cfg (which is not in repo, because its .gitignored, but can be used for local changes)
## Problems
Tried to find out which configs take preference, the overriding behaviour was weirdly inconsitent. Sometimes some values were taken from one file, others from another. Added new entry in config-definition.xml, which works as expected. When clarin-dspace.cfg is missing it should fail, but doesn't, did not manage to fix.