### PR TITLE
Changed matomo url to some valid URL

### DIFF
--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -154,7 +154,7 @@ matomo.auth.token = 26388b4164695d69e6ee6e2dd527b723
 matomo.site.id = 1
 matomo.tracker.bitstream.site_id = 1
 matomo.tracker.oai.site_id = 1
-matomo.tracker.host.url = http://change.me/matomo.php
+matomo.tracker.host.url = http://localhost.changeme/matomo.php
 matomo.custom.dimension.handle.id = 1
 statistics.cache-server.uri = http://cache-server.none
 

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -154,7 +154,7 @@ matomo.auth.token = 26388b4164695d69e6ee6e2dd527b723
 matomo.site.id = 1
 matomo.tracker.bitstream.site_id = 1
 matomo.tracker.oai.site_id = 1
-matomo.tracker.host.url = http://url:port/matomo.php
+matomo.tracker.host.url = http://change.me/matomo.php
 matomo.custom.dimension.handle.id = 1
 statistics.cache-server.uri = http://cache-server.none
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When the URL was invalid, the user could not open the OAI-PMH page due to the invalid Matomo URL, which caused the OAI-PMH to stop working.

Fixed: The URL was updated to a simple, valid URL.