### PR TITLE
UFAL/Shibboleth - load more net-id headers e.g. persistent-id

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -1211,14 +1211,11 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
         if (name == null) {
             return null;
         }
-
         String value = findAttribute(request, name);
 
-
         if (value != null) {
-            sortEmailsAndGetFirst(value);
+            value = sortEmailsAndGetFirst(value);
         }
-
         return value;
     }
 

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -853,7 +853,16 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
         }
         // The email could have changed if using netid based lookup.
         if (email != null) {
-            eperson.setEmail(email.toLowerCase());
+            String lowerCaseEmail = email.toLowerCase();
+            // Check the email is unique
+            EPerson epersonByEmail = ePersonService.findByEmail(context, lowerCaseEmail);
+            if (epersonByEmail != null && !epersonByEmail.getID().equals(eperson.getID())) {
+                log.error("Unable to update the eperson's email metadata because the email '{}' is already in use.",
+                        lowerCaseEmail);
+                throw new AuthorizeException("The email address is already in use.");
+            } else {
+                eperson.setEmail(email.toLowerCase());
+            }
         }
         if (fname != null) {
             eperson.setFirstName(context, fname);

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -1216,22 +1216,30 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
 
 
         if (value != null) {
-            // If there are multiple values encoded in the shibboleth attribute
-            // they are separated by a semicolon, and any semicolons in the
-            // attribute are escaped with a backslash.
-            // Step 1: Split the input string into email addresses
-            List<String> emails = Arrays.stream(value.split("(?<!\\\\);"))  // Split by unescaped semicolon
-                    .map(email -> email.replaceAll("\\\\;", ";")) // Unescape semicolons
-                    .collect(Collectors.toList());
-
-            // Step 2: Sort the email list alphabetically
-            emails.sort(String::compareToIgnoreCase);
-
-            // Step 3: Get the first sorted email
-            value = emails.get(0);
+            sortEmailsAndGetFirst(value);
         }
 
         return value;
+    }
+
+    /**
+     * Sort the email addresses and return the first one.
+     * @param value The email addresses separated by semicolons.
+     */
+    public static String sortEmailsAndGetFirst(String value) {
+        // If there are multiple values encoded in the shibboleth attribute
+        // they are separated by a semicolon, and any semicolons in the
+        // attribute are escaped with a backslash.
+        // Step 1: Split the input string into email addresses
+        List<String> emails = Arrays.stream(value.split("(?<!\\\\);"))  // Split by unescaped semicolon
+                .map(email -> email.replaceAll("\\\\;", ";")) // Unescape semicolons
+                .collect(Collectors.toList());
+
+        // Step 2: Sort the email list alphabetically
+        emails.sort(String::compareToIgnoreCase);
+
+        // Step 3: Get the first sorted email
+        return emails.get(0);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ShibHeaders.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ShibHeaders.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,7 +33,7 @@ public class ShibHeaders {
     // constants
     //
     private static final String header_separator_ = ";";
-    private String netIdHeader = "";
+    private String[] netIdHeaders = null;
     ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     // variables
@@ -105,7 +106,7 @@ public class ShibHeaders {
         List<String> values = get(name);
         if (values != null && !values.isEmpty()) {
             // Format netId
-            if (StringUtils.equals(name, this.netIdHeader)) {
+            if (ArrayUtils.contains(this.netIdHeaders, name)) {
                 return Util.formatNetId(values.get(0), this.get_idp());
             }
             return values.get(0);
@@ -150,6 +151,6 @@ public class ShibHeaders {
     }
 
     private void initializeNetIdHeader() {
-        this.netIdHeader = configurationService.getProperty("authentication-shibboleth.netid-header");
+        this.netIdHeaders = configurationService.getArrayProperty("authentication-shibboleth.netid-header");
     }
 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ShibHeaders.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ShibHeaders.java
@@ -153,4 +153,8 @@ public class ShibHeaders {
     private void initializeNetIdHeader() {
         this.netIdHeaders = configurationService.getArrayProperty("authentication-shibboleth.netid-header");
     }
+
+    public List<String> getNetIdHeaders() {
+        return Arrays.asList(this.netIdHeaders);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ShibHeaders.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ShibHeaders.java
@@ -154,7 +154,7 @@ public class ShibHeaders {
         this.netIdHeaders = configurationService.getArrayProperty("authentication-shibboleth.netid-header");
     }
 
-    public List<String> getNetIdHeaders() {
-        return Arrays.asList(this.netIdHeaders);
+    public String[] getNetIdHeaders() {
+        return this.netIdHeaders;
     }
 }

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -219,7 +219,7 @@ featured.service.teitok.description = A web-based platform for viewing, creating
 
 
 ##### Shibboleth #####
-authentication-shibboleth.netid-header = SHIB-NETID
+authentication-shibboleth.netid-header = SHIB-NETID,eppn,persistent-id
 authentication-shibboleth.email-header = SHIB-MAIL
 authentication-shibboleth.firstname-header = SHIB-GIVENNAME
 authentication-shibboleth.lastname-header = SHIB-SURNAME

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
@@ -166,27 +166,18 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
         }
 
         EPerson ePerson = null;
-        // 1. Try find the user by the netid
-        // Retrieve the netid and email values from the header.
-        for (String netidHeader : shib_headers.getNetIdHeaders()) {
-            try {
-                netidHeader = netidHeader.trim();
-                String netid = shib_headers.get_single(netidHeader);
-                // If email is null and netid exist try to find the eperson by netid and load its email
-                if (StringUtils.isEmpty(email)) {
-                    ePerson = ePersonService.findByNetid(context, netid);
-                    email = Objects.isNull(email) ? this.getEpersonEmail(ePerson) : null;
-                }
-            } catch (SQLException ignored) {
-                //
-            }
+        try {
+            ePerson = ClarinShibAuthentication.findEpersonByNetId(shib_headers.getNetIdHeaders(), shib_headers, ePerson,
+                    ePersonService, context, false);
+        } catch (SQLException e) {
+            // It is logged in the ClarinShibAuthentication class.
         }
 
         if (Objects.isNull(ePerson) && StringUtils.isNotEmpty(email)) {
             try {
                 ePerson = ePersonService.findByEmail(context, email);
             } catch (SQLException e) {
-                //
+                // It is logged in the ClarinShibAuthentication class.
             }
         }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.security;
 
 import static org.dspace.app.rest.security.ShibbolethLoginFilterIT.PASS_ONLY;
 import static org.dspace.app.rest.security.clarin.ClarinShibbolethLoginFilter.VERIFICATION_TOKEN_HEADER;
+import static org.dspace.rdf.negotiation.MediaRange.token;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -53,8 +55,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegrationTest {
 
     public static final String[] SHIB_ONLY = {"org.dspace.authenticate.clarin.ClarinShibAuthentication"};
+    private static final String NET_ID_EPPN_HEADER = "eppn";
+    private static final String NET_ID_PERSISTENT_ID = "persistent-id";
     private static final String NET_ID_TEST_EPERSON = "123456789";
     private static final String IDP_TEST_EPERSON = "Test Idp";
+    private static final String KNIHOVNA_KUN_TEST_ZLUTOUCKY = "knihovna Kůň test Žluťoučký";
+
 
     private EPersonRest ePersonRest;
     private final String feature = CanChangePasswordFeature.NAME;
@@ -183,10 +189,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andExpect(status().isOk());
 
         // Check if was created a user with such email and netid.
-        EPerson ePerson = ePersonService.findByNetid(context, Util.formatNetId(netId, idp));
-        assertTrue(Objects.nonNull(ePerson));
-        assertEquals(ePerson.getEmail(), email);
-        assertEquals(ePerson.getNetid(), Util.formatNetId(netId, idp));
+        EPerson ePerson = checkUserWasCreated(netId, idp, email, null);
 
         // The user is registered now log him
         getClient().perform(post("/api/authn/shibboleth")
@@ -207,7 +210,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andExpect(status().isFound());
 
         // Delete created eperson - clean after the test
-        EPersonBuilder.deleteEPerson(ePerson.getID());
+        deleteShibbolethUser(ePerson);
     }
 
     @Test
@@ -227,10 +230,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andReturn().getResponse().getHeader("Authorization");
 
 
-        getClient(token).perform(get("/api/authn/status"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authenticated", is(true)))
-                .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")));
+        checkUserIsSignedIn(token);
 
         // Check if was created a user with such email and netid.
         EPerson ePerson = ePersonService.findByNetid(context, Util.formatNetId(netId, IDP_TEST_EPERSON));
@@ -264,10 +264,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andExpect(redirectedUrl("http://localhost:8080/server/api/authn/status"))
                 .andReturn().getResponse().getHeader("Authorization");
 
-        getClient(token).perform(get("/api/authn/status"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authenticated", is(true)))
-                .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")));
+        checkUserIsSignedIn(token);
 
         getClient(token).perform(
                         get("/api/authz/authorizations/search/object")
@@ -299,11 +296,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andExpect(redirectedUrl("http://localhost:4000"))
                 .andReturn().getResponse().getHeader("Authorization");
 
-
-        getClient(token).perform(get("/api/authn/status"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authenticated", is(true)))
-                .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")));
+        checkUserIsSignedIn(token);
 
         // updates password
         getClient(token).perform(patch("/api/eperson/epersons/" + clarinEperson.getID())
@@ -328,11 +321,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andExpect(redirectedUrl("http://localhost:4000"))
                 .andReturn().getResponse().getHeader("Authorization");
 
-
-        getClient(token).perform(get("/api/authn/status"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authenticated", is(true)))
-                .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")));
+        checkUserIsSignedIn(token);
 
         getClient(token).perform(
                         get("/api/authz/authorizations/search/object")
@@ -463,28 +452,10 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andExpect(redirectedUrl("http://localhost:4000"))
                 .andReturn().getResponse().getHeader("Authorization");
 
-
-        getClient(token).perform(get("/api/authn/status"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authenticated", is(true)))
-                .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")));
-
+        checkUserIsSignedIn(token);
         // Check if was created a user with such email and netid.
-        EPerson ePerson = ePersonService.findByNetid(context, Util.formatNetId(testNetId, testIdp));
-        assertTrue(Objects.nonNull(ePerson));
-        assertEquals(ePerson.getEmail(), testMail);
-        assertEquals(ePerson.getFirstName(), "knihovna Kůň test Žluťoučký");
-
-        EPersonBuilder.deleteEPerson(ePerson.getID());
-
-        getClient(token).perform(
-                        get("/api/authz/authorizations/search/object")
-                                .param("embed", "feature")
-                                .param("feature", feature)
-                                .param("uri", utils.linkToSingleResource(ePersonRest, "self").getHref()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page.totalElements", is(0)))
-                .andExpect(jsonPath("$._embedded").doesNotExist());
+        EPerson ePerson = checkUserWasCreated(testNetId, testIdp, testMail, KNIHOVNA_KUN_TEST_ZLUTOUCKY);
+        deleteShibbolethUser(ePerson);
     }
 
     @Test
@@ -500,33 +471,15 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header("SHIB-MAIL", testMail)
                         .header("Shib-Identity-Provider", testIdp)
                         .header("SHIB-NETID", testNetId)
-                        .header("SHIB-GIVENNAME", "knihovna Kůň test Žluťoučký"))
+                        .header("SHIB-GIVENNAME", KNIHOVNA_KUN_TEST_ZLUTOUCKY))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost:4000"))
                 .andReturn().getResponse().getHeader("Authorization");
 
-
-        getClient(token).perform(get("/api/authn/status"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authenticated", is(true)))
-                .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")));
-
+        checkUserIsSignedIn(token);
         // Check if was created a user with such email and netid.
-        EPerson ePerson = ePersonService.findByNetid(context, Util.formatNetId(testNetId, testIdp));
-        assertTrue(Objects.nonNull(ePerson));
-        assertEquals(ePerson.getEmail(), testMail);
-        assertEquals(ePerson.getFirstName(), "knihovna Kůň test Žluťoučký");
-
-        EPersonBuilder.deleteEPerson(ePerson.getID());
-
-        getClient(token).perform(
-                        get("/api/authz/authorizations/search/object")
-                                .param("embed", "feature")
-                                .param("feature", feature)
-                                .param("uri", utils.linkToSingleResource(ePersonRest, "self").getHref()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page.totalElements", is(0)))
-                .andExpect(jsonPath("$._embedded").doesNotExist());
+        EPerson ePerson = checkUserWasCreated(testNetId, testIdp, testMail, KNIHOVNA_KUN_TEST_ZLUTOUCKY);
+        deleteShibbolethUser(ePerson);
     }
 
     @Test
@@ -539,5 +492,75 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header("SHIB-NETID", NET_ID_TEST_EPERSON))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl(expectedMissingHeadersUrl));
+    }
+
+    // eppn is set
+    @Test
+    public void testSuccessFullLoginEppnNetId() throws Exception {
+        String token = getClient().perform(get("/api/authn/shibboleth")
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON)
+                        .header("SHIB-MAIL", clarinEperson.getEmail())
+                        .header(NET_ID_EPPN_HEADER, NET_ID_TEST_EPERSON))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("http://localhost:4000"))
+                .andReturn().getResponse().getHeader("Authorization");
+
+        checkUserIsSignedIn(token);
+
+        EPerson ePerson = checkUserWasCreated(NET_ID_TEST_EPERSON, IDP_TEST_EPERSON, clarinEperson.getEmail(), null);
+        deleteShibbolethUser(ePerson);
+    }
+
+    // persistent-id is set
+    @Test
+    public void testSuccessFullLoginPersistentIdNetId() throws Exception {
+        String token = getClient().perform(get("/api/authn/shibboleth")
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON)
+                        .header("SHIB-MAIL", clarinEperson.getEmail())
+                        .header(NET_ID_PERSISTENT_ID, NET_ID_TEST_EPERSON))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("http://localhost:4000"))
+                .andReturn().getResponse().getHeader("Authorization");
+
+        checkUserIsSignedIn(token);
+        EPerson ePerson = checkUserWasCreated(NET_ID_TEST_EPERSON, IDP_TEST_EPERSON, clarinEperson.getEmail(), null);
+        deleteShibbolethUser(ePerson);
+    }
+
+    private EPerson checkUserWasCreated(String netIdValue, String idpValue, String email, String name)
+            throws SQLException {
+        // Check if was created a user with such email and netid.
+        EPerson ePerson = ePersonService.findByNetid(context, Util.formatNetId(netIdValue, idpValue));
+        assertTrue(Objects.nonNull(ePerson));
+        if (email != null) {
+            assertEquals(ePerson.getEmail(), email);
+        }
+
+        if (name != null) {
+            assertEquals(ePerson.getFirstName(), name);
+        }
+        return ePerson;
+    }
+
+    private void checkUserIsSignedIn(String token) throws Exception {
+        getClient(token).perform(get("/api/authn/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated", is(true)))
+                .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")));
+    }
+
+
+    private void deleteShibbolethUser(EPerson ePerson) throws Exception {
+        EPersonBuilder.deleteEPerson(ePerson.getID());
+
+        // Check it was correctly deleted
+        getClient(token).perform(
+                        get("/api/authz/authorizations/search/object")
+                                .param("embed", "feature")
+                                .param("feature", feature)
+                                .param("uri", utils.linkToSingleResource(ePersonRest, "self").getHref()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(0)))
+                .andExpect(jsonPath("$._embedded").doesNotExist());
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -254,7 +254,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
     // Login with email without netid, but the user with such email already exists and it has assigned netid.
     @Test
     public void testShouldReturnDuplicateUserErrorLoginWithoutNetId() throws Exception {
-        String email = "test@mail.epic";
+        String email = "test@email.sk";
         String netId = email;
 
         // login through shibboleth
@@ -268,8 +268,8 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
 
         checkUserIsSignedIn(token);
 
-        // login through shibboleth
-        String tokenDuplicate = getClient().perform(get("/api/authn/shibboleth")
+        // Should not login because the user with such email already exists
+        getClient().perform(get("/api/authn/shibboleth")
                         .header("SHIB-MAIL", email)
                         .header("Shib-Identity-Provider", IDP_TEST_EPERSON))
                 .andExpect(status().is3xxRedirection())
@@ -594,7 +594,7 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header(NET_ID_PERSISTENT_ID, NET_ID_TEST_EPERSON)
                         .header("SHIB-MAIL", userWithEppnEmail))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("http://localhost:4000/login/"));
+                .andExpect(redirectedUrl("http://localhost:4000/login/duplicate-user?email=" + userWithEppnEmail));
 
         // Check if was created a user with such email and netid.
         EPerson ePerson = checkUserWasCreated(customEppn, IDP_TEST_EPERSON, userWithEppnEmail, null);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -229,7 +229,6 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                 .andExpect(redirectedUrl("http://localhost:4000"))
                 .andReturn().getResponse().getHeader("Authorization");
 
-
         checkUserIsSignedIn(token);
 
         // Check if was created a user with such email and netid.
@@ -250,6 +249,33 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
 
         // Delete created eperson - clean after the test
         EPersonBuilder.deleteEPerson(ePerson.getID());
+    }
+
+    // Login with email without netid, but the user with such email already exists and it has assigned netid.
+    @Test
+    public void testShouldReturnDuplicateUserErrorLoginWithoutNetId() throws Exception {
+        String email = "test@mail.epic";
+        String netId = email;
+
+        // login through shibboleth
+        String token = getClient().perform(get("/api/authn/shibboleth")
+                        .header("SHIB-MAIL", email)
+                        .header("SHIB-NETID", netId)
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("http://localhost:4000"))
+                .andReturn().getResponse().getHeader("Authorization");
+
+        checkUserIsSignedIn(token);
+
+        // login through shibboleth
+        String tokenDuplicate = getClient().perform(get("/api/authn/shibboleth")
+                        .header("SHIB-MAIL", email)
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("http://localhost:4000/login/duplicate-user?email=" + email))
+                .andReturn().getResponse().getHeader("Authorization");
+
     }
 
     // This test is copied from the `ShibbolethLoginFilterIT` and modified following the Clarin updates.

--- a/dspace/config/modules/authentication-shibboleth.cfg
+++ b/dspace/config/modules/authentication-shibboleth.cfg
@@ -90,7 +90,7 @@ authentication-shibboleth.lazysession.secure = true
 
 # Authentication headers for Mail, NetID, and Tomcat's Remote User.
 # Supply all parameters possible.
-authentication-shibboleth.netid-header = eppn
+authentication-shibboleth.netid-header = eppn,persistent-id
 authentication-shibboleth.email-header = mail
 authentication-shibboleth.email-use-tomcat-remote-user = false
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
