### PR TITLE
enable different endpoint to S3 bitstorage

### DIFF
--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceTest.java
@@ -71,7 +71,7 @@ public class S3BitStoreServiceTest extends AbstractUnitTest {
 
     @Before
     public void setUp() throws Exception {
-        this.s3BitStoreService = new S3BitStoreService(s3Service, tm);
+            this.s3BitStoreService = new S3BitStoreService(s3Service, tm);
     }
 
     private Supplier<AmazonS3> mockedServiceSupplier() {
@@ -82,13 +82,13 @@ public class S3BitStoreServiceTest extends AbstractUnitTest {
     public void givenBucketWhenInitThenUsesSameBucket() throws IOException {
         String bucketName = "Bucket0";
         s3BitStoreService.setBucketName(bucketName);
-        when(this.s3Service.doesBucketExist(bucketName)).thenReturn(false);
+        when(this.s3Service.doesBucketExistV2(bucketName)).thenReturn(false);
 
         assertThat(s3BitStoreService.getAwsRegionName(), isEmptyOrNullString());
 
         this.s3BitStoreService.init();
 
-        verify(this.s3Service).doesBucketExist(bucketName);
+        verify(this.s3Service).doesBucketExistV2(bucketName);
         verify(this.s3Service, Mockito.times(1)).createBucket(bucketName);
         assertThat(s3BitStoreService.getAwsAccessKey(), isEmptyOrNullString());
         assertThat(s3BitStoreService.getAwsSecretKey(), isEmptyOrNullString());
@@ -98,7 +98,7 @@ public class S3BitStoreServiceTest extends AbstractUnitTest {
     @Test
     public void givenEmptyBucketWhenInitThenUsesDefaultBucket() throws IOException {
         assertThat(s3BitStoreService.getBucketName(), isEmptyOrNullString());
-        when(this.s3Service.doesBucketExist(startsWith(S3BitStoreService.DEFAULT_BUCKET_PREFIX))).thenReturn(false);
+        when(this.s3Service.doesBucketExistV2(startsWith(S3BitStoreService.DEFAULT_BUCKET_PREFIX))).thenReturn(false);
         assertThat(s3BitStoreService.getAwsRegionName(), isEmptyOrNullString());
 
         this.s3BitStoreService.init();
@@ -116,7 +116,7 @@ public class S3BitStoreServiceTest extends AbstractUnitTest {
         assertThat(s3BitStoreService.getAwsSecretKey(), isEmptyOrNullString());
         assertThat(s3BitStoreService.getBucketName(), isEmptyOrNullString());
         assertThat(s3BitStoreService.getAwsRegionName(), isEmptyOrNullString());
-        when(this.s3Service.doesBucketExist(startsWith(S3BitStoreService.DEFAULT_BUCKET_PREFIX))).thenReturn(false);
+        when(this.s3Service.doesBucketExistV2(startsWith(S3BitStoreService.DEFAULT_BUCKET_PREFIX))).thenReturn(false);
 
         final String awsAccessKey = "ACCESS_KEY";
         final String awsSecretKey = "SECRET_KEY";

--- a/dspace/config/modules/assetstore.cfg
+++ b/dspace/config/modules/assetstore.cfg
@@ -55,3 +55,8 @@ assetstore.s3.awsSecretKey =
 # If the credentials are left empty,
 # then this setting is ignored and the default AWS region will be used.
 assetstore.s3.awsRegionName =
+
+# Configuring S3 with different endpoint than amazon can require pathstyle access which can be configured here
+assetstore.s3.pathStyleAccessEnabled = false
+# Leave empty to use default (Amazon AWS) endpoint
+assetstore.s3.endpoint =

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -34,6 +34,10 @@
         <!-- Subfolder to organize assets within the bucket, in case this bucket is shared  -->
         <!-- Optional, default is root level of bucket -->
         <property name="subfolder" value="${assetstore.s3.subfolder}"/>
+
+<!--        Endpoint for other S3 providers than amazon AWS-->
+        <property name="endpoint" value="${assetstore.s3.endpoint}"/>
+        <property name="pathStyleAccessEnabled" value="${assetstore.s3.pathStyleAccessEnabled}"/>
     </bean>
 
     <!-- <bean name="localStore2 ... -->


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Vanilla Dspace only allows Amazon AWS S3 not other providers.
## Analysis
We needed to set different endpoint and different access pattern
## Problems
Lack of documentation from S3 storage providers, some of work had to be guess and try.
