### PR TITLE
105-be/user-is-not-registered-after-shibboleth-login

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -706,7 +706,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
             lname = shibheaders.get_single(lnameHeader);
         }
 
-        if (email == null || (fnameHeader != null && fname == null) || (lnameHeader != null && lname == null)) {
+        if ( email == null && netid == null) {
             // We require that there be an email, first name, and last name. If we
             // don't have at least these three pieces of information then we fail.
             String message = "Unable to register new eperson because we are unable to find an email address along " +
@@ -715,20 +715,11 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
             message += "  Email Header: '" + emailHeader + "'='" + email + "' \n";
             message += "  First Name Header: '" + fnameHeader + "'='" + fname + "' \n";
             message += "  Last Name Header: '" + lnameHeader + "'='" + lname + "'";
-            log.error(message);
-
+            log.error( String.format(
+                    "Could not identify a user from [%s] - we have not received enough information " +
+                            "(email, netid, eppn, ...). \n\nDetails:\n%s\n\nHeaders received:\n%s",
+                    org, message, request.getHeaderNames().toString()) );
             return null; // TODO should this throw an exception?
-        }
-
-        // Truncate values of parameters that are too big.
-        if (fname != null && fname.length() > NAME_MAX_SIZE) {
-            log.warn(
-                    "Truncating eperson's first name because it is longer than " + NAME_MAX_SIZE + ": '" + fname + "'");
-            fname = fname.substring(0, NAME_MAX_SIZE);
-        }
-        if (lname != null && lname.length() > NAME_MAX_SIZE) {
-            log.warn("Truncating eperson's last name because it is longer than " + NAME_MAX_SIZE + ": '" + lname + "'");
-            lname = lname.substring(0, NAME_MAX_SIZE);
         }
 
         // Turn off authorizations to create a new user

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -167,17 +167,13 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
     public void userFillInEmailAndShouldBeRegisteredByVerificationToken() throws Exception {
         String netId = "123456";
         String email = "test@mail.epic";
-        String firstname = "Test";
-        String lastname = "Buddy";
         String idp = "Test Idp";
 
         // Try to authenticate but the Shibboleth doesn't send the email in the header, so the user won't be registered
         // but the user will be redirected to the page where he will fill in the user email.
         getClient().perform(get("/api/authn/shibboleth")
                         .header("Shib-Identity-Provider", idp)
-                        .header("SHIB-NETID", netId)
-                        .header("SHIB-GIVENNAME", firstname)
-                        .header("SHIB-SURNAME", lastname))
+                        .header("SHIB-NETID", netId))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" + netId));
 
@@ -201,8 +197,6 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
         EPerson ePerson = ePersonService.findByNetid(context, netId);
         assertTrue(Objects.nonNull(ePerson));
         assertEquals(ePerson.getEmail(), email);
-        assertEquals(ePerson.getFirstName(), firstname);
-        assertEquals(ePerson.getLastName(), lastname);
 
         // The user is registered now log him
         getClient().perform(get("/api/authn/shibboleth")
@@ -215,17 +209,13 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
         getClient().perform(get("/api/authn/shibboleth")
                         .header("Shib-Identity-Provider", idp)
                         .header("SHIB-NETID", netId)
-                        .header("SHIB-GIVENNAME", firstname)
-                        .header("SHIB-SURNAME", lastname)
                         .header("SHIB-MAIL", email))
                 .andExpect(status().isFound());
 
         // Try to sign in the user by the netid if the eperson exist
         getClient().perform(get("/api/authn/shibboleth")
                         .header("Shib-Identity-Provider", idp)
-                        .header("SHIB-NETID", netId)
-                        .header("SHIB-GIVENNAME", firstname)
-                        .header("SHIB-SURNAME", lastname))
+                        .header("SHIB-NETID", netId))
                 .andExpect(status().isFound());
 
         // Delete created eperson - clean after the test


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  1.5  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Registration of the new user always checked if the IdP sent the firstname and lastname header - if not the user wasn't registered and the server throws an error. I just removed the condition which check if the IdP sent the firstname and lastname headers - this condition is very the same than in the CLARIN-DSpace 5.*
