### PR TITLE
use dspace.url to dspace.server.url

### DIFF
--- a/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
+++ b/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
@@ -96,7 +96,7 @@ public class DSpaceApi {
             return;
         }
 
-        String url = configurationService.getProperty("dspace.url");
+        String url = configurationService.getProperty("dspace.server.url");
         url = url + (url.endsWith("/") ? "" : "/") + "handle/" + pid;
 
         /*

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
@@ -88,7 +88,7 @@ public class HdlResolverRestController {
      * </br>
      * Example:
      *      <ul>
-     *          <li>Request: GET - http://{dspace.url}/hdlresolver/handleIdExample/1</li>
+     *          <li>Request: GET - http://{dspace.server.url}/hdlresolver/handleIdExample/1</li>
      *          <li>Response: 200 - ["http://localhost/handle/hanldeIdExample1"]
      *      </ul>
      *
@@ -118,7 +118,7 @@ public class HdlResolverRestController {
      * </br>
      * Example:
      *      <ul>
-     *          <li>Request: GET - http://{dspace.url}/listprefixes</li>
+     *          <li>Request: GET - http://{dspace.server.url}/listprefixes</li>
      *          <li>Response: 200 - ["123456789","prefix1","prefix2"]
      *      </ul>
      *
@@ -144,7 +144,7 @@ public class HdlResolverRestController {
      * </br>
      * Example:
      *      <ul>
-     *          <li>Request: GET - http://{dspace.url}/listhandles/prefix</li>
+     *          <li>Request: GET - http://{dspace.server.url}/listhandles/prefix</li>
      *          <li>Response: 200 - ["prefix/zero","prefix1/one","prefix2/two"]
      *      </ul>
      *


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
There are some uses of the property 'dspace.url'. Use 'dspace.server.url' instead.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the server URL retrieval to ensure consistent handling of server addresses.
- **Documentation**
  - Updated example URLs in API references to reflect the new server URL information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->