### PR TITLE
Ufal/header value could have equals char

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/Headers.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/Headers.java
@@ -82,7 +82,7 @@ public class Headers {
         for (String line : shibHeaders.split("\n")) {
             String key = " ";
             try {
-                String key_value[] = line.split("=");
+                String key_value[] = line.split("=", 2);
                 key = key_value[0].trim();
                 headers_.put(key, List.of(key_value[1]));
             } catch (Exception ignore) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethLoginFilterIT.java
@@ -20,6 +20,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -144,7 +146,8 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header("Shib-Identity-Provider", IDP_TEST_EPERSON))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" +
-                        Util.formatNetId(netId, IDP_TEST_EPERSON)));
+                        URLEncoder.encode(Objects.requireNonNull(Util.formatNetId(netId, IDP_TEST_EPERSON)),
+                                StandardCharsets.UTF_8)));
     }
 
     /**
@@ -170,7 +173,8 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header("SHIB-NETID", netId))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" +
-                        Util.formatNetId(netId, idp)));
+                        URLEncoder.encode(Objects.requireNonNull(Util.formatNetId(netId, idp)),
+                                StandardCharsets.UTF_8)));
 
         // Send the email with the verification token.
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -618,7 +622,8 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header(NET_ID_PERSISTENT_ID, persistentId))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" +
-                        Util.formatNetId(persistentId, IDP_TEST_EPERSON)));
+                        URLEncoder.encode(Objects.requireNonNull(Util.formatNetId(persistentId, IDP_TEST_EPERSON)),
+                                StandardCharsets.UTF_8)));
     }
 
     // The user was registered and signed in with the verification token on the second attempt, after the email
@@ -636,7 +641,8 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header("SHIB-NETID", netId))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" +
-                        Util.formatNetId(netId, idp)));
+                        URLEncoder.encode(Objects.requireNonNull(Util.formatNetId(netId, idp)),
+                                StandardCharsets.UTF_8)));
 
         // Send the email with the verification token.
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -655,7 +661,8 @@ public class ClarinShibbolethLoginFilterIT extends AbstractControllerIntegration
                         .header("SHIB-NETID", netId))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("http://localhost:4000/login/auth-failed?netid=" +
-                        Util.formatNetId(netId, idp)));
+                        URLEncoder.encode(Objects.requireNonNull(Util.formatNetId(netId, idp)),
+                                StandardCharsets.UTF_8)));
     }
 
     @Test


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the extraction of parameter values to prevent errors from unexpected input formats.
- **Tests**
	- Updated test cases to ensure login parameters are correctly encoded during authentication redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->