### PR TITLE
migrate2clarin7/authors-name-surname-autocomplete

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataValueRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataValueRestRepository.java
@@ -152,13 +152,19 @@ public class MetadataValueRestRepository extends DSpaceRestRepository<MetadataVa
             DiscoverResult searchResult = searchService.search(context, discoverQuery);
             for (IndexableObject object : searchResult.getIndexableObjects()) {
                 if (object instanceof IndexableItem) {
-                    // get metadata values of the item
+                    // Get the item which has the metadata with the search value
                     List<MetadataValue> metadataValues = itemService.getMetadataByMetadataString(
                             ((IndexableItem) object).getIndexedObject(), metadataField);
 
+                    // The Item could have more metadata than the metadata with searching value, filter that metadata
+                    String finalSearchValue = searchValue;
+                    List<MetadataValue> filteredMetadataValues = metadataValues.stream()
+                            .filter(metadataValue -> metadataValue.getValue().contains(finalSearchValue))
+                            .collect(Collectors.toList());
+
                     // convert metadata values to the wrapper
                     List<MetadataValueWrapper> metadataValueWrapperList =
-                            this.convertMetadataValuesToWrappers(metadataValues);
+                            this.convertMetadataValuesToWrappers(filteredMetadataValues);
                     metadataValueWrappers.addAll(metadataValueWrapperList);
                 }
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataValueRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataValueRestRepositoryIT.java
@@ -46,6 +46,8 @@ public class MetadataValueRestRepositoryIT extends AbstractControllerIntegration
     private Item publicItem;
     private Item sponsorItem;
 
+    private Collection col;
+
     public static final String METADATAVALUES_ENDPOINT = "/api/core/metadatavalues/";
     private static final String SEARCH_BYVALUE_ENDPOINT = METADATAVALUES_ENDPOINT + "search/byValue";
 
@@ -63,7 +65,7 @@ public class MetadataValueRestRepositoryIT extends AbstractControllerIntegration
                 .withName("Parent Community")
                 .build();
 
-        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
+        col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
 
         // 2. Create item and add it to the collection
         publicItem = ItemBuilder.createItem(context, col)
@@ -286,6 +288,44 @@ public class MetadataValueRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(content().contentType(contentType))
                 .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
+
+    /**
+     * If the Item has more metadata values in the metadata field e.g. it has more authors, return only the
+     * values which matches the search value.
+     */
+    @Test
+    public void shouldReturnOneSuggestionWhenInputHasMoreMetadataValues() throws Exception {
+        Item cuteItem = ItemBuilder.createItem(context, col)
+                .withAuthor(AUTHOR)
+                .withAuthor("second author")
+                .withAuthor("third author")
+                .withMetadata(SPONSOR_SCHEMA, SPONSOR_ELEMENT, null, SPONSOR_VALUE )
+                .build();
+
+        MetadataValue titleMetadataValue = itemService.getMetadataByMetadataString(cuteItem,
+                StringUtils.join(Arrays.asList(SCHEMA, ELEMENT, QUALIFIER),".")).get(0);
+
+        String metadataSchema = titleMetadataValue.getMetadataField().getMetadataSchema().getName();
+        String metadataElement = titleMetadataValue.getMetadataField().getElement();
+        String metadataQualifier = titleMetadataValue.getMetadataField().getQualifier();
+        String searchValue = titleMetadataValue.getValue();
+
+        getClient().perform(get(SEARCH_BYVALUE_ENDPOINT)
+                        .param("schema", metadataSchema)
+                        .param("element",metadataElement)
+                        .param("qualifier",metadataQualifier)
+                        .param("searchValue",searchValue))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.metadatavalues", Matchers.hasItem(
+                        MetadataValueMatcher.matchMetadataValueByKeys(titleMetadataValue.getValue(),
+                                titleMetadataValue.getLanguage(), titleMetadataValue.getAuthority(),
+                                titleMetadataValue.getConfidence(), titleMetadataValue.getPlace()))
+                ))
+                .andExpect(jsonPath("$.page.size", is(20)))
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
 
     private MetadataValue getTitleMetadataValue() {
         return itemService.getMetadataByMetadataString(publicItem,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataValueRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataValueRestRepositoryIT.java
@@ -295,12 +295,14 @@ public class MetadataValueRestRepositoryIT extends AbstractControllerIntegration
      */
     @Test
     public void shouldReturnOneSuggestionWhenInputHasMoreMetadataValues() throws Exception {
+        context.turnOffAuthorisationSystem();
         Item cuteItem = ItemBuilder.createItem(context, col)
                 .withAuthor(AUTHOR)
                 .withAuthor("second author")
                 .withAuthor("third author")
                 .withMetadata(SPONSOR_SCHEMA, SPONSOR_ELEMENT, null, SPONSOR_VALUE )
                 .build();
+        context.restoreAuthSystemState();
 
         MetadataValue titleMetadataValue = itemService.getMetadataByMetadataString(cuteItem,
                 StringUtils.join(Arrays.asList(SCHEMA, ELEMENT, QUALIFIER),".")).get(0);

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -85,7 +85,7 @@
                     <dc-qualifier>author</dc-qualifier>
                     <repeatable>true</repeatable>
                     <label>Author</label>
-                    <input-type>autocomplete</input-type>
+                    <input-type>name</input-type>
                     <hint>Enter the author's name (Family name, Given names).</hint>
                     <required></required>
                     <!-- Example ACL field definition.

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -85,7 +85,7 @@
                     <dc-qualifier>author</dc-qualifier>
                     <repeatable>true</repeatable>
                     <label>Author</label>
-                    <input-type>name</input-type>
+                    <input-type>clarin-name</input-type>
                     <hint>Enter the author's name (Family name, Given names).</hint>
                     <required></required>
                     <!-- Example ACL field definition.


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  3.4  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  2  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Check the issue.

## Problems
- MetadataValueRestRepository return all metadata from the Item which metadata contains search value, e.g. the Item has 80 authors and the user is searching the author `John`. The Item has one of the authors with the name of `John` but the MetadataValueRestRepository returns all 80 authors. But now it is fixed.