### PR TITLE
UFAL/Enhanced type bind error

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -170,6 +170,11 @@ public class DCInput {
     private String autocompleteCustom = null;
 
     /**
+     * the custom field for the type bind
+     */
+    private String typeBindField = null;
+
+    /**
      * the dropdown input type could have defined a default value
      */
     private String defaultValue = "";
@@ -259,7 +264,7 @@ public class DCInput {
         typeBind = new ArrayList<String>();
         String typeBindDef = fieldMap.get("type-bind");
         this.insertToTypeBind(typeBindDef);
-        String typeBindField = fieldMap.get(DCInputsReader.TYPE_BIND_FIELD_ATTRIBUTE);
+        typeBindField = fieldMap.get(DCInputsReader.TYPE_BIND_FIELD_ATTRIBUTE);
         this.insertToTypeBind(typeBindField);
 
 
@@ -739,6 +744,14 @@ public class DCInput {
 
     public void setAutocompleteCustom(String autocompleteCustom) {
         this.autocompleteCustom = autocompleteCustom;
+    }
+
+    public String getTypeBindField() {
+        return typeBindField;
+    }
+
+    public void setTypeBindField(String typeBindField) {
+        this.typeBindField = typeBindField;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -501,6 +501,11 @@ public class DCInputsReader {
                             handleInputTypeTagName(formName, field, nestedNode, nestedValue);
                         }
                     }
+                } else if (StringUtils.equals(tagName, "type-bind")) {
+                    String customField = getAttribute(nd, TYPE_BIND_FIELD_ATTRIBUTE);
+                    if (customField != null) {
+                        field.put(TYPE_BIND_FIELD_ATTRIBUTE, customField);
+                    }
                 }
             }
         }
@@ -547,20 +552,23 @@ public class DCInputsReader {
             } else {
                 field.put(PAIR_TYPE_NAME, pairTypeName);
             }
-        } else if (value.equals("complex")) {
-            String definitionName = getAttribute(nd, COMPLEX_DEFINITION_REF);
-            if (definitionName == null) {
-                throw new SAXException("Form " + formName
-                        + ", field " + field.get("dc-element")
-                        + "." + field.get("dc-qualifier")
-                        + " has no linked definition");
-            } else {
-                field.put(COMPLEX_DEFINITION_REF, definitionName);
+        } else  {
+            if (value.equals("complex")) {
+                String definitionName = getAttribute(nd, COMPLEX_DEFINITION_REF);
+                if (definitionName == null) {
+                    throw new SAXException("Form " + formName
+                            + ", field " + field.get("dc-element")
+                            + "." + field.get("dc-qualifier")
+                            + " has no linked definition");
+                } else {
+                    field.put(COMPLEX_DEFINITION_REF, definitionName);
+                }
             }
-        } else if (value.equals("autocomplete")) {
-            String definitionName = getAttribute(nd, AUTOCOMPLETE_CUSTOM);
-            if (definitionName != null) {
-                field.put(AUTOCOMPLETE_CUSTOM, definitionName);
+            if (value.equals("autocomplete")) {
+                String definitionName = getAttribute(nd, AUTOCOMPLETE_CUSTOM);
+                if (definitionName != null) {
+                    field.put(AUTOCOMPLETE_CUSTOM, definitionName);
+                }
             }
         }
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -163,6 +163,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         if (dcinput.isMetadataField()) {
             inputField.setSelectableMetadata(selectableMetadata);
             inputField.setTypeBind(dcinput.getTypeBindList());
+            inputField.setTypeBindField(dcinput.getTypeBindField());
             inputField.setComplexDefinition(dcinput.getComplexDefinitionJSONString());
             inputField.setAutocompleteCustom(dcinput.getAutocompleteCustom());
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
@@ -98,6 +98,12 @@ public class SubmissionFormFieldRest {
      */
     private String autocompleteCustom;
 
+    /**
+     * The custom field to type bind. It is used to check that the custom type bind field is defined when
+     * it is defined in the configuration property `submit.type-bind.field`
+     */
+    private String typeBindField;
+
 
     /**
      * Getter for {@link #selectableMetadata}
@@ -312,5 +318,13 @@ public class SubmissionFormFieldRest {
 
     public void setAutocompleteCustom(String autocompleteCustom) {
         this.autocompleteCustom = autocompleteCustom;
+    }
+
+    public String getTypeBindField() {
+        return typeBindField;
+    }
+
+    public void setTypeBindField(String typeBindField) {
+        this.typeBindField = typeBindField;
     }
 }


### PR DESCRIPTION
FE: https://github.com/dataquest-dev/dspace-angular/pull/745
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The type-binded input fields wasn't working properly. They were still displayed. 