### PR TITLE
check submit group for submitter not for current user

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -120,7 +120,7 @@ public class InstallItemServiceImpl implements InstallItemService {
 
         //Allow submitter to edit item
         if (isCollectionAllowedForSubmitterEditing(item.getOwningCollection()) &&
-                isInSubmitGroup(c.getCurrentUser(), item.getOwningCollection().getID())) {
+                isInSubmitGroup(item.getSubmitter(), item.getOwningCollection().getID())) {
             createResourcePolicy(c, item, Constants.WRITE);
         }
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
We checked if the current user is in the submit group, not if there is a person who created the item.