### PR TITLE
create license with current user

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinLicenseImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinLicenseImportController.java
@@ -57,22 +57,31 @@ public class ClarinLicenseImportController {
             throw new RuntimeException("Context is null!");
         }
         //get param
-        UUID epersonUUID = UUID.fromString(request.getParameter("eperson"));
-        EPerson ePerson = ePersonService.find(context, epersonUUID);
+        String epersonParam = request.getParameter("eperson");
+        EPerson ePerson = null;
+        if (Objects.nonNull(epersonParam)) {
+            UUID epersonUUID = UUID.fromString(request.getParameter("eperson"));
+            ePerson = ePersonService.find(context, epersonUUID);
+        }
 
-        //set current user to eperson and create license
-        EPerson currUser = context.getCurrentUser();
-        context.setCurrentUser(ePerson);
+        EPerson currUser = null;
+        // Set the current user to the EPerson if the EPerson was found and create the license.
+        if (Objects.nonNull(ePerson)) {
+            currUser = context.getCurrentUser();
+            context.setCurrentUser(ePerson);
+        }
+
         //turn off authorization
         context.turnOffAuthorisationSystem();
         ClarinLicenseRest clarinLicenseRest = clarinLicenseRestRepository.createAndReturn();
         context.restoreAuthSystemState();
-        //set back current use
-        context.setCurrentUser(currUser);
+
+        // Restore the current user if one was previously set.
+        if (Objects.nonNull(ePerson)) {
+            context.setCurrentUser(currUser);
+        }
 
         context.complete();
         return clarinLicenseRest;
     }
-
-
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
After the vanilla import, the tables containing licenses are empty because there were no licenses beforehand.

## Analysis
Fetch licenses, labels, and extended mappings from the database where licenses already exist. Filter them based on the definitions that are not required, and import them into vanilla DSpace where they are missing.
When we import the license this way, the person has to stay for the user.
