### PR TITLE
Enable orcid authority

### DIFF
--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -260,3 +260,4 @@ build.version.file.path = ${dspace.dir}/config/VERSION_D.txt
 #### Item View ####
 # Show handle and doi as identifiers - show only DOI if it exists instead of handle by default
 item-page.show-handle-and-doi = false
+

--- a/dspace/config/features/enable-orcid.cfg
+++ b/dspace/config/features/enable-orcid.cfg
@@ -1,0 +1,26 @@
+## ORCID authority (https://wiki.lyrasis.org/display/DSDOC7x/ORCID+Authority)
+plugin.named.org.dspace.content.authority.ChoiceAuthority = \
+    org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
+solr.authority.server=${solr.server}/authority
+choices.plugin.dc.contributor.author = SolrAuthorAuthority
+choices.presentation.dc.contributor.author = authorLookup
+authority.controlled.dc.contributor.author = true
+authority.author.indexer.field.1=dc.contributor.author
+# https://wiki.lyrasis.org/display/DSPACE/Authority+Control+of+Metadata+Values#AuthorityControlofMetadataValues-SettingMinimumConfidence
+authority.minconfidence.dc.contributor.author = unset
+ 
+# These ORCID settings are now required for ORCID Authority
+orcid.domain-url = https://orcid.org
+# You can use either the Public API or Member API
+orcid.api-url = https://pub.orcid.org/v3.0
+
+### add the following lines to local.cfg
+#include=features/enable-orcid.cfg
+
+# You do NOT need to pay for a Member API ID to use ORCID Authority.
+# Instead, you just need a Public API ID from a free ORCID account.
+# https://info.orcid.org/documentation/features/public-api/
+#orcid.application-client-id = 
+#orcid.application-client-secret = 
+#
+#event.dispatcher.default.consumers = authority, versioning, discovery, eperson

--- a/dspace/config/spring/api/orcid-authority-services.xml
+++ b/dspace/config/spring/api/orcid-authority-services.xml
@@ -16,6 +16,7 @@
     <bean id="dspace.DSpaceAuthorityIndexer" class="org.dspace.authority.indexer.DSpaceAuthorityIndexer"/>
 
 <!--
+ -->
     <alias name="OrcidSource" alias="AuthoritySource"/>
     <bean name="OrcidSource" class="org.dspace.authority.orcid.Orcidv3SolrAuthorityImpl">
         <property name="clientId" value="${orcid.application-client-id}" />
@@ -23,12 +24,11 @@
         <property name="OAUTHUrl" value="${orcid.token-url}" />
         <property name="orcidRestConnector" ref="orcidRestConnector"/>
     </bean>
- -->
  
     <bean name="AuthorityTypes" class="org.dspace.authority.AuthorityTypes">
         <property name="types">
             <list>
-                <!-- <bean class="org.dspace.authority.orcid.Orcidv3AuthorityValue"/> -->
+                <!--  --><bean class="org.dspace.authority.orcid.Orcidv3AuthorityValue"/>
                 <bean class="org.dspace.authority.PersonAuthorityValue"/>
             </list>
         </property>


### PR DESCRIPTION
based on https://wiki.lyrasis.org/display/DSDOC7x/ORCID+Authority

configuration changes needed:
```
diff local.cfg ../dspace-angular/docker/local.cfg
157c157
< event.dispatcher.default.consumers = versioning, discovery, eperson, doi
---
> event.dispatcher.default.consumers = authority, versioning, discovery, eperson, doi
183a184,203
>
> ## ORCID authority
> plugin.named.org.dspace.content.authority.ChoiceAuthority = \
>     org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
> solr.authority.server=${solr.server}/authority
> choices.plugin.dc.contributor.author = SolrAuthorAuthority
> choices.presentation.dc.contributor.author = authorLookup
> authority.controlled.dc.contributor.author = true
> authority.author.indexer.field.1=dc.contributor.author
>
> # These ORCID settings are now required for ORCID Authority
> orcid.domain-url = https://orcid.org
> # You can use either the Public API or Member API
> orcid.api-url = https://pub.orcid.org/v3.0
>
> # You do NOT need to pay for a Member API ID to use ORCID Authority.
> # Instead, you just need a Public API ID from a free ORCID account.
> # https://info.orcid.org/documentation/features/public-api/
> orcid.application-client-id = <ID>
> orcid.application-client-secret = <SECRET>
```

This is currently deployed on dspace-dev like this:
- the above config is in `dspace-angular/docker/local.cfg`
- the `orcid-authority-services.xml` is mounted in `docker/docker-compose-rest.yml`
```
diff --git a/docker/docker-compose-rest.yml b/docker/docker-compose-rest.yml
index 87cea6b1d..7caf48cc0 100644
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -75,6 +73,7 @@ services:
     # Mount DSpace's solr configs to a volume, so that we can share to 'dspacesolr' container (see below)
     - solr_configs:/dspace/solr
     - ./local.cfg:/dspace/config/local.cfg
+    - ./orcid-authority-services.xml:/dspace/config/spring/api/orcid-authority-services.xml
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
     # 2. Then, run database migration to init database tables
```

The wiki instructs me to run `bin/dspace index-authority`, but when I do that through docker dspace-cli image:
```
docker compose -p ukrepo --env-file .env -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f docker/cli.yml run dspace-cli index-authority
Cannot index authority values since the configuration isn't valid. Check dspace logs for more information.
```
1. Where are the logs? (cli has only assetstore mount)
  a. `docker cp 5603453344a9:/dspace/log/dspace.log /tmp/cli_dspace.log` ? (where the id is obtained via `docker ps -a`)
  b. the error there is 
```
2024-03-28 09:18:28,589 WARN  unknown unknown org.dspace.authority.indexer.DSpaceAuthorityIndexer @ Authority indexer not properly configured, no metadata fields configured for indexing. Check the "authority.author.indexer.field" properties.
```
but
```
grep "authority.author.indexer" docker/local.cfg
authority.author.indexer.field.1=dc.contributor.author
```
@milanmajchrak does dspace-cli even see the `dspace-angular/docker/local.cfg`?

summary:

- [ ] enable orcid authority
- [ ] find a place for the configs (so we don't bloat `local.cfg`)
- [ ] comment/fix local.cfg and dspace-cli