### PR TITLE
UFAL/Shibboleth - show error in the UI when shibboleth authentication is failed

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -239,7 +239,17 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
         // The user e-mail is not stored in the `shibheaders` but in the `clarinVerificationToken`.
         // The email was added to the `clarinVerificationToken` in the ClarinShibbolethFilter.
         String[] netidHeaders = configurationService.getArrayProperty("authentication-shibboleth.netid-header");
-        clarinVerificationToken = clarinVerificationTokenService.findByNetID(context, netidHeaders, shibheaders);
+
+        // Load the verification token from the request header or from the request parameter.
+        // This is only set if the user is trying to authenticate with the `verification-token`.
+        String VERIFICATION_TOKEN = "verification-token";
+        String verificationTokenFromRequest = StringUtils.defaultIfBlank(request.getHeader(VERIFICATION_TOKEN),
+                        request.getParameter(VERIFICATION_TOKEN));
+        if (StringUtils.isNotEmpty(verificationTokenFromRequest)) {
+            log.info("Verification token from request header `{}`: {}", VERIFICATION_TOKEN,
+                    verificationTokenFromRequest);
+            clarinVerificationToken = clarinVerificationTokenService.findByToken(context, verificationTokenFromRequest);
+        }
         // CLARIN
 
         // Initialize the additional EPerson metadata.

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -506,4 +506,21 @@ public final class Utils {
         ConfigurationService config = DSpaceServicesFactory.getInstance().getConfigurationService();
         return StringSubstitutor.replace(string, config.getProperties());
     }
+
+    /**
+     * Replace the last occurrence of a substring within a string.
+     *
+     * @param input The input string
+     * @param toReplace The substring to replace
+     * @param replacement The replacement substring
+     * @return Replaced input string or the original input string if the substring to replace is not found
+     */
+    public static String replaceLast(String input, String toReplace, String replacement) {
+        int lastIndex = input.lastIndexOf(toReplace);
+        if (lastIndex == -1) {
+            return input; // No replacement if not found
+        }
+
+        return input.substring(0, lastIndex) + replacement + input.substring(lastIndex + toReplace.length());
+    }
 }

--- a/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
@@ -132,4 +132,24 @@ public class UtilsTest extends AbstractUnitTest {
         // remove the config we added
         configurationService.setProperty(configName, null);
     }
+
+    // Replace the last occurrence of a substring
+    @Test
+    public void testReplaceLast_SingleOccurrence() {
+        String input = "/login/";
+        String result = Utils.replaceLast(input, "/", "replacement");
+
+        // Expected output: "/loginreplacement"
+        assertEquals("/loginreplacement", result);
+    }
+
+    // No replacement when the substring is not found
+    @Test
+    public void testReplaceLast_NoMatch() {
+        String input = "/login";
+        String result = Utils.replaceLast(input, "/", "replacement");
+
+        // Expected output: "/login"
+        assertEquals("replacementlogin", result);
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
@@ -261,6 +261,7 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
         String missingHeadersUrl = "missing-headers";
         String userWithoutEmailUrl = "auth-failed";
         String duplicateUser = "duplicate-user";
+        String cannotAuthenticate = "shibboleth-authentication-failed";
 
         // Compose the redirect URL
         if (this.isMissingHeadersFromIdp) {
@@ -270,6 +271,11 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
         } else if (StringUtils.isNotEmpty(this.netId)) {
             // netId is set if the user doesn't have the email
             redirectUrl += userWithoutEmailUrl + "?netid=" + this.netId;
+        } else {
+            // Remove the last slash from the URL `login/`
+            String redirectUrlWithoutSlash = redirectUrl.endsWith("/") ?
+                    Utils.replaceLast(redirectUrl, "/", "") : redirectUrl;
+            redirectUrl = redirectUrlWithoutSlash + "?error=" + cannotAuthenticate;
         }
 
         response.sendRedirect(redirectUrl);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -621,6 +621,43 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         Util.formatNetId(persistentId, IDP_TEST_EPERSON)));
     }
 
+    // The user was registered and signed in with the verification token on the second attempt, after the email
+    // containing the verification token was sent.
+    @Test
+    public void shouldNotAuthenticateOnSecondAttemptWithoutVerificationTokenInRequest() throws Exception {
+        String email = "test@mail.epic";
+        String netId = email;
+        String idp = "Test Idp";
+
+        // Try to authenticate but the Shibboleth doesn't send the email in the header, so the user won't be registered
+        // but the user will be redirected to the page where he will fill in the user email.
+        getClient().perform(get("/api/authn/shibboleth")
+                        .header("Shib-Identity-Provider", idp)
+                        .header("SHIB-NETID", netId))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" +
+                        Util.formatNetId(netId, idp)));
+
+        // Send the email with the verification token.
+        String tokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(tokenAdmin).perform(post("/api/autoregistration?netid=" + netId + "&email=" + email)
+                        .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        // Load the created verification token.
+        ClarinVerificationToken clarinVerificationToken = clarinVerificationTokenService.findByNetID(context, netId);
+        assertTrue(Objects.nonNull(clarinVerificationToken));
+
+        // Try to authenticate the user again, and it should NOT to be automatically registered and signed in,
+        // because the verification token is not passed in the request header.
+        getClient().perform(get("/api/authn/shibboleth")
+                        .header("Shib-Identity-Provider", idp)
+                        .header("SHIB-NETID", netId))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" +
+                        Util.formatNetId(netId, idp)));
+    }
+
     private EPerson checkUserWasCreated(String netIdValue, String idpValue, String email, String name)
             throws SQLException {
         // Check if was created a user with such email and netid.

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -658,6 +658,18 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         Util.formatNetId(netId, idp)));
     }
 
+    @Test
+    public void shouldSendShibbolethAuthError() throws Exception {
+        String idp = "Test Idp";
+
+        // Try to authenticate but the Shibboleth doesn't send the email or netid in the header,
+        // so the user won't be registered but the user will be redirected to the login page with the error message.
+        getClient().perform(get("/api/authn/shibboleth")
+                        .header("Shib-Identity-Provider", idp))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://localhost:4000/login?error=shibboleth-authentication-failed"));
+    }
+
     private EPerson checkUserWasCreated(String netIdValue, String idpValue, String email, String name)
             throws SQLException {
         // Check if was created a user with such email and netid.


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
