### PR TITLE
UFAL/Net it encodig - The `+` characted was wrongly encoded in the URL

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
@@ -8,6 +8,8 @@
 package org.dspace.app.rest.security.clarin;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Objects;
@@ -269,8 +271,9 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
         } else if (this.isEmailIsAssociated) {
             redirectUrl += duplicateUser + "?email=" + this.email;
         } else if (StringUtils.isNotEmpty(this.netId)) {
-            // netId is set if the user doesn't have the email
-            redirectUrl += userWithoutEmailUrl + "?netid=" + this.netId;
+            // Ensure netId is URL-encoded to prevent `+` from turning into a space
+            String encodedNetId = URLEncoder.encode(this.netId, StandardCharsets.UTF_8);
+            redirectUrl += userWithoutEmailUrl + "?netid=" + encodedNetId;
         } else {
             // Remove the last slash from the URL `login/`
             String redirectUrlWithoutSlash = redirectUrl.endsWith("/") ?


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the login redirection process to correctly handle user identifiers with special characters, ensuring a smoother and more reliable login experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->