### PR TITLE
feature/se-9-uploadCMDI-cannot-remove

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamRemovePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamRemovePatchOperation.java
@@ -43,6 +43,7 @@ public class BitstreamRemovePatchOperation extends RemovePatchOperation<String> 
 
         Item item = source.getItem();
         List<Bundle> bbb = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
+        bbb.addAll(itemService.getBundles(item, Constants.METADATA_BUNDLE_NAME));
         Bitstream bitstream = null;
         external:
         for (Bundle bb : bbb) {


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  3  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
The CMDI cannot be removed if was uploaded to the METADATA bundle.

## Problems

### 1. Cannot create test where is deposited the WorkspaceItem with the cmdi file.
Solution: Create issue
- [ ] Create test to deposit item with CMDI file and remove CMDI file from METADATA bundle.