### PR TITLE
Changed com/col prefix in the comcolfilter

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/ColComFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/ColComFilter.java
@@ -82,10 +82,16 @@ public class ColComFilter extends DSpaceFilter {
 
     private String getSetSpec() {
         // Set prefix for the community as default value.
-        String handlePrefix = "com_";
+        String handlePrefix;
         if (dso instanceof Collection) {
             // Prefix for the Collection.
             handlePrefix = "col_";
+        } else if (dso instanceof Community) {
+            handlePrefix = "com_";
+        } else {
+            String message = "The DSO object must be of type Community or Collection.";
+            log.error(message);
+            throw new RuntimeException(message);
         }
         return handlePrefix + dso.getHandle().replace("/", "_");
     }

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/ColComFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/ColComFilter.java
@@ -81,7 +81,13 @@ public class ColComFilter extends DSpaceFilter {
     }
 
     private String getSetSpec() {
-        return "hdl_" + dso.getHandle().replace("/", "_");
+        // Set prefix for the community as default value.
+        String handlePrefix = "com_";
+        if (dso instanceof Collection) {
+            // Prefix for the Collection.
+            handlePrefix = "col_";
+        }
+        return handlePrefix + dso.getHandle().replace("/", "_");
     }
 
     private DSpaceObject getDSpaceObject() {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Use the community or the collection handle prefix `com_/col_` instead of v5 prefix `hdl_` because the filter cannot match the handle of the community which should not be exposed.