### PR TITLE
ufal/s3-check-etag

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -10,15 +10,12 @@ package org.dspace.storage.bitstore;
 import static java.lang.String.valueOf;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +24,6 @@ import java.util.function.Supplier;
 import javax.validation.constraints.NotNull;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -37,13 +33,8 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PartETag;
-import com.amazonaws.services.s3.model.UploadPartRequest;
-import com.amazonaws.services.s3.model.UploadPartResult;
 import com.amazonaws.services.s3.transfer.Download;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
@@ -54,14 +45,11 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.poi.util.ArrayUtil;
 import org.dspace.content.Bitstream;
 import org.dspace.core.Utils;
 import org.dspace.services.ConfigurationService;
@@ -121,7 +109,7 @@ public class S3BitStoreService extends BaseBitStoreService {
     /**
      * container for all the assets
      */
-    protected String bucketName = null;
+    private String bucketName = null;
 
     /**
      * (Optional) subfolder within bucket where objects are stored
@@ -139,7 +127,8 @@ public class S3BitStoreService extends BaseBitStoreService {
      */
     protected TransferManager tm = null;
 
-    private ConfigurationService configurationService = null;
+    private static final ConfigurationService configurationService
+            = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     /**
      * Utility method for generate AmazonS3 builder
@@ -247,9 +236,6 @@ public class S3BitStoreService extends BaseBitStoreService {
             // bucket name
             if (StringUtils.isEmpty(bucketName)) {
                 // get hostname of DSpace UI to use to name bucket
-                if (configurationService == null) {
-                    configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-                }
                 String hostname = Utils.getHostName(configurationService.getProperty("dspace.ui.url"));
                 bucketName = DEFAULT_BUCKET_PREFIX + hostname;
                 log.warn("S3 BucketName is not configured, setting default: " + bucketName);
@@ -573,19 +559,6 @@ public class S3BitStoreService extends BaseBitStoreService {
      * @throws Exception generic exception
      */
     public static void main(String[] args) throws Exception {
-
-
-        class TestBitstream extends Bitstream {
-            public TestBitstream() {
-                super();
-            }
-
-            public TestBitstream(String internalId) {
-                super();
-                setInternalId(internalId);
-            }
-        }
-
         //TODO Perhaps refactor to be a unit test. Can't mock this without keys though.
 
         // parse command line
@@ -609,198 +582,30 @@ public class S3BitStoreService extends BaseBitStoreService {
         } catch (ParseException e) {
             System.err.println(e.getMessage());
             new HelpFormatter().printHelp(
-                    SyncS3BitStoreService.class.getSimpleName() + "options", options);
+                    S3BitStoreService.class.getSimpleName() + "options", options);
             return;
         }
 
         String accessKey = command.getOptionValue("a");
         String secretKey = command.getOptionValue("s");
 
-        SyncS3BitStoreService store = new SyncS3BitStoreService();
+        S3BitStoreService store = new S3BitStoreService();
 
         AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
 
-        AwsClientBuilder.EndpointConfiguration ec =
-                new AwsClientBuilder.EndpointConfiguration("https://s3.cl4.du.cesnet.cz", "");
-        store.s3Service = FunctionalUtils.getDefaultOrBuild(
-                store.s3Service,
-                amazonClientBuilderBy(ec, awsCredentials, true)
-        );
-        store.bucketName = "testbucket";
+        store.s3Service = AmazonS3ClientBuilder.standard()
+            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+            .build();
 
-        store.tm = FunctionalUtils.getDefaultOrBuild(store.tm, () -> TransferManagerBuilder.standard()
-                .withAlwaysCalculateMultipartMd5(true)
-                .withS3Client(store.s3Service)
-                .build());
-
-        String id = store.generateId();
-        String assetFile = command.getOptionValue("f");
-        System.out.println("put() file " + assetFile + " under ID " + id + ": ");
-        FileInputStream fis = new FileInputStream(assetFile);
-        //TODO create bitstream for assetfile...
-        TestBitstream bitstream = new TestBitstream(id);
-
-        // Initialize MessageDigest for computing checksum
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance("MD5");
-        } catch (Exception e) {
-            throw new RuntimeException("MD5 algorithm not available", e);
-        }
-
-        // Initiate multipart upload
-        InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(store.getBucketName(), bitstream.getInternalId());
-        String uploadId = store.s3Service.initiateMultipartUpload(initiateRequest).getUploadId();
-        long start1 = System.currentTimeMillis();
-        // Upload a file in multiple parts, one part has 50MB
-        // Set part size
-        long partSize = 50 * 1024 * 1024; // 50 MB
-
-        // Create a list to hold the ETags for individual parts
-        List<PartETag> partETags = new ArrayList<>();
-
-        try {
-            // Upload parts
-            File file = new File(assetFile);
-            long fileLength = file.length();
-            long remainingBytes = fileLength;
-            int partNumber = 1;
-
-            while (remainingBytes > 0) {
-                long bytesToUpload = Math.min(partSize, remainingBytes);
-
-                // Calculate checksum for the part
-                String partChecksum = calculateChecksum(file, fileLength - remainingBytes, bytesToUpload, digest);
-
-                UploadPartRequest uploadRequest = new UploadPartRequest()
-                        .withBucketName(store.getBucketName())
-                        .withKey(bitstream.getInternalId())
-                        .withUploadId(uploadId)
-                        .withPartNumber(partNumber)
-                        .withFile(file)
-                        .withFileOffset(fileLength - remainingBytes)
-                        .withPartSize(bytesToUpload);
-
-                // Upload the part
-                UploadPartResult uploadPartResponse = store.s3Service.uploadPart(uploadRequest);
-
-                // Collect the ETag for the part
-                partETags.add(uploadPartResponse.getPartETag());
-
-                // Compare checksums - local with ETag
-                if (!StringUtils.equals(uploadPartResponse.getETag(), partChecksum)) {
-                    String errorMessage = "Checksum does not match error: The locally computed checksum does not match with ETag " +
-                            "from the UploadPartResult. Local checksum: " + partChecksum + ", ETag: " +
-                            uploadPartResponse.getETag() + ", partNumber: " + partNumber;
-                    log.error(errorMessage);
-                    throw new IOException(errorMessage);
-                }
-
-                remainingBytes -= bytesToUpload;
-                partNumber++;
-            }
-
-            // Complete the multipart upload
-            CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(store.getBucketName(), bitstream.getInternalId(), uploadId, partETags);
-            store.s3Service.completeMultipartUpload(completeRequest);
-
-            long now1 =  System.currentTimeMillis();
-            System.out.println("Part uploading: " + (now1 - start1) + " msecs");
-        } catch (AmazonClientException e) {
-            e.printStackTrace();
-        }
-
-// WORKING START
-
-        // Case 1: store a file
-        long start2 = System.currentTimeMillis();
-        store.put(bitstream, fis);
-//        System.out.println("Downloading started");
-        long now2 =  System.currentTimeMillis();
-        System.out.println("Fluent uploading: " + (now2 - start2) + " msecs");
-        InputStream downloaded = store.get(bitstream);
-        FileInputStream fisCheck = new FileInputStream(assetFile);
-//        System.out.print(ArrayUtils.isEquals(downloaded.readAllBytes(), fisCheck.readAllBytes()));
-
-        S3BitStoreService.storeInputStreamToFile(downloaded, "C:\\Users\\MilanMajchrák\\Videos\\Captures\\test3.mp4");
-        System.exit(0);
-// WORKING END
-
-
-//        long now =  System.currentTimeMillis();
-//        System.out.println((now - start) + " msecs");
-//        start = now;
-//        // examine the metadata returned
-//        Iterator iter = attrs.keySet().iterator();
-//        System.out.println("Metadata after put():");
-//        while (iter.hasNext())
-//        {
-//            String key = (String)iter.next();
-//            System.out.println( key + ": " + (String)attrs.get(key) );
-//        }
-//        // Case 2: get metadata and compare
-//        System.out.print("about() file with ID " + id + ": ");
-//        Map attrs2 = store.about(id, attrs);
-//        now =  System.currentTimeMillis();
-//        System.out.println((now - start) + " msecs");
-//        start = now;
-//        iter = attrs2.keySet().iterator();
-//        System.out.println("Metadata after about():");
-//        while (iter.hasNext())
-//        {
-//            String key = (String)iter.next();
-//            System.out.println( key + ": " + (String)attrs.get(key) );
-//        }
-//        // Case 3: retrieve asset and compare bits
-//        System.out.print("get() file with ID " + id + ": ");
-//        java.io.FileOutputStream fos = new java.io.FileOutputStream(assetFile+".echo");
-//        InputStream in = store.get(id);
-//        Utils.bufferedCopy(in, fos);
-//        fos.close();
-//        in.close();
-//        now =  System.currentTimeMillis();
-//        System.out.println((now - start) + " msecs");
-//        start = now;
-//        // Case 4: remove asset
-//        System.out.print("remove() file with ID: " + id + ": ");
-//        store.remove(id);
-//        now =  System.currentTimeMillis();
-//        System.out.println((now - start) + " msecs");
-//        System.out.flush();
-//        // should get nothing back now - will throw exception
-//        store.get(id);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-//        store.s3Service = AmazonS3ClientBuilder.standard()
-//            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-//            .withRegion(Regions.EU_CENTRAL_1)
-//            .build();
-//
-//        //Todo configurable region
-//        Region usEast1 = Region.getRegion(Regions.US_EAST_1);
-//        store.s3Service.setRegion(usEast1);
+        //Todo configurable region
+        Region usEast1 = Region.getRegion(Regions.US_EAST_1);
+        store.s3Service.setRegion(usEast1);
 
         // get hostname of DSpace UI to use to name bucket
-
-//        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-//        String hostname = Utils.getHostName(configurationService.getProperty("dspace.ui.url"));
-        String hostname = Utils.getHostName("http://localhost:4000");
+        String hostname = Utils.getHostName(configurationService.getProperty("dspace.ui.url"));
         //Bucketname should be lowercase
-//        store.bucketName = DEFAULT_BUCKET_PREFIX + hostname + ".s3test";
-//        store.s3Service.createBucket(store.bucketName);
+        store.bucketName = DEFAULT_BUCKET_PREFIX + hostname + ".s3test";
+        store.s3Service.createBucket(store.bucketName);
         /* Broken in DSpace 6 TODO Refactor
         // time everything, todo, swtich to caliper
         long start = System.currentTimeMillis();
@@ -855,22 +660,6 @@ public class S3BitStoreService extends BaseBitStoreService {
 */
     }
 
-    private static String calculateChecksum(File file, long offset, long length, MessageDigest digest) throws IOException {
-        try (FileInputStream fis = new FileInputStream(file);
-             DigestInputStream dis = new DigestInputStream(fis, digest)) {
-            // Skip to the specified offset
-            fis.skip(offset);
-
-            // Read the specified length
-            IOUtils.copyLarge(dis, OutputStream.nullOutputStream(), 0, length);
-            // Use Apache Commons IO to copy the specified length
-//            Utils.bufferedCopy(dis, OutputStream.nullOutputStream());
-
-            // Convert the digest to a hex string
-            return Utils.toHex(digest.digest());
-        }
-    }
-
     /**
      * Is this a registered bitstream? (not stored via this service originally)
      * @param internalId
@@ -878,20 +667,6 @@ public class S3BitStoreService extends BaseBitStoreService {
      */
     public boolean isRegisteredBitstream(String internalId) {
         return internalId.startsWith(REGISTERED_FLAG);
-    }
-
-    public static void storeInputStreamToFile(InputStream inputStream, String filePath) throws IOException {
-        // Open the output file stream
-        try (OutputStream outputStream = new FileOutputStream(filePath)) {
-            // Create a buffer to read and write data
-            byte[] buffer = new byte[4096];
-            int bytesRead;
-
-            // Read from the InputStream and write to the file
-            while ((bytesRead = inputStream.read(buffer)) != -1) {
-                outputStream.write(buffer, 0, bytesRead);
-            }
-        }
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/SyncS3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/SyncS3BitStoreService.java
@@ -258,7 +258,8 @@ public class SyncS3BitStoreService extends S3BitStoreService {
             }
 
             // Complete the multipart upload
-            CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(this.getBucketName(), key, uploadId, partETags);
+            CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(this.getBucketName(),
+                    key, uploadId, partETags);
             this.s3Service.completeMultipartUpload(completeRequest);
         } catch (AmazonClientException e) {
             log.error("Cannot upload the file by parts because: ", e);
@@ -275,7 +276,8 @@ public class SyncS3BitStoreService extends S3BitStoreService {
      * @return the checksum of the part
      * @throws IOException if an I/O error occurs
      */
-    public static String calculatePartChecksum(File file, long offset, long length, MessageDigest digest) throws IOException {
+    public static String calculatePartChecksum(File file, long offset, long length, MessageDigest digest)
+            throws IOException {
         try (FileInputStream fis = new FileInputStream(file);
              DigestInputStream dis = new DigestInputStream(fis, digest)) {
             // Skip to the specified offset

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/SyncS3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/SyncS3BitStoreService.java
@@ -12,12 +12,22 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
 import com.amazonaws.services.s3.transfer.Upload;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;
@@ -38,6 +48,12 @@ public class SyncS3BitStoreService extends S3BitStoreService {
     private static final Logger log = LogManager.getLogger(SyncS3BitStoreService.class);
     private boolean syncEnabled = false;
 
+    /**
+     * Upload large file by parts - check the checksum of every part
+     */
+    private boolean uploadByParts = false;
+
+
     @Autowired(required = true)
     DSBitStoreService dsBitStoreService;
 
@@ -48,9 +64,29 @@ public class SyncS3BitStoreService extends S3BitStoreService {
         super();
     }
 
+    /**
+     * Define syncEnabled and uploadByParts in the constructor - this values won't be overridden by the configuration
+     *
+     * @param syncEnabled   if true, the file will be uploaded to the local assetstore
+     * @param uploadByParts if true, the file will be uploaded by parts
+     */
+    public SyncS3BitStoreService(boolean syncEnabled, boolean uploadByParts) {
+        super();
+        this.syncEnabled = syncEnabled;
+        this.uploadByParts = uploadByParts;
+    }
+
     public void init() throws IOException {
         super.init();
-        syncEnabled = configurationService.getBooleanProperty("sync.storage.service.enabled", false);
+
+        // The syncEnabled and uploadByParts could be set to true in the constructor,
+        // do not override them by the configuration in this case
+        if (!syncEnabled) {
+            syncEnabled = configurationService.getBooleanProperty("sync.storage.service.enabled", false);
+        }
+        if (!uploadByParts) {
+            uploadByParts = configurationService.getBooleanProperty("upload.by.parts.enabled", false);
+        }
     }
 
     @Override
@@ -66,9 +102,11 @@ public class SyncS3BitStoreService extends S3BitStoreService {
             Utils.bufferedCopy(dis, fos);
             in.close();
 
-            Upload upload = tm.upload(getBucketName(), key, scratchFile);
-
-            upload.waitForUploadResult();
+            if (uploadByParts) {
+                uploadByParts(key, scratchFile);
+            } else {
+                uploadFluently(key, scratchFile);
+            }
 
             bitstream.setSizeBytes(scratchFile.length());
             // we cannot use the S3 ETAG here as it could be not a MD5 in case of multipart upload (large files) or if
@@ -119,6 +157,7 @@ public class SyncS3BitStoreService extends S3BitStoreService {
 
     /**
      * Create a new file in the assetstore if it does not exist
+     *
      * @param localFile
      * @throws IOException
      */
@@ -135,6 +174,118 @@ public class SyncS3BitStoreService extends S3BitStoreService {
         if (!localFile.createNewFile()) {
             throw new IOException("Assetstore synchronization error: File " + localFile.getPath() +
                     " was not created");
+        }
+    }
+
+    /**
+     * Upload a file fluently. The file is uploaded in a single request.
+     *
+     * @param key the bitstream's internalId
+     * @param scratchFile the file to upload
+     * @throws InterruptedException if the S3 upload is interrupted
+     */
+    private void uploadFluently(String key, File scratchFile) throws InterruptedException {
+        Upload upload = tm.upload(getBucketName(), key, scratchFile);
+
+        upload.waitForUploadResult();
+    }
+
+    /**
+     * Upload a file by parts. The file is divided into parts and each part is uploaded separately.
+     * The checksum of each part is checked. If the checksum does not match, the file is not uploaded.
+     *
+     * @param key the bitstream's internalId
+     * @param scratchFile the file to upload
+     * @throws IOException if an I/O error occurs
+     */
+    private void uploadByParts(String key, File scratchFile) throws IOException {
+        // Initialize MessageDigest for computing checksum
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("MD5");
+        } catch (Exception e) {
+            throw new RuntimeException("MD5 algorithm not available", e);
+        }
+
+        // Initiate multipart upload
+        InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(getBucketName(), key);
+        String uploadId = this.s3Service.initiateMultipartUpload(initiateRequest).getUploadId();
+        // Upload a file in multiple parts, one part has 50MB
+        long partSize = 50 * 1024 * 1024; // 50 MB
+
+        // Create a list to hold the ETags for individual parts
+        List<PartETag> partETags = new ArrayList<>();
+
+        try {
+            // Upload parts
+            File file = new File(scratchFile.getPath());
+            long fileLength = file.length();
+            long remainingBytes = fileLength;
+            int partNumber = 1;
+
+            while (remainingBytes > 0) {
+                long bytesToUpload = Math.min(partSize, remainingBytes);
+
+                // Calculate the checksum for the part
+                String partChecksum = calculatePartChecksum(file, fileLength - remainingBytes, bytesToUpload, digest);
+
+                UploadPartRequest uploadRequest = new UploadPartRequest()
+                        .withBucketName(this.getBucketName())
+                        .withKey(key)
+                        .withUploadId(uploadId)
+                        .withPartNumber(partNumber)
+                        .withFile(file)
+                        .withFileOffset(fileLength - remainingBytes)
+                        .withPartSize(bytesToUpload);
+
+                // Upload the part
+                UploadPartResult uploadPartResponse = this.s3Service.uploadPart(uploadRequest);
+
+                // Collect the ETag for the part
+                partETags.add(uploadPartResponse.getPartETag());
+
+                // Compare checksums - local with ETag
+                if (!StringUtils.equals(uploadPartResponse.getETag(), partChecksum)) {
+                    String errorMessage = "Checksums do not match error: The locally computed checksum does " +
+                            "not match with the ETag from the UploadPartResult. Local checksum: " + partChecksum +
+                            ", ETag: " + uploadPartResponse.getETag() + ", partNumber: " + partNumber;
+                    log.error(errorMessage);
+                    throw new IOException(errorMessage);
+                }
+
+                remainingBytes -= bytesToUpload;
+                partNumber++;
+            }
+
+            // Complete the multipart upload
+            CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(this.getBucketName(), key, uploadId, partETags);
+            this.s3Service.completeMultipartUpload(completeRequest);
+        } catch (AmazonClientException e) {
+            log.error("Cannot upload the file by parts because: ", e);
+        }
+    }
+
+    /**
+     * Calculate the checksum of the specified part of the file (Multipart upload)
+     *
+     * @param file the uploading file
+     * @param offset the offset in the file
+     * @param length the length of the part
+     * @param digest the message digest for computing the checksum
+     * @return the checksum of the part
+     * @throws IOException if an I/O error occurs
+     */
+    public static String calculatePartChecksum(File file, long offset, long length, MessageDigest digest) throws IOException {
+        try (FileInputStream fis = new FileInputStream(file);
+             DigestInputStream dis = new DigestInputStream(fis, digest)) {
+            // Skip to the specified offset
+            fis.skip(offset);
+
+            // Read the specified length
+            IOUtils.copyLarge(dis, OutputStream.nullOutputStream(), 0, length);
+
+            // Convert the digest to a hex string
+            return Utils.toHex(digest.digest());
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/SyncS3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/SyncS3BitStoreService.java
@@ -53,7 +53,6 @@ public class SyncS3BitStoreService extends S3BitStoreService {
      */
     private boolean uploadByParts = false;
 
-
     @Autowired(required = true)
     DSBitStoreService dsBitStoreService;
 

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -247,7 +247,7 @@ file.preview.enabled = false
 # Synchronization is NOT enabled by default
 sync.storage.service.enabled = true
 # Upload large file by parts - check the checksum of every part
-upload.by.parts.enabled = true
+s3.upload.by.parts.enabled = true
 
 
 ### The build version is stored in the specific file ###

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -246,6 +246,8 @@ file.preview.enabled = false
 ### Storage service ###
 # Synchronization is NOT enabled by default
 sync.storage.service.enabled = true
+# Upload large file by parts - check the checksum of every part
+upload.by.parts.enabled = true
 
 
 ### The build version is stored in the specific file ###


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  10  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Added a new feature: uploading a large file part by part. The ETag from UploadPartResult is compared with locally computed checksum. This feature could be enabled or disabled by cfg.

For comparation the upload of 500MB file:
Old upload (fluently): 114621ms
New upload(part): 170105ms
