### PR TITLE
ZCU-PUB/The `dc.format.version` is used, but it does not exist in metadata fields definition

### DIFF
--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -653,4 +653,11 @@
       <scope_note></scope_note>
     </dc-type>
 
+    <dc-type>
+      <schema>dc</schema>
+      <element>format</element>
+      <qualifier>version</qualifier>
+      <scope_note></scope_note>
+    </dc-type>
+
 </dspace-dc-types>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
