### PR TITLE
Internal discoveryrestcontrollerit tests are failing

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinDiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinDiscoveryRestControllerIT.java
@@ -70,8 +70,13 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
-@Ignore
-public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest {
+/**
+ * This class is modified version of the DiscoveryRestControllerIT. Because for CLARIN customization
+ * the facets/filters was updated and the tests were failing. So the test class had must be updated.
+ *
+ * @author Milan Majchrak (milan.majchrak at dataquest.sk)
+ */
+public class ClarinDiscoveryRestControllerIT extends AbstractControllerIntegrationTest {
     @Autowired
     ConfigurationService configurationService;
 
@@ -113,8 +118,10 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)))
                 );
     }
@@ -589,6 +596,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         ;
     }
 
+    @Ignore
     @Test
     public void discoverFacetsDateTest() throws Exception {
         //We turn off the authorization system in order to create the structure defined below
@@ -759,6 +767,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         ;
     }
 
+    @Ignore
     @Test
     public void discoverFacetsDateTestForHasMore() throws Exception {
         //We turn off the authorization system to create the structure defined below
@@ -872,6 +881,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
 
+    @Ignore
     @Test
     public void discoverFacetsDateTestWithSearchFilter() throws Exception {
 
@@ -973,7 +983,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         SearchFilterMatcher.titleFilter(),
                         SearchFilterMatcher.authorFilter(),
                         SearchFilterMatcher.subjectFilter(),
-                        SearchFilterMatcher.dateIssuedFilter(),
+//                       SearchFilterMatcher.dateIssuedFilter(),
                         SearchFilterMatcher.hasContentInOriginalBundleFilter(),
                         SearchFilterMatcher.hasFileNameInOriginalBundleFilter(),
                         SearchFilterMatcher.hasFileDescriptionInOriginalBundleFilter(),
@@ -982,7 +992,10 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         SearchFilterMatcher.isProjectOfPublicationRelation(),
                         SearchFilterMatcher.isOrgUnitOfPublicationRelation(),
                         SearchFilterMatcher.isPublicationOfJournalIssueRelation(),
-                        SearchFilterMatcher.isJournalOfPublicationRelation()
+                        SearchFilterMatcher.isJournalOfPublicationRelation(),
+                        SearchFilterMatcher.clarinLicenseRightsFilter(),
+                        SearchFilterMatcher.clarinItemsLanguageFilter(),
+                        SearchFilterMatcher.clarinItemsCommunityFilter()
                 )))
                 //These sortOptions need to be present as it's the default in the configuration
                 .andExpect(jsonPath("$.sortOptions", contains(
@@ -1128,7 +1141,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link
@@ -1267,7 +1282,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(true),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1357,7 +1374,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1437,7 +1456,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1545,7 +1566,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1625,7 +1648,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1660,7 +1685,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1696,7 +1723,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1736,7 +1765,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1823,7 +1854,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //We want to get the sort that's been used as well in the response
@@ -2034,7 +2067,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(true),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false)
                 )))
@@ -2125,7 +2160,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2215,7 +2252,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2299,7 +2338,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2378,7 +2419,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2463,7 +2506,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2643,7 +2688,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2787,7 +2834,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2863,7 +2912,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2937,7 +2988,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3012,7 +3065,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3097,7 +3152,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3166,7 +3223,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3240,7 +3299,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3315,7 +3376,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3390,7 +3453,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3466,7 +3531,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3540,7 +3607,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3615,7 +3684,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -4061,7 +4132,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                     .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                             FacetEntryMatcher.authorFacet(false),
                             FacetEntryMatcher.subjectFacet(false),
-                            FacetEntryMatcher.dateIssuedFacet(false),
+                            FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                            FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                            FacetEntryMatcher.clarinItemsCommunityFacet(false),
                             FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
                             FacetEntryMatcher.entityTypeFacet(false)
                     )))
@@ -5724,7 +5797,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         .param("size", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._links.first.href",containsString(
-            "/api/discover/facets/discoverable?configuration=administrativeView&sort=score,DESC&page=0&size=1")))
+                "/api/discover/facets/discoverable?configuration=administrativeView&sort=score,DESC&page=0&size=1")))
                 .andExpect(jsonPath("$._links.prev.href",containsString(
                 "/api/discover/facets/discoverable?configuration=administrativeView&sort=score,DESC&page=0&size=1")))
                 .andExpect(jsonPath("$._links.self.href",containsString(
@@ -5789,6 +5862,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     }
 
+    @Ignore
     @Test
     public void discoverFacetsTestWithDsoTypeTest() throws Exception {
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -112,9 +112,10 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)))
         );
     }
@@ -589,6 +590,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         ;
     }
 
+    @Ignore
     @Test
     public void discoverFacetsDateTest() throws Exception {
         //We turn off the authorization system in order to create the structure defined below
@@ -759,6 +761,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         ;
     }
 
+    @Ignore
     @Test
     public void discoverFacetsDateTestForHasMore() throws Exception {
         //We turn off the authorization system to create the structure defined below
@@ -872,6 +875,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
 
+    @Ignore
     @Test
     public void discoverFacetsDateTestWithSearchFilter() throws Exception {
 
@@ -973,7 +977,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        SearchFilterMatcher.titleFilter(),
                        SearchFilterMatcher.authorFilter(),
                        SearchFilterMatcher.subjectFilter(),
-                       SearchFilterMatcher.dateIssuedFilter(),
+//                       SearchFilterMatcher.dateIssuedFilter(),
                        SearchFilterMatcher.hasContentInOriginalBundleFilter(),
                        SearchFilterMatcher.hasFileNameInOriginalBundleFilter(),
                        SearchFilterMatcher.hasFileDescriptionInOriginalBundleFilter(),
@@ -983,7 +987,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        SearchFilterMatcher.isOrgUnitOfPublicationRelation(),
                        SearchFilterMatcher.isPublicationOfJournalIssueRelation(),
                        SearchFilterMatcher.isJournalOfPublicationRelation(),
-                       SearchFilterMatcher.clarinLicenseRightsFilter()
+                       SearchFilterMatcher.clarinLicenseRightsFilter(),
+                       SearchFilterMatcher.clarinItemsLanguageFilter(),
+                       SearchFilterMatcher.clarinItemsCommunityFilter()
                    )))
                    //These sortOptions need to be present as it's the default in the configuration
                    .andExpect(jsonPath("$.sortOptions", contains(
@@ -1129,8 +1135,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link
@@ -1269,8 +1276,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(true),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1360,8 +1368,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1441,8 +1450,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1550,8 +1560,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1631,8 +1642,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1667,8 +1679,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1704,8 +1717,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1745,8 +1759,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -1833,8 +1848,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //We want to get the sort that's been used as well in the response
@@ -2045,8 +2061,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(true),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false)
                 )))
@@ -2137,8 +2154,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2228,8 +2246,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2313,8 +2332,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2393,8 +2413,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2479,8 +2500,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2660,8 +2682,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2805,8 +2828,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -2882,8 +2906,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        FacetEntryMatcher.authorFacet(false),
                        FacetEntryMatcher.entityTypeFacet(false),
                        FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                           FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                           FacetEntryMatcher.clarinItemsCommunityFacet(false),
                            FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                                                                                         )))
                    //There always needs to be a self link available
@@ -2957,8 +2982,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3033,8 +3059,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        FacetEntryMatcher.authorFacet(false),
                        FacetEntryMatcher.entityTypeFacet(false),
                        FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                           FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                           FacetEntryMatcher.clarinItemsCommunityFacet(false),
                            FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                                                                                         )))
                    //There always needs to be a self link available
@@ -3119,8 +3146,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3189,8 +3217,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(true),
-                        FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3264,8 +3293,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3340,8 +3370,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        FacetEntryMatcher.authorFacet(false),
                        FacetEntryMatcher.entityTypeFacet(false),
                        FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                           FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                           FacetEntryMatcher.clarinItemsCommunityFacet(false),
                            FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                                                                                         )))
                    //There always needs to be a self link available
@@ -3416,8 +3447,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3493,8 +3525,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        FacetEntryMatcher.authorFacet(false),
                        FacetEntryMatcher.entityTypeFacet(false),
                        FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                           FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                           FacetEntryMatcher.clarinItemsCommunityFacet(false),
                            FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                                                                                         )))
                    //There always needs to be a self link available
@@ -3568,8 +3601,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.entityTypeFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false),
                         FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                        FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                        FacetEntryMatcher.clarinItemsCommunityFacet(false),
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
@@ -3644,8 +3678,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        FacetEntryMatcher.authorFacet(false),
                        FacetEntryMatcher.entityTypeFacet(false),
                        FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
                        FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                           FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                           FacetEntryMatcher.clarinItemsCommunityFacet(false),
                            FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                                                                                         )))
                    //There always needs to be a self link available
@@ -4091,8 +4126,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                     .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                             FacetEntryMatcher.authorFacet(false),
                             FacetEntryMatcher.subjectFacet(false),
-                            FacetEntryMatcher.dateIssuedFacet(false),
                             FacetEntryMatcher.clarinLicenseRightsFacet(false),
+                            FacetEntryMatcher.clarinItemsLanguageFacet(false),
+                            FacetEntryMatcher.clarinItemsCommunityFacet(false),
                             FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
                             FacetEntryMatcher.entityTypeFacet(false)
                     )))
@@ -5820,6 +5856,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     }
 
+    @Ignore
     @Test
     public void discoverFacetsTestWithDsoTypeTest() throws Exception {
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
@@ -109,6 +109,28 @@ public class FacetEntryMatcher {
         );
     }
 
+    public static Matcher<? super Object> clarinItemsLanguageFacet(boolean hasNext) {
+        return allOf(
+                hasJsonPath("$.name", is("language")),
+                hasJsonPath("$.facetType", is("standard")),
+                hasJsonPath("$.facetLimit", any(Integer.class)),
+                hasJsonPath("$._links.self.href", containsString("api/discover/facets/language")),
+                hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/language"))
+        );
+    }
+
+    public static Matcher<? super Object> clarinItemsCommunityFacet(boolean hasNext) {
+        return allOf(
+                hasJsonPath("$.name", is("items_owning_community")),
+                hasJsonPath("$.facetType", is("standard")),
+                hasJsonPath("$.facetLimit", any(Integer.class)),
+                hasJsonPath("$._links.self.href",
+                        containsString("api/discover/facets/items_owning_community")),
+                hasJsonPath("$._links", matchNextLink(hasNext,
+                        "api/discover/facets/items_owning_community"))
+        );
+    }
+
     /**
      * Check that a facet over the dc.type exists and match the default configuration
      * 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
@@ -165,4 +165,24 @@ public class SearchFilterMatcher {
                 checkOperators()
         );
     }
+
+    public static Matcher<? super Object> clarinItemsLanguageFilter() {
+        return allOf(
+                hasJsonPath("$.filter", is("language")),
+                hasJsonPath("$.hasFacets", is(true)),
+                hasJsonPath("$.type", is("standard")),
+                hasJsonPath("$.openByDefault", is(false)),
+                checkOperators()
+        );
+    }
+
+    public static Matcher<? super Object> clarinItemsCommunityFilter() {
+        return allOf(
+                hasJsonPath("$.filter", is("items_owning_community")),
+                hasJsonPath("$.hasFacets", is(true)),
+                hasJsonPath("$.type", is("standard")),
+                hasJsonPath("$.openByDefault", is(false)),
+                checkOperators()
+        );
+    }
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  2.5  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The test was failing because of changed search facets/filters. We removed dataIssued filter/facet and then the tests had started failing.
