### PR TITLE
Update clarin-dspace.cfg - handle.plugin.checknameauthority

### DIFF
--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -42,6 +42,8 @@ lr.pid.community.configurations = community=09f09b11-cba1-4c43-9e01-29fe919991ab
 lr.pid.community.configurations = community=*, prefix=123456789, type=local, canonical_prefix=http://hdl.handle.net/, subprefix=2
 # if true, PID metadata will be filled with object metadata like title
 lr.pid.resolvemetadata = true
+# needed when responsible for multiple pid prefixes
+handle.plugin.checknameauthority = false
 
 ######
 #


### PR DESCRIPTION
Needed when responsible for multiple pid prefixes. Without this the handle server reports "not found" (http proxy) or something like "this prefix doesn't live here" (udp/tcp java client) when trying to resolve a prefix different from `handle.prefix`.

see https://github.com/ufal/clarin-dspace/blob/f51de745b6baf7ee7c34682338aa6bddbf81e24b/dspace-api/src/main/java/org/dspace/handle/HandlePlugin.java#L446

Was already in v5: https://github.com/ufal/clarin-dspace/blob/d20cbdb420e7c7ac01bfea8e3285b4ffaff1c1ed/dspace/config/dspace.cfg#L2188-L2190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to disable name authority verification for handling multiple identifier prefixes.
- **Chores**
	- Enhanced configuration file formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->