### PR TITLE
93BE/hide-some-metadata-fields-from-full-item-page

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/service/MetadataExposureService.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/MetadataExposureService.java
@@ -9,6 +9,7 @@ package org.dspace.app.util.service;
 
 import java.sql.SQLException;
 
+import org.dspace.content.Item;
 import org.dspace.core.Context;
 
 /**
@@ -62,4 +63,19 @@ public interface MetadataExposureService {
      */
     public boolean isHidden(Context context, String schema, String element, String qualifier)
         throws SQLException;
+
+    /**
+     * Returns whether the given metadata field should be exposed (visible). The metadata field is in the DSpace's DC
+     * notation: schema.element.qualifier
+     *
+     * @param context   DSpace context
+     * @param schema    metadata field schema (namespace), e.g. "dc"
+     * @param element   metadata field element
+     * @param qualifier metadata field qualifier
+     * @param item      check if the user is submitter of this item
+     * @return true (hidden) or false (exposed)
+     * @throws SQLException if database error
+     */
+    public boolean isHidden(Context context, String schema, String element, String qualifier, Item item)
+            throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseServiceImpl.java
@@ -185,11 +185,6 @@ public class ClarinLicenseServiceImpl implements ClarinLicenseService {
 
     @Override
     public List<ClarinLicense> findAll(Context context) throws SQLException, AuthorizeException {
-        if (!authorizeService.isAdmin(context)) {
-            throw new AuthorizeException(
-                     "You must be an admin to create an CLARIN License");
-        }
-
         return clarinLicenseDAO.findAll(context, ClarinLicense.class);
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -113,7 +113,7 @@ public class ItemConverter
                 if (!metadataExposureService
                         .isHidden(context, metadataField.getMetadataSchema().getName(),
                                   metadataField.getElement(),
-                                  metadataField.getQualifier())) {
+                                  metadataField.getQualifier(), obj)) {
                     returnList.add(mv);
                 }
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinLicenseRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinLicenseRestRepository.java
@@ -119,7 +119,7 @@ public class ClarinLicenseRestRepository extends DSpaceRestRepository<ClarinLice
     }
 
     @Override
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("permitAll()")
     public Page<ClarinLicenseRest> findAll(Context context, Pageable pageable) {
         try {
             List<ClarinLicense> clarinLicenseList = clarinLicenseService.findAll(context);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.matcher;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.dspace.app.rest.matcher.HalMatcher.matchEmbeds;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataDoesNotExist;
 import static org.dspace.app.rest.test.AbstractControllerIntegrationTest.REST_SERVER_URL;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
@@ -56,6 +57,44 @@ public class ItemMatcher {
                         matchMetadata("dc.title", title),
                         matchMetadata("local.approximateDate.issued", approximateDateIssued),
                         matchMetadata("dc.date.issued", approximateDateIssued))),
+
+                //Check links
+                matchLinks(item.getID())
+        );
+    }
+
+    /**
+     * The item has the metadata `local.submission.note`
+     */
+    public static Matcher<? super Object> matchItemWithTitleAndLocalNote(Item item, String title,
+                                                                                     String localNote) {
+        return allOf(
+                //Check item properties
+                matchItemProperties(item),
+
+                //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
+                hasJsonPath("$.metadata", allOf(
+                        matchMetadata("dc.title", title),
+                        matchMetadata("local.submission.note", localNote))),
+
+                //Check links
+                matchLinks(item.getID())
+        );
+    }
+
+    /**
+     * The item doesn't have the metadata `local.submission.note`
+     */
+    public static Matcher<? super Object> notMatchItemWithTitleAndLocalNote(Item item, String title,
+                                                                         String localNote) {
+        return allOf(
+                //Check item properties
+                matchItemProperties(item),
+
+                //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
+                hasJsonPath("$.metadata", allOf(
+                        matchMetadata("dc.title", title),
+                        matchMetadataDoesNotExist("local.submission.note"))),
 
                 //Check links
                 matchLinks(item.getID())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
@@ -66,15 +66,13 @@ public class ItemMatcher {
     /**
      * The item has the metadata `local.submission.note`
      */
-    public static Matcher<? super Object> matchItemWithTitleAndLocalNote(Item item, String title,
-                                                                                     String localNote) {
+    public static Matcher<? super Object> matchItemWithLocalNote(Item item, String localNote) {
         return allOf(
                 //Check item properties
                 matchItemProperties(item),
 
                 //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
                 hasJsonPath("$.metadata", allOf(
-                        matchMetadata("dc.title", title),
                         matchMetadata("local.submission.note", localNote))),
 
                 //Check links
@@ -85,16 +83,48 @@ public class ItemMatcher {
     /**
      * The item doesn't have the metadata `local.submission.note`
      */
-    public static Matcher<? super Object> notMatchItemWithTitleAndLocalNote(Item item, String title,
-                                                                         String localNote) {
+    public static Matcher<? super Object> notMatchItemWithLocalNote(Item item) {
         return allOf(
                 //Check item properties
                 matchItemProperties(item),
 
                 //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
                 hasJsonPath("$.metadata", allOf(
-                        matchMetadata("dc.title", title),
                         matchMetadataDoesNotExist("local.submission.note"))),
+
+                //Check links
+                matchLinks(item.getID())
+        );
+    }
+
+    /**
+     * The item doesn't have the metadata `dc.description.provenance`
+     */
+    public static Matcher<? super Object> matchItemWithDescriptionProvenance(Item item, String provenance) {
+        return allOf(
+                //Check item properties
+                matchItemProperties(item),
+
+                //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
+                hasJsonPath("$.metadata", allOf(
+                        matchMetadata("dc.description.provenance", provenance))),
+
+                //Check links
+                matchLinks(item.getID())
+        );
+    }
+
+    /**
+     * The item doesn't have the metadata `dc.description.provenance`
+     */
+    public static Matcher<? super Object> notMatchItemWithDescriptionProvenance(Item item) {
+        return allOf(
+                //Check item properties
+                matchItemProperties(item),
+
+                //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
+                hasJsonPath("$.metadata", allOf(
+                        matchMetadataDoesNotExist("dc.description.provenance"))),
 
                 //Check links
                 matchLinks(item.getID())

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -879,6 +879,7 @@ webui.licence_bundle.show = false
 # since that usually contains email addresses which ought to be kept
 # private and is mainly of interest to administrators:
 metadata.hide.dc.description.provenance = true
+metadata.hide.local.submission.note = submitter
 
 ##### Settings for Submission Process #####
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -879,7 +879,7 @@ webui.licence_bundle.show = false
 # since that usually contains email addresses which ought to be kept
 # private and is mainly of interest to administrators:
 metadata.hide.dc.description.provenance = true
-metadata.hide.local.submission.note = submitter
+metadata.hide.local.submission.note = true
 
 ##### Settings for Submission Process #####
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -879,7 +879,7 @@ webui.licence_bundle.show = false
 # since that usually contains email addresses which ought to be kept
 # private and is mainly of interest to administrators:
 metadata.hide.dc.description.provenance = true
-metadata.hide.local.submission.note = true
+metadata.hide.local.submission.note = submitter
 
 ##### Settings for Submission Process #####
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  2  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  2.5  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Check the issue.

## Problems
- Licenses wasn't showed up for all users, but only for admin, so I updated ClarinLicenseRestRepository.
