### PR TITLE
Cannot create a new version because an owningcollection is null

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -315,6 +315,8 @@ public class ItemUtils {
         if (restricted) {
             other.getField().add(createValue("restrictedAccess", "true"));
         }
+        // because we reindex solr which is doesn't do in vanilla
+        // for workspace items the owning collection is null, we need to control it
         other.getField().add(createValue("owningCollection",
                 item.getOwningCollection() != null ? item.getOwningCollection().getName() : null));
         other.getField().add(createValue("itemId", item.getID().toString()));

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -315,7 +315,8 @@ public class ItemUtils {
         if (restricted) {
             other.getField().add(createValue("restrictedAccess", "true"));
         }
-        other.getField().add(createValue("owningCollection", item.getOwningCollection().getName()));
+        other.getField().add(createValue("owningCollection",
+                item.getOwningCollection() != null ? item.getOwningCollection().getName() : null));
         other.getField().add(createValue("itemId", item.getID().toString()));
         metadata.getElement().add(other);
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -315,7 +315,8 @@ public class ItemUtils {
         if (restricted) {
             other.getField().add(createValue("restrictedAccess", "true"));
         }
-        // Because we reindex Solr, which is not done in vanilla, the owning collection for workspace items is null
+        // Because we reindex Solr, which is not done in vanilla
+        // The owning collection for workspace items is null
         other.getField().add(createValue("owningCollection",
                 item.getOwningCollection() != null ? item.getOwningCollection().getName() : null));
         other.getField().add(createValue("itemId", item.getID().toString()));

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -315,8 +315,7 @@ public class ItemUtils {
         if (restricted) {
             other.getField().add(createValue("restrictedAccess", "true"));
         }
-        // because we reindex solr which is doesn't do in vanilla
-        // for workspace items the owning collection is null, we need to control it
+        // Because we reindex Solr, which is not done in vanilla, the owning collection for workspace items is null
         other.getField().add(createValue("owningCollection",
                 item.getOwningCollection() != null ? item.getOwningCollection().getName() : null));
         other.getField().add(createValue("itemId", item.getID().toString()));


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

## Problem description
Owning collection is null for some of the  items.

## Solution
The items for which the owning group has assigned roles are created as workspace items that need to be claimed and approved. As a result of this, in the reindexing in Solr, the owning collection of the workspace item is null. We added a condition to handle this. Cannot get the name from a null community.