### PR TITLE
UFAL/header value could have equals char

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/Headers.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/Headers.java
@@ -82,7 +82,7 @@ public class Headers {
         for (String line : shibHeaders.split("\n")) {
             String key = " ";
             try {
-                String key_value[] = line.split("=");
+                String key_value[] = line.split("=", 2);
                 key = key_value[0].trim();
                 headers_.put(key, List.of(key_value[1]));
             } catch (Exception ignore) {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the processing of header values to ensure more reliable handling of delimiter characters, leading to increased stability in authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->