### PR TITLE
 different required fileds when download hamledt

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicense.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicense.java
@@ -53,6 +53,7 @@ public class ClarinLicense implements ReloadableEntity<Integer> {
      * Required info key word.
      */
     public static final String SEND_TOKEN = "SEND_TOKEN";
+    public static final String EXTRA_EMAIL = "EXTRA_EMAIL";
 
     @Id
     @Column(name = "license_id")

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.repository;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.dspace.app.rest.utils.ContextUtil.obtainContext;
+import static org.dspace.content.clarin.ClarinLicense.EXTRA_EMAIL;
 import static org.dspace.content.clarin.ClarinLicense.SEND_TOKEN;
 import static org.dspace.content.clarin.ClarinUserRegistration.ANONYMOUS_USER_REGISTRATION;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
@@ -185,6 +186,7 @@ public class ClarinUserMetadataRestController {
 
     @RequestMapping(method = POST, consumes = APPLICATION_JSON)
     @PreAuthorize("permitAll()")
+
     public ResponseEntity manageUserMetadata(@RequestParam("bitstreamUUID") UUID bitstreamUUID,
                                                      HttpServletRequest request)
             throws SQLException, ParseException, IOException, AuthorizeException, MessagingException {
@@ -395,7 +397,7 @@ public class ClarinUserMetadataRestController {
     }
 
     private String getEmailFromUserMetadata(List<ClarinUserMetadataRest> clarinUserMetadataRestList) {
-        return getFieldFromUserMetadata(SEND_TOKEN, clarinUserMetadataRestList);
+        return getFieldFromUserMetadata(EXTRA_EMAIL, clarinUserMetadataRestList);
     }
 
     private String getFieldFromUserMetadata(String field, List<ClarinUserMetadataRest> clarinUserMetadataRestList) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -186,7 +186,6 @@ public class ClarinUserMetadataRestController {
 
     @RequestMapping(method = POST, consumes = APPLICATION_JSON)
     @PreAuthorize("permitAll()")
-
     public ResponseEntity manageUserMetadata(@RequestParam("bitstreamUUID") UUID bitstreamUUID,
                                                      HttpServletRequest request)
             throws SQLException, ParseException, IOException, AuthorizeException, MessagingException {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
@@ -170,12 +170,16 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
         ClarinUserMetadataRest clarinUserMetadata3 = new ClarinUserMetadataRest();
         clarinUserMetadata3.setMetadataKey("SEND_TOKEN");
-        clarinUserMetadata3.setMetadataValue("test@test.edu");
+
+        ClarinUserMetadataRest clarinUserMetadata4 = new ClarinUserMetadataRest();
+        clarinUserMetadata4.setMetadataKey("EXTRA_EMAIL");
+        clarinUserMetadata4.setMetadataValue("test@test.edu");
 
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
         clarinUserMetadataRestList.add(clarinUserMetadata1);
         clarinUserMetadataRestList.add(clarinUserMetadata2);
         clarinUserMetadataRestList.add(clarinUserMetadata3);
+        clarinUserMetadataRestList.add(clarinUserMetadata4);
 
         String adminToken = getAuthToken(admin.getEmail(), password);
         // Load bitstream from the item.
@@ -256,12 +260,16 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
         ClarinUserMetadataRest clarinUserMetadata3 = new ClarinUserMetadataRest();
         clarinUserMetadata3.setMetadataKey("SEND_TOKEN");
-        clarinUserMetadata3.setMetadataValue("test@test.edu");
+
+        ClarinUserMetadataRest clarinUserMetadata4 = new ClarinUserMetadataRest();
+        clarinUserMetadata4.setMetadataKey("EXTRA_EMAIL");
+        clarinUserMetadata4.setMetadataValue("test@test.edu");
 
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
         clarinUserMetadataRestList.add(clarinUserMetadata1);
         clarinUserMetadataRestList.add(clarinUserMetadata2);
         clarinUserMetadataRestList.add(clarinUserMetadata3);
+        clarinUserMetadataRestList.add(clarinUserMetadata4);
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 
@@ -359,12 +367,16 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
         ClarinUserMetadataRest clarinUserMetadata3 = new ClarinUserMetadataRest();
         clarinUserMetadata3.setMetadataKey("SEND_TOKEN");
-        clarinUserMetadata3.setMetadataValue("test@test.edu");
+
+        ClarinUserMetadataRest clarinUserMetadata4 = new ClarinUserMetadataRest();
+        clarinUserMetadata4.setMetadataKey("EXTRA_EMAIL");
+        clarinUserMetadata4.setMetadataValue("test@test.edu");
 
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
         clarinUserMetadataRestList.add(clarinUserMetadata1);
         clarinUserMetadataRestList.add(clarinUserMetadata2);
         clarinUserMetadataRestList.add(clarinUserMetadata3);
+        clarinUserMetadataRestList.add(clarinUserMetadata4);
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 


### PR DESCRIPTION
**Problem description**
In the required info, there are SEND_TOKEN and EXTRA_EMAIL. In version 5, when SEND_TOKEN is required, the system sends information to the address in the EXTRA_EMAIL field. We require two addresses from the user and will send an email to the address in the SEND_TOKEN field when SEND_TOKEN is required.

**Solution**
Do not require SEND_TOKEN as an input field. Instead, send the email to the EXTRA_EMAIL address when SEND_TOKEN is required.
