### PR TITLE
87-BE/adding-missing-attributes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
@@ -17,6 +17,7 @@ import java.io.PipedOutputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -463,11 +464,11 @@ public class RoleDisseminator implements PackageDisseminator {
             writer.writeEmptyElement(SELF_REGISTERED);
         }
 
-        if (null != eperson.getWelcomeInfo()) {
+        if (Objects.nonNull(eperson.getWelcomeInfo())) {
             writer.writeEmptyElement(WELCOME_INFO);
         }
 
-        if (null != eperson.getCanEditSubmissionMetadata()) {
+        if (Objects.nonNull(eperson.getCanEditSubmissionMetadata())) {
             writer.writeEmptyElement(CAN_EDIT_SUBMISSION_METADATA);
         }
         writer.writeEndElement();

--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
@@ -78,6 +78,8 @@ public class RoleDisseminator implements PackageDisseminator {
     public static final String CAN_LOGIN = "CanLogin";
     public static final String REQUIRE_CERTIFICATE = "RequireCertificate";
     public static final String SELF_REGISTERED = "SelfRegistered";
+    public static final String WELCOME_INFO = "welcomeInfo";
+    public static final String CAN_EDIT_SUBMISSION_METADATA = "canEditSubmissionMetadata";
 
     // Valid type values for Groups (only used when Group is associated with a Community or Collection)
     public static final String GROUP_TYPE_ADMIN = "ADMIN";
@@ -461,6 +463,13 @@ public class RoleDisseminator implements PackageDisseminator {
             writer.writeEmptyElement(SELF_REGISTERED);
         }
 
+        if (null != eperson.getWelcomeInfo()) {
+            writer.writeEmptyElement(WELCOME_INFO);
+        }
+
+        if (null != eperson.getCanEditSubmissionMetadata()) {
+            writer.writeEmptyElement(CAN_EDIT_SUBMISSION_METADATA);
+        }
         writer.writeEndElement();
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -80,7 +80,7 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport {
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "epeople")
     private final List<Group> groups = new ArrayList<>();
 
-    @Column(name = "welcome_info", length = 32)
+    @Column(name = "welcome_info")
     private String welcomeInfo;
 
     @Column(name = "can_edit_submission_metadata")

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -80,6 +80,12 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport {
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "epeople")
     private final List<Group> groups = new ArrayList<>();
 
+    @Column(name = "welcome_info", length = 32)
+    private String welcomeInfo;
+
+    @Column(name = "can_edit_submission_metadata")
+    private Boolean canEditSubmissionMetadata;
+
     /**
      * The e-mail field (for sorting)
      */
@@ -445,5 +451,20 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport {
         }
         return previousActive;
     }
+
+    public String getWelcomeInfo() {
+        return welcomeInfo;
+    }
+    public void setWelcomeInfo(String welcomeInfo) {
+        this.welcomeInfo = welcomeInfo;
+    }
+    public Boolean getCanEditSubmissionMetadata() {
+        return canEditSubmissionMetadata;
+    }
+    public void setCanEditSubmissionMetadata(Boolean canEditSubmissionMetadata) {
+        this.canEditSubmissionMetadata = canEditSubmissionMetadata;
+    }
+
+
 
 }

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.2_2022.07.28__Upgrade_to_Lindat_Clarin_schema.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.2_2022.07.28__Upgrade_to_Lindat_Clarin_schema.sql
@@ -407,3 +407,7 @@ ALTER TABLE metadatafieldregistry
 
 ALTER TABLE handle
     ALTER COLUMN url TYPE character varying(8192);
+
+ALTER TABLE eperson ADD welcome_info varchar(30);
+
+ALTER TABLE eperson ADD can_edit_submission_metadata BOOL;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.2_2022.07.28__Upgrade_to_Lindat_Clarin_schema.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.2_2022.07.28__Upgrade_to_Lindat_Clarin_schema.sql
@@ -484,3 +484,7 @@ ALTER TABLE eperson
 ALTER TABLE metadatafieldregistry
 
 ALTER COLUMN element TYPE character varying(128);
+
+ALTER TABLE eperson ADD welcome_info varchar(30);
+
+ALTER TABLE eperson ADD can_edit_submission_metadata BOOL;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/EPersonConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/EPersonConverter.java
@@ -30,6 +30,8 @@ public class EPersonConverter extends DSpaceObjectConverter<EPerson, org.dspace.
         eperson.setRequireCertificate(obj.getRequireCertificate());
         eperson.setSelfRegistered(obj.getSelfRegistered());
         eperson.setEmail(obj.getEmail());
+        eperson.setWelcomeInfo(obj.getWelcomeInfo());
+        eperson.setCanEditSubmissionMetadata(obj.getCanEditSubmissionMetadata());
 
         return eperson;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EPersonRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EPersonRest.java
@@ -42,6 +42,8 @@ public class EPersonRest extends DSpaceObjectRest {
     private boolean requireCertificate = false;
 
     private Boolean selfRegistered;
+    private String welcomeInfo;
+    private Boolean canEditSubmissionMetadata;
 
     @JsonProperty(access = Access.WRITE_ONLY)
     private String password;
@@ -106,6 +108,18 @@ public class EPersonRest extends DSpaceObjectRest {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+    public String getWelcomeInfo() {
+        return welcomeInfo;
+    }
+    public void setWelcomeInfo(String welcomeInfo) {
+        this.welcomeInfo = welcomeInfo;
+    }
+    public Boolean getCanEditSubmissionMetadata() {
+        return canEditSubmissionMetadata;
+    }
+    public void setCanEditSubmissionMetadata(Boolean canEditSubmissionMetadata) {
+        this.canEditSubmissionMetadata = canEditSubmissionMetadata;
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -128,6 +128,8 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
             eperson.setRequireCertificate(epersonRest.isRequireCertificate());
             eperson.setEmail(epersonRest.getEmail());
             eperson.setNetid(epersonRest.getNetid());
+            eperson.setWelcomeInfo(epersonRest.getWelcomeInfo());
+            eperson.setCanEditSubmissionMetadata(epersonRest.getCanEditSubmissionMetadata());
             if (epersonRest.getPassword() != null) {
                 es.setPassword(eperson, epersonRest.getPassword());
             }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In dspace5, there were two more attributes in eperson table: welcome_info and can_edit_submission_metadata.

## Analysis
Add these missing attributes into dspace7, but only for migration purposes.
