### PR TITLE
Update clarin_autoregistration

### DIFF
--- a/dspace/config/emails/clarin_autoregistration
+++ b/dspace/config/emails/clarin_autoregistration
@@ -10,7 +10,7 @@
 ## See org.dspace.core.Email for information on the format of this file.
 ##
 #set($subject = 'Account Registration')
-To complete registration for a ${params[3]} repository account at {params[5]}, please click the link below:
+To complete registration for a ${params[3]} repository account at ${params[5]}, please click the link below:
 
   ${params[0]}
 


### PR DESCRIPTION
The `{params[5]}` in the message body was not interpolated due to missing `$`


