### PR TITLE
64-BE/user could see withdrawn items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseDAO.java
@@ -8,8 +8,8 @@
 package org.dspace.browse;
 
 import java.util.List;
-import java.util.UUID;
 
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 
 /**
@@ -140,21 +140,21 @@ public interface BrowseDAO {
     public void setAscending(boolean ascending);
 
     /**
-     * Get the database ID of the container object.  The container object will be a
+     * Get the container object.  The container object will be a
      * Community or a Collection.
      *
-     * @return the database id of the container, or -1 if none is set
+     * @return the container, or null if none is set
      */
-    public UUID getContainerID();
+    public DSpaceObject getContainer();
 
     /**
-     * Set the database id of the container object.  This should be the id of a
-     * Community or Collection.  This will constrain the results of the browse
-     * to only items or values within items that appear in the given container.
+     * Set the container object.  This should be a Community or Collection.
+     * This will constrain the results of the browse to only items or values within items that appear in the given
+     * container and add the related configuration default filters.
      *
-     * @param containerID community/collection internal ID (UUID)
+     * @param container community/collection
      */
-    public void setContainerID(UUID containerID);
+    public void setContainer(DSpaceObject container);
 
     /**
      * get the name of the field in which to look for the container id.  This is
@@ -346,7 +346,7 @@ public interface BrowseDAO {
     public String getFilterValueField();
 
     /**
-     * Set he name of the field in which the value to constrain results is
+     * Set the name of the field in which the value to constrain results is
      * contained
      *
      * @param valueField the name of the field

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -140,12 +140,12 @@ public class BrowseEngine {
                 Collection col = (Collection) scope.getBrowseContainer();
                 dao.setContainerTable("collection2item");
                 dao.setContainerIDField("collection_id");
-                dao.setContainerID(col.getID());
+                dao.setContainer(col);
             } else if (scope.inCommunity()) {
                 Community com = (Community) scope.getBrowseContainer();
                 dao.setContainerTable("communities2item");
                 dao.setContainerIDField("community_id");
-                dao.setContainerID(com.getID());
+                dao.setContainer(com);
             }
         }
 
@@ -239,12 +239,12 @@ public class BrowseEngine {
                     Collection col = (Collection) scope.getBrowseContainer();
                     dao.setContainerTable("collection2item");
                     dao.setContainerIDField("collection_id");
-                    dao.setContainerID(col.getID());
+                    dao.setContainer(col);
                 } else if (scope.inCommunity()) {
                     Community com = (Community) scope.getBrowseContainer();
                     dao.setContainerTable("communities2item");
                     dao.setContainerIDField("community_id");
-                    dao.setContainerID(com.getID());
+                    dao.setContainer(com);
                 }
             }
 
@@ -408,12 +408,12 @@ public class BrowseEngine {
                     Collection col = (Collection) scope.getBrowseContainer();
                     dao.setContainerTable("collection2item");
                     dao.setContainerIDField("collection_id");
-                    dao.setContainerID(col.getID());
+                    dao.setContainer(col);
                 } else if (scope.inCommunity()) {
                     Community com = (Community) scope.getBrowseContainer();
                     dao.setContainerTable("communities2item");
                     dao.setContainerIDField("community_id");
-                    dao.setContainerID(com.getID());
+                    dao.setContainer(com);
                 }
             }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -176,7 +176,22 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                       .withSubject("AnotherTest").withSubject("TestingForMore")
                                       .withSubject("ExtraEntry")
                                       .build();
-
+        Item withdrawnItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("WithdrawnEntry")
+                .withdrawn()
+                .build();
+        Item privateItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Private item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("PrivateEntry")
+                .makeUnDiscoverable()
+                .build();
         context.restoreAuthSystemState();
 
         //** WHEN **
@@ -369,6 +384,23 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                       .withSubject("AnotherTest")
                                       .build();
 
+        Item withdrawnItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("WithdrawnEntry")
+                .withdrawn()
+                .build();
+        Item privateItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Private item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("PrivateEntry")
+                .makeUnDiscoverable()
+                .build();
+
         context.restoreAuthSystemState();
 
         //** WHEN **
@@ -406,6 +438,277 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                        ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-14"),
                        ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "zPublic item more", "2017-10-17")
                    )));
+
+        //** WHEN **
+        //An anonymous user browses the items that correspond with the PrivateEntry subject query
+        getClient().perform(get("/api/discover/browses/subject/items")
+                        .param("filterValue", "PrivateEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements because the item is private
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
+
+        //** WHEN **
+        //An anonymous user browses the items that correspond with the WithdrawnEntry subject query
+        getClient().perform(get("/api/discover/browses/subject/items")
+                        .param("filterValue", "WithdrawnEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements because the item is withdrawn
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
+    }
+
+    @Test
+    public void findBrowseBySubjectItemsWithScope() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+
+        //2. Two public items with the same subject and another public item that contains that same subject, but also
+        // another one
+        //   All of the items are readable by an Anonymous user
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("zPublic item more")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withSubject("ExtraEntry").withSubject("AnotherTest")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 3")
+                .withIssueDate("2016-02-14")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest")
+                .build();
+
+        Item withdrawnItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("WithdrawnEntry")
+                .withdrawn()
+                .build();
+        Item privateItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Private item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("PrivateEntry")
+                .makeUnDiscoverable()
+                .build();
+
+        context.restoreAuthSystemState();
+
+        //** WHEN **
+        //An anonymous user browses the items that correspond with the ExtraEntry subject query
+        getClient().perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "ExtraEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements in collection 2
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
+
+        //** WHEN **
+        //An anonymous user browses the items that correspond with the AnotherTest subject query
+        getClient().perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "AnotherTest"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be only two elements, the ones that we've added with the requested subject
+                // in collection 2
+                .andExpect(jsonPath("$.page.totalElements", is(2)))
+                .andExpect(jsonPath("$.page.size", is(20)))
+                //Verify that the title of the public and embargoed items are present and sorted descending
+                .andExpect(jsonPath("$._embedded.items", contains(
+                        ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13"),
+                        ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-14")
+                )));
+
+        //** WHEN **
+        //An anonymous user browses the items that correspond with the PrivateEntry subject query
+        getClient().perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "PrivateEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements because the item is private
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
+
+        //** WHEN **
+        //An anonymous user browses the items that correspond with the WithdrawnEntry subject query
+        getClient().perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "WithdrawnEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements because the item is withdrawn
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
+    }
+
+    @Test
+    public void findBrowseBySubjectItemsWithScopeAsAdmin() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+
+        //2. Two public items with the same subject and another public item that contains that same subject, but also
+        // another one
+        //   All of the items are readable by an Anonymous user
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("zPublic item more")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withSubject("ExtraEntry").withSubject("AnotherTest")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 3")
+                .withIssueDate("2016-02-14")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest")
+                .build();
+
+        Item withdrawnItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("WithdrawnEntry")
+                .withdrawn()
+                .build();
+        Item privateItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Private item 1")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("PrivateEntry")
+                .makeUnDiscoverable()
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+
+        //** WHEN **
+        //An admin user browses the items that correspond with the ExtraEntry subject query
+        getClient(adminToken).perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "ExtraEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements in collection 2
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
+
+        //** WHEN **
+        //An admin user browses the items that correspond with the AnotherTest subject query
+        getClient(adminToken).perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "AnotherTest"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be only two elements, the ones that we've added with the requested subject
+                // in collection 2
+                .andExpect(jsonPath("$.page.totalElements", is(2)))
+                .andExpect(jsonPath("$.page.size", is(20)))
+                //Verify that the title of the public and embargoed items are present and sorted descending
+                .andExpect(jsonPath("$._embedded.items", contains(
+                        ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13"),
+                        ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-14")
+                )));
+
+        //** WHEN **
+        //An admin user browses the items that correspond with the PrivateEntry subject query
+        getClient(adminToken).perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "PrivateEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements because the item is private
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
+
+        //** WHEN **
+        //An admin user browses the items that correspond with the WithdrawnEntry subject query
+        getClient(adminToken).perform(get("/api/discover/browses/subject/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("filterValue", "WithdrawnEntry"))
+                //** THEN **
+                //The status has to be 200
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //We expect there to be no elements because the item is withdrawn
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$.page.size", is(20)));
 
     }
 
@@ -501,6 +804,173 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    .andExpect(jsonPath("$._embedded.items[*].metadata", Matchers.allOf(
                            not(matchMetadata("dc.title", "This is a private item")),
                            not(matchMetadata("dc.title", "Internal publication")))));
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        //** WHEN **
+        //An anonymous user browses the items in the Browse by item endpoint
+        //sorted descending by tile
+        getClient(adminToken).perform(get("/api/discover/browses/title/items")
+                        .param("sort", "title,desc"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                .andExpect(jsonPath("$.page.size", is(20)))
+                .andExpect(jsonPath("$.page.totalElements", is(4)))
+                .andExpect(jsonPath("$.page.totalPages", is(1)))
+                .andExpect(jsonPath("$.page.number", is(0)))
+
+                .andExpect(jsonPath("$._embedded.items",
+                        contains(ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2,
+                                        "Public item 2",
+                                        "2016-02-13"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1,
+                                        "Public item 1",
+                                        "2017-10-17"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(internalItem,
+                                        "Internal publication",
+                                        "2016-09-19"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(embargoedItem,
+                                        "An embargoed publication",
+                                        "2017-08-10")
+                        )))
+
+                //The private and internal items must not be present
+                .andExpect(jsonPath("$._embedded.items[*].metadata", Matchers.allOf(
+                        not(matchMetadata("dc.title", "This is a private item")),
+                        not(matchMetadata("dc.title", "Internal publication")))));
+    }
+
+    @Test
+    public void findBrowseByTitleItemsWithScope() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+
+        //2. Two public items that are readable by Anonymous
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withSubject("Java").withSubject("Unit Testing")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("Angular").withSubject("Unit Testing")
+                .build();
+
+        //3. An item that has been made private
+        Item privateItem = ItemBuilder.createItem(context, col2)
+                .withTitle("This is a private item")
+                .withIssueDate("2015-03-12")
+                .withAuthor("Duck, Donald")
+                .withSubject("Cartoons").withSubject("Ducks")
+                .makeUnDiscoverable()
+                .build();
+
+        //4. An item with an item-level embargo
+        Item embargoedItem = ItemBuilder.createItem(context, col2)
+                .withTitle("An embargoed publication")
+                .withIssueDate("2017-08-10")
+                .withAuthor("Mouse, Mickey")
+                .withSubject("Cartoons").withSubject("Mice")
+                .withEmbargoPeriod("12 months")
+                .build();
+
+        //5. An item that is only readable for an internal groups
+        Group internalGroup = GroupBuilder.createGroup(context)
+                .withName("Internal Group")
+                .build();
+
+        Item internalItem = ItemBuilder.createItem(context, col2)
+                .withTitle("Internal publication")
+                .withIssueDate("2016-09-19")
+                .withAuthor("Doe, John")
+                .withSubject("Unknown")
+                .withReaderGroup(internalGroup)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        //** WHEN **
+        //An anonymous user browses the items in the Browse by item endpoint
+        //sorted descending by tile
+        getClient().perform(get("/api/discover/browses/title/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("sort", "title,desc"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                .andExpect(jsonPath("$.page.size", is(20)))
+                .andExpect(jsonPath("$.page.totalElements", is(1)))
+                .andExpect(jsonPath("$.page.totalPages", is(1)))
+                .andExpect(jsonPath("$.page.number", is(0)))
+
+                .andExpect(jsonPath("$._embedded.items",
+                        contains(ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2,
+                                "Public item 2",
+                                "2016-02-13"))))
+
+                //The private and internal items must not be present
+                .andExpect(jsonPath("$._embedded.items[*].metadata", Matchers.allOf(
+                        not(matchMetadata("dc.title", "This is a private item")),
+                        not(matchMetadata("dc.title", "Internal publication")))));
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        //** WHEN **
+        //An admin user browses the items in the Browse by item endpoint
+        //sorted descending by tile
+        getClient(adminToken).perform(get("/api/discover/browses/title/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("sort", "title,desc"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                .andExpect(jsonPath("$.page.size", is(20)))
+                .andExpect(jsonPath("$.page.totalElements", is(3)))
+                .andExpect(jsonPath("$.page.totalPages", is(1)))
+                .andExpect(jsonPath("$.page.number", is(0)))
+                .andExpect(jsonPath("$._embedded.items", contains(
+                        ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2,
+                                "Public item 2",
+                                "2016-02-13"),
+                        ItemMatcher.matchItemWithTitleAndDateIssued(internalItem,
+                                "Internal publication",
+                                "2016-09-19"),
+                        ItemMatcher.matchItemWithTitleAndDateIssued(embargoedItem,
+                                "An embargoed publication",
+                                "2017-08-10")
+
+                )))
+
+
+                //The private and internal items must not be present
+                .andExpect(jsonPath("$._embedded.items[*].metadata", Matchers.allOf(
+                        not(matchMetadata("dc.title", "This is a private item"))
+                )));
     }
 
     @Test
@@ -623,6 +1093,18 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                 .withIssueDate("2016-01-12")
                                 .build();
 
+        Item withdrawnItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn item 1")
+                .withIssueDate("2016-02-13")
+                .withdrawn()
+                .build();
+
+        Item privateItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Private item 1")
+                .makeUnDiscoverable()
+                .build();
+
+
         context.restoreAuthSystemState();
 
         //** WHEN **
@@ -682,6 +1164,158 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                                 ItemMatcher.matchItemWithTitleAndDateIssued(item7,
                                                                                             "Item 7", "2016-01-12")
                                        )));
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        //The next page gives us the last two items
+        getClient(adminToken).perform(get("/api/discover/browses/dateissued/items")
+                        .param("sort", "title,asc")
+                        .param("size", "5")
+                        .param("page", "1"))
+
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                //We expect only the first five items to be present
+                .andExpect(jsonPath("$.page.size", is(5)))
+                .andExpect(jsonPath("$.page.totalElements", is(7)))
+                .andExpect(jsonPath("$.page.totalPages", is(2)))
+                .andExpect(jsonPath("$.page.number", is(1)))
+
+                //Verify that the title and date of the items match and that they are sorted ascending
+                .andExpect(jsonPath("$._embedded.items",
+                        contains(ItemMatcher.matchItemWithTitleAndDateIssued(item6,
+                                        "Item 6", "2016-01-13"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item7,
+                                        "Item 7", "2016-01-12")
+                        )));
+    }
+
+    @Test
+    public void testPaginationBrowseByDateIssuedItemsWithScope() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+
+        //2. 7 public items that are readable by Anonymous
+        Item item1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Item 1")
+                .withIssueDate("2017-10-17")
+                .build();
+
+        Item item2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Item 2")
+                .withIssueDate("2016-02-13")
+                .build();
+
+        Item item3 = ItemBuilder.createItem(context, col1)
+                .withTitle("Item 3")
+                .withIssueDate("2016-02-12")
+                .build();
+
+        Item item4 = ItemBuilder.createItem(context, col2)
+                .withTitle("Item 4")
+                .withIssueDate("2016-02-11")
+                .build();
+
+        Item item5 = ItemBuilder.createItem(context, col1)
+                .withTitle("Item 5")
+                .withIssueDate("2016-02-10")
+                .build();
+
+        Item item6 = ItemBuilder.createItem(context, col2)
+                .withTitle("Item 6")
+                .withIssueDate("2016-01-13")
+                .build();
+
+        Item item7 = ItemBuilder.createItem(context, col1)
+                .withTitle("Item 7")
+                .withIssueDate("2016-01-12")
+                .build();
+
+        Item withdrawnItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn item 1")
+                .withIssueDate("2016-02-13")
+                .withdrawn()
+                .build();
+
+        Item privateItem1 = ItemBuilder.createItem(context, col2)
+                .withTitle("Private item 1")
+                .makeUnDiscoverable()
+                .build();
+
+
+        context.restoreAuthSystemState();
+
+        //** WHEN **
+        //An anonymous user browses the items in the Browse by date issued endpoint
+        //sorted ascending by tile with a page size of 5
+        getClient().perform(get("/api/discover/browses/dateissued/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("sort", "title,asc")
+                        .param("size", "5"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                //We expect only the first five items to be present
+                .andExpect(jsonPath("$.page.size", is(5)))
+                .andExpect(jsonPath("$.page.totalElements", is(3)))
+                .andExpect(jsonPath("$.page.totalPages", is(1)))
+                .andExpect(jsonPath("$.page.number", is(0)))
+
+                //Verify that the title and date of the items match and that they are sorted ascending
+                .andExpect(jsonPath("$._embedded.items",
+                        contains(
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item2,
+                                        "Item 2", "2016-02-13"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item4,
+                                        "Item 4", "2016-02-11"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item6,
+                                        "Item 6", "2016-01-13")
+                        )));
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/discover/browses/dateissued/items")
+                        .param("scope", String.valueOf(col2.getID()))
+                        .param("sort", "title,asc")
+                        .param("size", "5"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                //We expect only the first five items to be present
+                .andExpect(jsonPath("$.page.size", is(5)))
+                .andExpect(jsonPath("$.page.totalElements", is(3)))
+                .andExpect(jsonPath("$.page.totalPages", is(1)))
+                .andExpect(jsonPath("$.page.number", is(0)))
+
+                //Verify that the title and date of the items match and that they are sorted ascending
+                .andExpect(jsonPath("$._embedded.items",
+                        contains(
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item2,
+                                        "Item 2", "2016-02-13"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item4,
+                                        "Item 4", "2016-02-11"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item6,
+                                        "Item 6", "2016-01-13")
+                        )));
     }
 
     @Test

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1067,7 +1067,10 @@ webui.browse.index.1 = dateissued:item:dateissued
 webui.browse.index.2 = author:metadata:dc.contributor.*\,dc.creator:text
 webui.browse.index.3 = title:item:title
 webui.browse.index.4 = subject:metadata:dc.subject.*:text
-#webui.browse.index.5 = dateaccessioned:item:dateaccessioned
+webui.browse.index.5 = publisher:metadata:dc.publisher:text
+webui.browse.index.6 = language:metadata:dc.language.iso:iso_lang
+webui.browse.index.7 = itemtype:metadata:dc.type:text
+webui.browse.index.8 = rights:metadata:dc.rights.label:text
 
 ## example of authority-controlled browse category - see authority control config
 #webui.browse.index.5 = lcAuthor:metadataAuthority:dc.contributor.author:authority

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -158,6 +158,7 @@
                 <ref bean="searchFilterRights" />
                 <ref bean="searchFilterLanguage" />
                 <ref bean="searchFilterItemsCommunity"/>
+                <ref bean="searchFilterType"/>
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -1656,6 +1657,19 @@
         <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
 
+    <bean id="searchFilterType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="itemtype"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.type</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="type" value="standard"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+    </bean>
+
     <bean id="searchFilterEntityType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="entityType"/>
         <property name="metadataFields">
@@ -1726,15 +1740,6 @@
         <property name="indexFieldName" value="original_bundle_descriptions"/>
         <property name="metadataFields">
             <list/>
-        </property>
-    </bean>
-
-    <bean id="searchFilterType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
-        <property name="indexFieldName" value="itemtype" />
-        <property name="metadataFields">
-            <list>
-                <value>dc.type</value>
-            </list>
         </property>
     </bean>
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -179,6 +179,7 @@
             <list>
                 <!--Only find items, communities and collections-->
                 <value>search.resourcetype:Item OR search.resourcetype:Collection OR search.resourcetype:Community</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
         <!--The configuration for the recent submissions-->


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  2.4  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  3.5  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
I copied code from the vanilla DSpace where this issue is fixed: https://github.com/DSpace/DSpace/pull/8642 and I updated discovery.xml to do not search withdrawn items.
 
