### PR TITLE
feature/se-4-autocomplete-bad-behavior

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataValueRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataValueRestRepository.java
@@ -15,12 +15,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -124,29 +124,25 @@ public class MetadataValueRestRepository extends DSpaceRestRepository<MetadataVa
                 this.createDiscoverQuery(metadataField, searchValue, pageable);
 
         if (ObjectUtils.isEmpty(discoverQuery)) {
-            // @TODO throw exception
+            throw new IllegalArgumentException("Cannot create a DiscoverQuery from the arguments.");
         }
 
         // regex if searchValue consist of numbers and characters
-        String regex = "(.)*(\\d)(.)*";
-        Pattern pattern = Pattern.compile(regex);
-        // if searchValue is mix numbers with characters
-        if (pattern.matcher(searchValue).matches()) {
-            List<String> characterList = null;
-            List<String> numberList = new ArrayList<>();
+        // \d - digit
+        String regexNumber = "(.)*(\\d)(.)*";
+        // \D - non digit
+        String regexString = "(.)*(\\D)(.)*";
+        Pattern patternNumber = Pattern.compile(regexNumber);
+        Pattern patternString = Pattern.compile(regexString);
+        // if the searchValue is mixed with numbers and characters the Solr ignore numbers by default
+        // divide the characters and numbers from searchValue to the separate queries and from separate queries
+        // create one complex query
+        if (patternNumber.matcher(searchValue).matches() && patternString.matcher(searchValue).matches()) {
+            List<String> characterList = this.extractCharacterListFromString(searchValue);
+            List<String> numberList = this.extractNumberListFromString(searchValue);
 
-            // get numbers from searchValue as List
-            Pattern numberRegex = Pattern.compile("-?\\d+");
-            Matcher numberMatcher = numberRegex.matcher(searchValue);
-            while (numberMatcher.find()) {
-                numberList.add(numberMatcher.group());
-            }
-
-            // get characters from searchValue as List
-            searchValue = searchValue.replaceAll("[0-9]", " ");
-            characterList = new LinkedList<>(Arrays.asList(searchValue.split(" ")));
-            // remove empty characters from the characterList
-            characterList.removeIf(characters -> characters == null || "".equals(characters));
+            String newQuery = this.composeQueryWithNumbersAndChars(metadataField, characterList, numberList);
+            discoverQuery.setQuery(newQuery);
         }
 
 
@@ -180,6 +176,11 @@ public class MetadataValueRestRepository extends DSpaceRestRepository<MetadataVa
         return converter.toRestPage(metadataValueWrappers, pageable, utils.obtainProjection());
     }
 
+    /**
+     * From searchValue get all String values which are separated by the number to the List of Strings.
+     * @param searchValue e.g. 'my1Search2'
+     * @return e.g. [my, Search]
+     */
     private List<String> extractCharacterListFromString(String searchValue) {
         List<String> characterList = null;
         // get characters from searchValue as List
@@ -190,7 +191,25 @@ public class MetadataValueRestRepository extends DSpaceRestRepository<MetadataVa
 
         return characterList;
     }
-    
+
+    /**
+     * From searchValue get all number values which are separated by the number to the List of Strings.
+     * @param searchValue e.g. 'my1Search2'
+     * @return e.g. [1, 2]
+     */
+    private List<String> extractNumberListFromString(String searchValue) {
+        List<String> numberList = new ArrayList<>();
+
+        // get numbers from searchValue as List
+        Pattern numberRegex = Pattern.compile("-?\\d+");
+        Matcher numberMatcher = numberRegex.matcher(searchValue);
+        while (numberMatcher.find()) {
+            numberList.add(numberMatcher.group());
+        }
+
+        return numberList;
+    }
+
     public List<MetadataValueWrapper> filterEUSponsors(List<MetadataValueWrapper> metadataWrappers) {
         return metadataWrappers.stream().filter(m -> !m.getMetadataValue().getValue().contains("info:eu-repo"))
                 .collect(Collectors.toList());
@@ -200,6 +219,42 @@ public class MetadataValueRestRepository extends DSpaceRestRepository<MetadataVa
         return metadataWrappers.stream().filter(
                 distinctByKey(metadataValueWrapper -> metadataValueWrapper.getMetadataValue().getValue()) )
                 .collect( Collectors.toList() );
+    }
+
+    /**
+     * From list of String and list of Numbers create a query for the SolrQuery.
+     * @param metadataField e.g. `dc.contributor.author`
+     * @param characterList e.g. [my, Search]
+     * @param numberList e.g. [1, 2]
+     * @return "dc.contributor.author:*my* AND dc.contributor.author:*Search* AND dc.contributor.author:*1* AND ..."
+     */
+    private String composeQueryWithNumbersAndChars(String metadataField, List<String> characterList,
+                                                   List<String> numberList) {
+        this.addQueryTemplateToList(metadataField, characterList);
+        this.addQueryTemplateToList(metadataField, numberList);
+
+        String joinedChars = String.join(" AND ", characterList);
+        String joinedNumbers = String.join(" AND ", numberList);
+        return joinedChars + " AND " + joinedNumbers;
+
+    }
+
+    /**
+     * Add SolrQuery template to the every item of the List
+     * @param metadataField e.g. `dc.contributor.author`
+     * @param stringList could be List of String or List of Numbers which are in the String format because of Solr
+     *                   e.g. [my, Search]
+     * @return [dc.contributor.author:*my*, dc.contributor.author:*Search*]
+     */
+    private List<String> addQueryTemplateToList(String metadataField, List<String> stringList) {
+        String template = metadataField + ":" + "*" + " " + "*";
+
+        AtomicInteger index = new AtomicInteger();
+        stringList.forEach(characters -> {
+            String queryString = template.replaceAll(" ", characters);
+            stringList.set(index.getAndIncrement(), queryString);
+        });
+        return stringList;
     }
 
     private DiscoverQuery createDiscoverQuery(String metadataField, String searchValue, Pageable pageable) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataValueRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataValueRestRepositoryIT.java
@@ -160,9 +160,83 @@ public class MetadataValueRestRepositoryIT extends AbstractControllerIntegration
 
         getClient().perform(get(SEARCH_BYVALUE_ENDPOINT)
                         .param("schema", metadataSchema)
-                        .param("element",metadataElement)
-                        .param("qualifier",metadataQualifier)
-                        .param("searchValue",searchValue))
+                        .param("element", metadataElement)
+                        .param("qualifier", metadataQualifier)
+                        .param("searchValue", searchValue))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.metadatavalues", Matchers.hasItem(
+                        MetadataValueMatcher.matchMetadataValueByKeys(titleMetadataValue.getValue(),
+                                titleMetadataValue.getLanguage(), titleMetadataValue.getAuthority(),
+                                titleMetadataValue.getConfidence(), titleMetadataValue.getPlace()))
+                ))
+                .andExpect(jsonPath("$.page.size", is(20)))
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void findByValue_searchValueWithStringAndNumber() throws Exception {
+        MetadataValue titleMetadataValue = this.getTitleMetadataValue();
+
+        // add number to the title
+        titleMetadataValue.setValue(titleMetadataValue.getValue() + "1");
+        context.turnOffAuthorisationSystem();
+
+        // update item with the new title
+        itemService.setMetadataSingleValue(context, publicItem, SCHEMA, ELEMENT, QUALIFIER, null,
+                titleMetadataValue.getValue());
+        itemService.update(context, publicItem);
+
+        context.restoreAuthSystemState();
+
+
+        String metadataSchema = titleMetadataValue.getMetadataField().getMetadataSchema().getName();
+        String metadataElement = titleMetadataValue.getMetadataField().getElement();
+        String metadataQualifier = titleMetadataValue.getMetadataField().getQualifier();
+        String searchValue = titleMetadataValue.getValue();
+
+        getClient().perform(get(SEARCH_BYVALUE_ENDPOINT)
+                        .param("schema", metadataSchema)
+                        .param("element", metadataElement)
+                        .param("qualifier", metadataQualifier)
+                        .param("searchValue", searchValue))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.metadatavalues", Matchers.hasItem(
+                        MetadataValueMatcher.matchMetadataValueByKeys(titleMetadataValue.getValue(),
+                                titleMetadataValue.getLanguage(), titleMetadataValue.getAuthority(),
+                                titleMetadataValue.getConfidence(), titleMetadataValue.getPlace()))
+                ))
+                .andExpect(jsonPath("$.page.size", is(20)))
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void findByValue_searchValueIsNumber() throws Exception {
+        MetadataValue titleMetadataValue = this.getTitleMetadataValue();
+
+        // add number to the title
+        titleMetadataValue.setValue("123");
+        context.turnOffAuthorisationSystem();
+
+        // update item with the new title
+        itemService.setMetadataSingleValue(context, publicItem, SCHEMA, ELEMENT, QUALIFIER, null,
+                titleMetadataValue.getValue());
+        itemService.update(context, publicItem);
+
+        context.restoreAuthSystemState();
+
+
+        String metadataSchema = titleMetadataValue.getMetadataField().getMetadataSchema().getName();
+        String metadataElement = titleMetadataValue.getMetadataField().getElement();
+        String metadataQualifier = titleMetadataValue.getMetadataField().getQualifier();
+        String searchValue = titleMetadataValue.getValue();
+
+        getClient().perform(get(SEARCH_BYVALUE_ENDPOINT)
+                        .param("schema", metadataSchema)
+                        .param("element", metadataElement)
+                        .param("qualifier", metadataQualifier)
+                        .param("searchValue", searchValue))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
                 .andExpect(jsonPath("$._embedded.metadatavalues", Matchers.hasItem(


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  6.5  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
After testing: https://github.com/dataquest-dev/DSpace/issues/16#issuecomment-1203874625

**Reason of the problem:** 
The Solr do not search values when the search expression consist of characters and numbers. DSpace creates SolrQuery like `*search*` and the asterisk in the end or in the beginning matches only for **characters**.
**Solution:**
If the search expression consist of characters and numbers e.g. `my1Search2` divide the characters and numbers from that search expression to the separate Solr Queries and from separate queries  create one complex query.
The mixed SolrQuery looks like this: `"dc.contributor.author:*my* AND dc.contributor.author:*Search* AND dc.contributor.author:*1* AND dc.contributor.author:*2* "`

I also asked an question about this Solr behavior in the DSpace Slack: https://dspace-org.slack.com/archives/C3SG47SGY/p1659538649497719?thread_ts=1659537524.764349&cid=C3SG47SGY