### PR TITLE
internal/shibboleth-missing-one-error-page

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/Util.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Util.java
@@ -528,6 +528,6 @@ public class Util {
         if (StringUtils.isBlank(netId)) {
             return null;
         }
-        return netId + "[" + organization +"]";
+        return netId + "[" + organization + "]";
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/util/Util.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Util.java
@@ -522,4 +522,12 @@ public class Util {
 
         return ListUtils.removeAll(fromFieldName, toFieldName);
     }
+
+
+    public static String formatNetId(String netId, String organization) {
+        if (StringUtils.isBlank(netId)) {
+            return null;
+        }
+        return netId + "[" + organization +"]";
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.Util;
 import org.dspace.authenticate.AuthenticationMethod;
 import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authorize.AuthorizeException;
@@ -550,7 +551,8 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
 
         // 1) First, look for a netid header.
         if (netidHeader != null) {
-            String netid = findSingleAttribute(request, netidHeader);
+            String org = shibheaders.get_idp();
+            String netid = Util.formatNetId(findSingleAttribute(request, netidHeader), org);
             if (StringUtils.isEmpty(netid)) {
                 netid = shibheaders.get_single(netidHeader);
             }
@@ -687,7 +689,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
         // CLARIN
 
         // Header values
-        String netid = findSingleAttribute(request, netidHeader);
+        String netid = Util.formatNetId(findSingleAttribute(request, netidHeader), org);
         String email = findSingleAttribute(request, emailHeader);
         String fname = findSingleAttribute(request, fnameHeader);
         String lname = findSingleAttribute(request, lnameHeader);
@@ -809,7 +811,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
         String fnameHeader = configurationService.getProperty("authentication-shibboleth.firstname-header");
         String lnameHeader = configurationService.getProperty("authentication-shibboleth.lastname-header");
 
-        String netid = findSingleAttribute(request, netidHeader);
+        String netid = Util.formatNetId(findSingleAttribute(request, netidHeader), shibheaders.get_idp());
         String email = findSingleAttribute(request, emailHeader);
         String fname = findSingleAttribute(request, fnameHeader);
         String lname = findSingleAttribute(request, lnameHeader);

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -83,6 +83,9 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
      */
     private static final Logger log = LogManager.getLogger(ClarinShibAuthentication.class);
 
+    // If the user which are in the login process has email already associated with a different users email.
+    private boolean isDuplicateUser = false;
+
     /**
      * Additional metadata mappings
      **/
@@ -250,7 +253,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
             EPerson eperson = findEPerson(context, request);
 
             // Step 2: Register New User, if necessary
-            if (eperson == null && autoRegister) {
+            if (eperson == null && autoRegister && !isDuplicateUser) {
                 eperson = registerNewEPerson(context, request);
             }
 
@@ -607,6 +610,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
                                     "'. This might be a possible hacking attempt to steal another users " +
                                     "credentials. If the user's netid has changed you will need to manually " +
                                     "change it to the correct value or unset it in the database.");
+                    this.isDuplicateUser = true;
                     eperson = null;
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -712,7 +712,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
             lname = shibheaders.get_single(lnameHeader);
         }
 
-        if ( email == null && netid == null) {
+        if ( email == null ) {
             // We require that there be an email, first name, and last name. If we
             // don't have at least these three pieces of information then we fail.
             String message = "Unable to register new eperson because we are unable to find an email address along " +

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinVerificationTokenDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinVerificationTokenDAOImpl.java
@@ -9,8 +9,12 @@ package org.dspace.content.dao.impl.clarin;
 
 import java.sql.SQLException;
 import javax.persistence.Query;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
 import org.dspace.content.clarin.ClarinVerificationToken;
+import org.dspace.content.clarin.ClarinVerificationToken_;
 import org.dspace.content.dao.clarin.ClarinVerificationTokenDAO;
 import org.dspace.core.AbstractHibernateDAO;
 import org.dspace.core.Context;
@@ -39,13 +43,14 @@ public class ClarinVerificationTokenDAOImpl extends AbstractHibernateDAO<ClarinV
 
     @Override
     public ClarinVerificationToken findByNetID(Context context, String netID) throws SQLException {
-        Query query = createQuery(context, "SELECT cvt " +
-                "FROM ClarinVerificationToken cvt " +
-                "WHERE cvt.ePersonNetID = :netID");
-
-        query.setParameter("netID", netID);
-        query.setHint("org.hibernate.cacheable", Boolean.TRUE);
-
-        return singleResult(query);
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, ClarinVerificationToken.class);
+        Root<ClarinVerificationToken> clarinVerificationTokenRoot = criteriaQuery.from(ClarinVerificationToken.class);
+        criteriaQuery.select(clarinVerificationTokenRoot);
+        criteriaQuery.where(criteriaBuilder.like(clarinVerificationTokenRoot.get(ClarinVerificationToken_.ePersonNetID),
+                "%" + netID + "%"));
+        criteriaQuery.orderBy(criteriaBuilder.asc(clarinVerificationTokenRoot.
+                get(ClarinVerificationToken_.ePersonNetID)));
+        return singleResult(context, criteriaQuery);
     }
 }

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -85,6 +85,9 @@ handle.remote-resolver.enabled = true
 # of this DSpace installation, whenever the `handle.remote-resolver.enabled = true`.
 handle.hide.listhandles = false
 
+# Set is to null because of failing some IT
+handle.additional.prefixes =
+
 #####################
 # LOGLEVEL SETTINGS #
 #####################

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
@@ -93,6 +93,11 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
      */
     private String netId = "";
 
+    /**
+     * If is duplicate user error send the redirect request with email param. Store that email into this variable.
+     */
+    private String email = "";
+
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
     private ClarinVerificationTokenService clarinVerificationTokenService = ClarinServiceFactory.getInstance()
             .getClarinVerificationTokenService();
@@ -110,6 +115,7 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
         this.setMissingHeadersFromIdp(false);
         this.setEmailIsAssociated(false);
         this.netId = "";
+        this.email = "";
 
         // First, if Shibboleth is not enabled, throw an immediate ProviderNotFoundException
         // This tells Spring Security that authentication failed
@@ -179,6 +185,7 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
             if (ePerson != null && ePerson.getNetid() != null && Objects.isNull(clarinVerificationToken)) {
                 log.error("The users email is already associated with a different user");
                 this.setEmailIsAssociated(true);
+                this.email = email;
             }
 
             // The Idp hasn't sent the email - the user will be redirected to the page where he must fill in that
@@ -265,7 +272,7 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
         if (this.isMissingHeadersFromIdp) {
             redirectUrl += missingHeadersUrl;
         } else if (this.isEmailIsAssociated) {
-            redirectUrl += duplicateUser;
+            redirectUrl += duplicateUser + "?email=" + this.email;
         } else if (StringUtils.isNotEmpty(this.netId)) {
             // netId is set if the user doesn't have the email
             redirectUrl += userWithoutEmailUrl + "?netid=" + this.netId;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
@@ -165,8 +165,7 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
                     // Try to get user by the email because of possible duplicate of the user email
                     ePerson = ePersonService.findByEmail(context, email);
                 }
-            }
-             catch (SQLException ignored) {
+            } catch (SQLException ignored) {
                 //
             }
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinAuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinAuthenticationRestControllerIT.java
@@ -34,6 +34,7 @@ import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.projection.DefaultProjection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.app.rest.utils.Utils;
+import org.dspace.app.util.Util;
 import org.dspace.builder.EPersonBuilder;
 import org.dspace.core.I18nUtil;
 import org.dspace.eperson.EPerson;
@@ -54,6 +55,8 @@ public class ClarinAuthenticationRestControllerIT extends AbstractControllerInte
     private final String feature = CanChangePasswordFeature.NAME;
     private Authorization authorization;
     public static final String[] PASS_ONLY = {"org.dspace.authenticate.PasswordAuthentication"};
+    private static final String NET_ID_TEST_EPERSON = "123456789";
+    private static final String IDP_TEST_EPERSON = "Test Idp";
 
     @Autowired
     ConfigurationService configurationService;
@@ -88,7 +91,7 @@ public class ClarinAuthenticationRestControllerIT extends AbstractControllerInte
                 .withEmail("clarin@email.com")
                 .withNameInMetadata("first", "last")
                 .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .withNetId("123456789")
+                .withNetId(Util.formatNetId(NET_ID_TEST_EPERSON, IDP_TEST_EPERSON))
                 .build();
         context.restoreAuthSystemState();
 
@@ -112,8 +115,8 @@ public class ClarinAuthenticationRestControllerIT extends AbstractControllerInte
                         .header("Referer", "https://myshib.example.com")
                         .param("redirectUrl", uiURL)
                         .header("SHIB-MAIL", clarinEperson.getEmail())
-                        .header("Shib-Identity-Provider", "Test idp")
-                        .header("SHIB-NETID", clarinEperson.getNetid())
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON)
+                        .header("SHIB-NETID", NET_ID_TEST_EPERSON)
                         .requestAttr("SHIB-SCOPED-AFFILIATION", "faculty;staff"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl(uiURL))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinHandleImportControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinHandleImportControllerIT.java
@@ -35,9 +35,11 @@ public class ClarinHandleImportControllerIT extends AbstractControllerIntegratio
 
     @Test
     public void createHandleWithoutDSpaceObjectTest() throws Exception {
+        String uniqueHandle = "123456789/135479";
+
         ObjectMapper mapper = new ObjectMapper();
         HandleRest handleRest = new HandleRest();
-        handleRest.setHandle("123456789/1");
+        handleRest.setHandle(uniqueHandle);
         handleRest.setResourceTypeID(2);
         Integer handleId = null;
         String adminToken = getAuthToken(admin.getEmail(), password);
@@ -53,7 +55,7 @@ public class ClarinHandleImportControllerIT extends AbstractControllerIntegratio
         //find created handle
         Handle handle = handleService.findByID(context, handleId);
         //control
-        assertEquals(handle.getHandle(), "123456789/1");
+        assertEquals(handle.getHandle(), uniqueHandle);
         assertEquals(handle.getResourceTypeId(), (Integer)2);
         assertNull(handle.getUrl());
         assertNull(handle.getDSpaceObject());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethAuthAssing2GroupsIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethAuthAssing2GroupsIT.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.util.Util;
 import org.dspace.builder.EPersonBuilder;
 import org.dspace.builder.GroupBuilder;
 import org.dspace.core.I18nUtil;
@@ -54,7 +55,7 @@ public class ClarinShibbolethAuthAssing2GroupsIT extends AbstractControllerInteg
                 .withEmail("clarin@email.com")
                 .withNameInMetadata("first", "last")
                 .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .withNetId("123456789")
+                .withNetId(Util.formatNetId("123456789", "Test Idp"))
                 .build();
         context.turnOffAuthorisationSystem();
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethAuthAssing2GroupsIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethAuthAssing2GroupsIT.java
@@ -32,6 +32,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class ClarinShibbolethAuthAssing2GroupsIT extends AbstractControllerIntegrationTest {
 
     public static final String[] SHIB_ONLY = {"org.dspace.authenticate.clarin.ClarinShibAuthentication"};
+    private static final String NET_ID_TEST_EPERSON = "123456789";
+    private static final String IDP_TEST_EPERSON = "Test Idp";
+
 
     private EPerson clarinEperson;
 
@@ -55,7 +58,7 @@ public class ClarinShibbolethAuthAssing2GroupsIT extends AbstractControllerInteg
                 .withEmail("clarin@email.com")
                 .withNameInMetadata("first", "last")
                 .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .withNetId(Util.formatNetId("123456789", "Test Idp"))
+                .withNetId(Util.formatNetId(NET_ID_TEST_EPERSON, IDP_TEST_EPERSON))
                 .build();
         context.turnOffAuthorisationSystem();
     }
@@ -75,8 +78,8 @@ public class ClarinShibbolethAuthAssing2GroupsIT extends AbstractControllerInteg
 
         String token = getClient().perform(get("/api/authn/shibboleth")
                         .header("SHIB-MAIL", clarinEperson.getEmail())
-                        .header("Shib-Identity-Provider", "Test idp")
-                        .header("SHIB-NETID", clarinEperson.getNetid()))
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON)
+                        .header("SHIB-NETID", NET_ID_TEST_EPERSON))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost:4000"))
                 .andReturn().getResponse().getHeader("Authorization");
@@ -118,8 +121,8 @@ public class ClarinShibbolethAuthAssing2GroupsIT extends AbstractControllerInteg
         // The user will be added to the AUTHENTICATED and UFAL group
         String token = getClient().perform(get("/api/authn/shibboleth")
                         .header("SHIB-MAIL", clarinEperson.getEmail())
-                        .header("Shib-Identity-Provider", "Test idp")
-                        .header("SHIB-NETID", clarinEperson.getNetid())
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON)
+                        .header("SHIB-NETID", NET_ID_TEST_EPERSON)
                         .header("entitlement", "ufal.mff.cuni.cz"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost:4000"))
@@ -171,8 +174,8 @@ public class ClarinShibbolethAuthAssing2GroupsIT extends AbstractControllerInteg
         // The user will be added to the AUTHENTICATED and UFAL group
         String token = getClient().perform(get("/api/authn/shibboleth")
                         .header("SHIB-MAIL", clarinEperson.getEmail())
-                        .header("Shib-Identity-Provider", "Test idp")
-                        .header("SHIB-NETID", clarinEperson.getNetid())
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON)
+                        .header("SHIB-NETID", NET_ID_TEST_EPERSON)
                         .header("entitlement", "staff@org1297.mff.cuni.cz"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost:4000"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -259,7 +259,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header("SHIB-NETID", netId)
                         .header("Shib-Identity-Provider", differentIdP))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("http://localhost:4000/login/duplicate-user"))
+                .andExpect(redirectedUrl("http://localhost:4000/login/duplicate-user?email=" + email))
                 .andReturn().getResponse().getHeader("Authorization");
 
         // Delete created eperson - clean after the test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -93,7 +93,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .withEmail("clarin@email.com")
                 .withNameInMetadata("first", "last")
                 .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .withNetId(Util.formatNetId("123456789", "Test Idp"))
+                .withNetId(Util.formatNetId(NET_ID_TEST_EPERSON, IDP_TEST_EPERSON))
                 .build();
         context.restoreAuthSystemState();
     }
@@ -144,7 +144,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
     @Test
     public void shouldReturnUserWithoutEmailException() throws Exception {
         // Create a new netId because the user shouldn't exist
-        String netId  = NET_ID_TEST_EPERSON + 0;
+        String netId  = NET_ID_TEST_EPERSON + 986;
         // Try to authenticate but the Shibboleth doesn't send the email in the header, so the user won't be registered
         // but the user will be redirected to the page where he will fill in the user email.
         getClient().perform(get("/api/authn/shibboleth")


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  9+3 |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
- The netId is composed from IdP and email in the format `<EMAIL>[<IDP>]`
- The user is redirected to the error page `/login/duplicate-user` with the email param