### PR TITLE
test for bitstream with null value for sizebytes

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -137,7 +137,7 @@ public class ClarinBitstreamImportController {
 
             Boolean deleted = Boolean.parseBoolean(deletedString);
             //set size bytes
-            if (!Objects.isNull(bitstreamRest.getSizeBytes())) {
+            if (Objects.nonNull(bitstreamRest.getSizeBytes())) {
                 bitstream.setSizeBytes(bitstreamRest.getSizeBytes());
             } else {
                 log.info("SizeBytes is null. Bitstream UUID: " + bitstream.getID());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -210,7 +210,7 @@ public class ClarinBitstreamImportController {
                 message += " for bundle with uuid: " + bundle.getID();
             }
             log.error(message, e);
-            throw new RuntimeException("message", e);
+            throw new RuntimeException(message, e);
         }
         return bitstreamRest;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -137,7 +137,11 @@ public class ClarinBitstreamImportController {
 
             Boolean deleted = Boolean.parseBoolean(deletedString);
             //set size bytes
-            bitstream.setSizeBytes(bitstreamRest.getSizeBytes());
+            if (!Objects.isNull(bitstreamRest.getSizeBytes())) {
+                bitstream.setSizeBytes(bitstreamRest.getSizeBytes());
+            } else {
+                log.info("SizeBytes is null. Bitstream UUID: " + bitstream.getID());
+            }
             //set checksum
             bitstream.setChecksum(bitstreamRest.getCheckSum().getValue());
             //set checksum algorithm

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinBitstreamImportControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinBitstreamImportControllerIT.java
@@ -270,6 +270,28 @@ public class ClarinBitstreamImportControllerIT extends AbstractEntityIntegration
         assertEquals(bitstreamService.findAll(context).size(), 0);
     }
 
+    @Test
+    public void importDeletedBitstreamTest() throws Exception {
+        assertEquals(bitstreamService.findAll(context).size(), 0);
+        //input data
+        ObjectNode checksumNode = jsonNodeFactory.objectNode();
+        checksumNode.set("checkSumAlgorithm", null);
+        checksumNode.set("value", null);
+        ObjectNode node = jsonNodeFactory.objectNode();
+        node.set("sizeBytes", null);
+        node.set("checkSum", checksumNode);
+
+        //create new bitstream for existing file
+        ObjectMapper mapper = new ObjectMapper();
+        getClient(token).perform(post("/api/clarin/import/core/bitstream")
+                        .content(mapper.writeValueAsBytes(node))
+                        .contentType(contentType)
+                        .param("internal_id", internalId)
+                        .param("storeNumber", "0")
+                        .param("deleted", "true"))
+                .andExpect(status().is(500));
+    }
+
     private void checkCreatedBitstream(UUID uuid, String internalId, int storeNumber,
                                        String bitstreamFormat, int sequence, boolean deleted, long sizeBytes,
                                        String checkSum) throws SQLException {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinBitstreamImportControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinBitstreamImportControllerIT.java
@@ -292,8 +292,12 @@ public class ClarinBitstreamImportControllerIT extends AbstractEntityIntegration
                 .andReturn().getResponse().getContentAsString(),
                 "$.id"));
 
-        checkCreatedBitstream(uuid, internalId, 0, null, -1, true,
-                0, null);
+        bitstream = bitstreamService.find(context, uuid);
+        assertEquals(bitstream.getSizeBytes(), 0);
+        assertEquals(bitstream.getInternalId(), internalId);
+        assertEquals(bitstream.getStoreNumber(), 0);
+        assertEquals(bitstream.getSequenceID(), -1);
+        assertEquals(bitstream.isDeleted(), true);
 
         //clean all
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  | 1  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

## Problem description
During Ondrej's bitstream import, two bitstreams were not imported.

**1. Problem:**  Backend logs didn't help.
**Solution:** Fixed exception message in logs.

**2. Problem:** The byte_size of this bitstream is null. We tried inserting a null value into a long type
**Solution:** Checked if inserted value is notNull.

**3. Problem**: add warning about importing bitstream which is already deleted to pump

## Warning
Since we cannot add null to the long type, the imported values ​​of sizebytes, sequence_id and bitstream_format are not null, but predefined values ​​(sizebytes = 0, sequence_id = -1, bitstream_format = "Unknown").
