### PR TITLE
added mvn argument fail-at-end

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           #  - failsafe.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
           - type: "Integration Tests"
             java: 11
-            mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true -Dfailsafe.rerunFailingTestsCount=2"
+            mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true -Dfailsafe.rerunFailingTestsCount=2 -fae"
             resultsdir: "**/target/failsafe-reports/**"
       # Do NOT exit immediately if one matrix job fails
       # This ensures ITs continue running even if Unit Tests fail, or visa versa

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
       # Also specify version of Java to use (this can allow us to optionally run tests on multiple JDKs in future)
       matrix:
         include:
+          - type: "Maven version"
+            java: 11
+            mvnflags: "-version"
+            resultsdir: "**/target/surefire-reports/**"
           # NOTE: Unit Tests include deprecated REST API v6 (as it has unit tests)
           #  - surefire.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
           - type: "Unit Tests"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       # Give Maven 1GB of memory to work with
       # Suppress all Maven "downloading" messages in logs (see https://stackoverflow.com/a/35653426)
       # This also slightly speeds builds, as there is less logging
-      MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+      MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -fae"
     strategy:
       # Create a matrix of two separate configurations for Unit vs Integration Tests
       # This will ensure those tasks are run in parallel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,6 @@ jobs:
       # Also specify version of Java to use (this can allow us to optionally run tests on multiple JDKs in future)
       matrix:
         include:
-          - type: "Maven version"
-            java: 11
-            mvnflags: "-version"
-            resultsdir: "**/target/surefire-reports/**"
           # NOTE: Unit Tests include deprecated REST API v6 (as it has unit tests)
           #  - surefire.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
           - type: "Unit Tests"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       # Give Maven 1GB of memory to work with
       # Suppress all Maven "downloading" messages in logs (see https://stackoverflow.com/a/35653426)
       # This also slightly speeds builds, as there is less logging
-      MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -fae"
+      MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     strategy:
       # Create a matrix of two separate configurations for Unit vs Integration Tests
       # This will ensure those tasks are run in parallel


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    1 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    1 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

Enables all maven subproject to run tests, even if some fail.
Provides better information about how many tests failed.
Otherwise, first submodule with failed tests stops the testing.

It should be noted, some modules are forbidden to run, if other
fail testing. In those cases it does not help significantly, but in
other cases it is advantageous.
