### PR TITLE
119-BE/remove-validation-of-deleted-bitstreams

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -149,6 +149,9 @@ public class ClarinBitstreamImportController {
                     log.info("Validation failed - return null. Bitstream UUID: " + bitstream.getID());
                     return null;
                 }
+            } else {
+                log.info("Validation is not checked for deleted bitstream id: " + bitstream.getID() +
+                        ", because it may not exist in assetstore.");
             }
             if (bitstreamRest.getMetadata().getMap().size() > 0) {
                 metadataConverter.setMetadata(context, bitstream, bitstreamRest.getMetadata());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -144,14 +144,14 @@ public class ClarinBitstreamImportController {
             bitstream.setChecksumAlgorithm(bitstreamRest.getCheckSum().getCheckSumAlgorithm());
             //do validation between input fields and calculated fields based on file from assetstore
             //we do validation only if the bitstream is not deleted
-            if (!deleted) {
+            if (deleted) {
+                log.info("Validation is not checked for deleted bitstream id: " + bitstream.getID() +
+                        ", because it may not exist in assetstore.");
+            } else {
                 if (!clarinBitstreamService.validation(context, bitstream)) {
                     log.info("Validation failed - return null. Bitstream UUID: " + bitstream.getID());
                     return null;
                 }
-            } else {
-                log.info("Validation is not checked for deleted bitstream id: " + bitstream.getID() +
-                        ", because it may not exist in assetstore.");
             }
             if (bitstreamRest.getMetadata().getMap().size() > 0) {
                 metadataConverter.setMetadata(context, bitstream, bitstreamRest.getMetadata());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -135,6 +135,7 @@ public class ClarinBitstreamImportController {
             }
             bitstream.setFormat(context, bitstreamFormat);
             String deletedString = request.getParameter("deleted");
+            Boolean deleted = Boolean.parseBoolean(deletedString);
             //set size bytes
             bitstream.setSizeBytes(bitstreamRest.getSizeBytes());
             //set checksum
@@ -142,11 +143,13 @@ public class ClarinBitstreamImportController {
             //set checksum algorithm
             bitstream.setChecksumAlgorithm(bitstreamRest.getCheckSum().getCheckSumAlgorithm());
             //do validation between input fields and calculated fields based on file from assetstore
-            if (!clarinBitstreamService.validation(context, bitstream)) {
-                log.info("Validation failed - return null. Bitstream UUID: " + bitstream.getID());
-                return null;
+            //we do validation only if the bitstream is not deleted
+            if (!deleted) {
+                if (!clarinBitstreamService.validation(context, bitstream)) {
+                    log.info("Validation failed - return null. Bitstream UUID: " + bitstream.getID());
+                    return null;
+                }
             }
-
             if (bitstreamRest.getMetadata().getMap().size() > 0) {
                 metadataConverter.setMetadata(context, bitstream, bitstreamRest.getMetadata());
             }
@@ -170,7 +173,7 @@ public class ClarinBitstreamImportController {
             bitstreamService.update(context, bitstream);
 
             // If bitstream is deleted make it deleted
-            if (Boolean.parseBoolean(deletedString)) {
+            if (deleted) {
                 bitstreamService.delete(context, bitstream);
                 log.info("Bitstream with id: " + bitstream.getID() + " is deleted!");
             }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Deleted bitstreams are not in assetsore, so there is exception when we do validation of this bitstream.
## Analysis
Do validation only of bitstreams which are not deleted.
