### PR TITLE
The bitstreams cannot be seen after the item is created

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -26,6 +26,7 @@ import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -66,6 +67,8 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
     protected BitstreamStorageService bitstreamStorageService;
     @Autowired(required = true)
     protected ClarinLicenseResourceMappingService clarinLicenseResourceMappingService;
+    @Autowired(required = true)
+    protected ClarinItemService clarinItemService;
 
     protected BitstreamServiceImpl() {
         super();
@@ -286,7 +289,8 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
             }
             bundle.removeBitstream(bitstream);
         }
-
+        // Update Item's metadata about bitstreams
+        clarinItemService.updateItemFilesMetadata(context, bitstream);
         //Remove all bundles from the bitstream object, clearing the connection in 2 ways
         bundles.clear();
 

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -278,6 +278,8 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         // Remove bitstream itself
         bitstream.setDeleted(true);
         update(context, bitstream);
+        // Update Item's metadata about bitstreams
+        clarinItemService.updateItemFilesMetadata(context, bitstream);
 
         //Remove our bitstream from all our bundles
         final List<Bundle> bundles = bitstream.getBundles();
@@ -289,8 +291,6 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
             }
             bundle.removeBitstream(bitstream);
         }
-        // Update Item's metadata about bitstreams
-        clarinItemService.updateItemFilesMetadata(context, bitstream);
         //Remove all bundles from the bitstream object, clearing the connection in 2 ways
         bundles.clear();
 

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -164,7 +164,6 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         // Ensure that the last modified from the item is triggered !
         Item owningItem = (Item) getParentObject(context, bundle);
         if (owningItem != null) {
-            clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
             itemService.updateLastModified(context, owningItem);
             itemService.update(context, owningItem);
         }
@@ -219,6 +218,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         }
         bitstreamService.update(context, bitstream);
 
+        clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
         // Add clarin license to the bitstream and clarin license values to the item metadata
         clarinLicenseService.addClarinLicenseToBitstream(context, owningItem, bundle, bitstream);
     }
@@ -240,9 +240,9 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         //Ensure that the last modified from the item is triggered !
         Item owningItem = (Item) getParentObject(context, bundle);
         if (owningItem != null) {
-            clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
             itemService.updateLastModified(context, owningItem);
             itemService.update(context, owningItem);
+            clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
         }
 
         // In the event that the bitstream to remove is actually
@@ -456,10 +456,9 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
             //The order of the bitstreams has changed, ensure that we update the last modified of our item
             Item owningItem = (Item) getParentObject(context, bundle);
             if (owningItem != null) {
-                clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
                 itemService.updateLastModified(context, owningItem);
                 itemService.update(context, owningItem);
-
+                clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -197,6 +197,10 @@ public class ClarinItemServiceImpl implements ClarinItemService {
             break;
         }
 
+        // It could be null when the bundle name is e.g. `LICENSE`
+        if (Objects.isNull(item) || Objects.isNull(bundle)) {
+            return;
+        }
         this.updateItemFilesMetadata(context, item, bundle);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -175,4 +175,28 @@ public class ClarinItemServiceImpl implements ClarinItemService {
         itemService.addMetadata(context, item,"local", "files", "count", Item.ANY, "" + totalNumberOfFiles);
         itemService.addMetadata(context, item,"local", "files", "size", Item.ANY, "" + totalSizeofFiles);
     }
+
+    @Override
+    public void updateItemFilesMetadata(Context context, Bitstream bit) throws SQLException {
+        // Get the Item the bitstream is associated with
+        Item item = null;
+        Bundle bundle = null;
+        List<Bundle> origs = bit.getBundles();
+        for (Bundle orig : origs) {
+            if (!Constants.CONTENT_BUNDLE_NAME.equals(orig.getName())) {
+                continue;
+            }
+
+            List<Item> items = orig.getItems();
+            if (CollectionUtils.isEmpty(items)) {
+                continue;
+            }
+
+            item = items.get(0);
+            bundle = orig;
+            break;
+        }
+
+        this.updateItemFilesMetadata(context, item, bundle);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinItemService.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
 
+import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
@@ -79,5 +80,14 @@ public interface ClarinItemService {
      * @throws SQLException
      */
     void updateItemFilesMetadata(Context context, Item item, Bundle bundle) throws SQLException;
+
+    /**
+     * Update item's metadata about its files (local.has.files, local.files.size, local.files.count).
+     * The Item and Bundle information is taken from the Bitstream object.
+     * @param context
+     * @param bit
+     * @throws SQLException
+     */
+    void updateItemFilesMetadata(Context context, Bitstream bit) throws SQLException;
 
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Two problems:
- The metadata about bitstreams were updating when the bitstream wasn't attached to the Item, so everytime the metadata told, that Item has no bitstreams.
- After deleting the Bitstream the Item's metadata wasn't updated.
