### PR TITLE
UFAL/bitstream preview wrong file name according to it's mimetype

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
@@ -21,6 +21,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
@@ -196,6 +197,11 @@ public class PreviewContentServiceImpl implements PreviewContentService {
         List<FileInfo> fileInfos = new ArrayList<>();
         String bitstreamMimeType = bitstream.getFormat(context).getMIMEType();
         if (bitstreamMimeType.equals("text/plain")) {
+            if (!validateBitstreamNameWithType(bitstream, "zip,tar,gz,tar.gz,tar.bz2")) {
+                throw new IOException("he file has an incorrect type according to the MIME type stored in the database." +
+                        " This could cause the ZIP file to be previewed as a text file, potentially leading" +
+                        " to a database error.");
+            }
             String data = getFileContent(inputStream, true);
             fileInfos.add(new FileInfo(data, false));
         } else if (bitstreamMimeType.equals("text/html")) {
@@ -252,6 +258,22 @@ public class PreviewContentServiceImpl implements PreviewContentService {
 
         url += "&isAllowed=" + isAllowed;
         return url;
+    }
+
+    /**
+     * Validate the bitstream name with the specified type. Check if the ZIP file is not previewed as a text file.
+     * @param bitstream
+     * @param forbiddenTypes "in the form of 'type1,type2,type3'"
+     * @return
+     */
+    private boolean validateBitstreamNameWithType(Bitstream bitstream, String forbiddenTypes) {
+        ArrayList<String> forbiddenTypesList = new ArrayList(Arrays.asList(forbiddenTypes.split(",")));
+        for (String forbiddenType : forbiddenTypesList) {
+            if (bitstream.getName().endsWith(forbiddenType)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
@@ -198,8 +198,8 @@ public class PreviewContentServiceImpl implements PreviewContentService {
         String bitstreamMimeType = bitstream.getFormat(context).getMIMEType();
         if (bitstreamMimeType.equals("text/plain")) {
             if (!validateBitstreamNameWithType(bitstream, "zip,tar,gz,tar.gz,tar.bz2")) {
-                throw new IOException("he file has an incorrect type according to the MIME type stored in the database." +
-                        " This could cause the ZIP file to be previewed as a text file, potentially leading" +
+                throw new IOException("he file has an incorrect type according to the MIME type stored in the " +
+                        "database. This could cause the ZIP file to be previewed as a text file, potentially leading" +
                         " to a database error.");
             }
             String data = getFileContent(inputStream, true);

--- a/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreview.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreview.java
@@ -123,7 +123,7 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
             return;
         }
 
-        List<Bundle> bundles = item.getBundles();
+        List<Bundle> bundles = item.getBundles("ORIGINAL");
         for (Bundle bundle : bundles) {
             List<Bitstream> bitstreams = bundle.getBitstreams();
             for (Bitstream bitstream : bitstreams) {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
