### PR TITLE
UFAL/Fix different handle per community

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -88,12 +88,6 @@ public class InstallItemServiceImpl implements InstallItemService {
         Item item = is.getItem();
         Collection collection = is.getCollection();
 
-        // CLARIN
-        // The owning collection is needed for getting owning community and creating configured handle.
-        c.addEvent(new Event(Event.MODIFY, Constants.ITEM, item.getID(),
-                SET_OWNING_COLLECTION_EVENT_DETAIL + collection.getID()));
-        // CLARIN
-
         // Get map of filters to use for identifier types.
         Map<Class<? extends Identifier>, Filter> filters = FilterUtils.getIdentifierFilters(false);
         try {

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.content;
 
+import static org.dspace.content.InstallItemServiceImpl.SET_OWNING_COLLECTION_EVENT_DETAIL;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -117,6 +119,12 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
             item = itemService.create(context, workspaceItem);
         }
         item.setSubmitter(context.getCurrentUser());
+
+        // CLARIN
+        // The owning collection is needed for getting owning community and creating configured handle.
+        context.addEvent(new Event(Event.MODIFY, Constants.ITEM, item.getID(),
+                SET_OWNING_COLLECTION_EVENT_DETAIL + collection.getID()));
+        // CLARIN
 
         // Now create the policies for the submitter to modify item and contents
         // contents = bitstreams, bundles

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -518,7 +519,7 @@ public class HandleServiceImpl implements HandleService {
     private Event getClarinSetOwningCollectionEvent(Context context) {
         int index = -1;
         LinkedList<Event> allEvents = context.getEvents();
-        for (Event event: allEvents) {
+        for (Event event: ListUtils.emptyIfNull(allEvents)) {
             index++;
             if (StringUtils.isBlank(event.getDetail())) {
                 continue;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkspaceItemRestRepositoryIT.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest;
 
 import static org.dspace.app.rest.repository.ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE;
+import static org.dspace.content.InstallItemServiceImpl.SET_OWNING_COLLECTION_EVENT_DETAIL;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -49,6 +50,8 @@ import org.dspace.content.service.InstallItemService;
 import org.dspace.content.service.clarin.ClarinLicenseLabelService;
 import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
 import org.dspace.content.service.clarin.ClarinLicenseService;
+import org.dspace.core.Constants;
+import org.dspace.event.Event;
 import org.dspace.handle.PIDConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.junit.Assert;
@@ -865,6 +868,10 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
                 .withTitle("Item with custom handle")
                 .withIssueDate("2017-10-17")
                 .build();
+
+        // Add event here, because the `build()` remove all events.
+        context.addEvent(new Event(Event.MODIFY, Constants.ITEM, wItem.getItem().getID(),
+                SET_OWNING_COLLECTION_EVENT_DETAIL + col.getID()));
 
         Item installedItem = installItemService.installItem(context, wItem);
         context.restoreAuthSystemState();


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When the Community has defined a specific handle it won't be used because the owning community of the creating Item was null.