### PR TITLE
Update logging of downloading files

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -122,8 +122,6 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
 
         List<Item> items = clarinItemService.findByBitstreamUUID(context, bit.getID());
         if (CollectionUtils.isEmpty(items)) {
-            log.error("Cannot find the Item for the bitstream with ID: " + bit.getID() +
-                    " - the statistics cannot be logged.");
             return;
         }
 

--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -71,7 +71,7 @@
                   type='RollingFile'
                   fileName='${log.dir}/file_downloads.log'>
             <Layout type='PatternLayout'
-                    pattern='%m%n'/>
+                    pattern='%d %m%n'/>
             <policies>
                 <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
             </policies>


### PR DESCRIPTION
Issue: https://github.com/dataquest-dev/DSpace/issues/704

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
1. sort file_downloads.log based on time
2. remove log info which could generate noise
3. check that the error is being logged to the correct log file