### PR TITLE
Download restricted zip

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinUserMetadataImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinUserMetadataImportController.java
@@ -168,12 +168,12 @@ public class ClarinUserMetadataImportController {
                 //create user metadata and license resource user allowance
                 newClarinUserMetadataList = clarinUserMetadataRestController.processSignedInUser(
                         context, ePerson, clarinUserMetadataRestList,
-                        clarinLicenseResourceMapping, bitstreamUUID, token);
+                        clarinLicenseResourceMapping, token);
             } else {
                 // The user not is signed in
                 //create user metadata and license resource user allowance
                 newClarinUserMetadataList = clarinUserMetadataRestController.processNonSignedInUser(
-                        context, clarinUserMetadataRestList, clarinLicenseResourceMapping, bitstreamUUID, token);
+                        context, clarinUserMetadataRestList, clarinLicenseResourceMapping, token);
             }
             //set eperson_id (user registration) in user_metadata
             newClarinUserMetadataList.get(0).setEperson(userRegistration);


### PR DESCRIPTION
Issue: https://github.com/dataquest-dev/DSpace/issues/538

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
**Problem**: After click on download token the whole ZIP file is not downloaded, the first bitstream is downloaded instead
**Reason:** Downloading via link from the email is authorized by the `dtoken`. This `dtoken` is associated with downloading bitstream, which means every bitstream from the ZIP file must have an associated `dtoken`, which did not happen. The `dtoken` was generated only for the first bitstream and when the server tried to retrieve bitstream content of second bitstream it threw `Unauthorized error`.
**Solution:** Create a new endpoint for downloading **restricted** ZIP file, which creates `dtoken` for every bitstream of the Item. I have done a small refactor, because I needed to reuse some code, but this code should be refactored at all.
