### PR TITLE
Handle table no search result

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HandleRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HandleRestRepository.java
@@ -37,6 +37,7 @@ import org.dspace.handle.service.HandleClarinService;
 import org.dspace.handle.service.HandleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
@@ -111,6 +112,14 @@ public class HandleRestRepository extends  DSpaceRestRepository<HandleRest, Inte
 
             // List of all founded handles
             List<Handle> handles = handleClarinService.findAll(context, sortingColumnDefinition);
+
+            // Adjust the page number if the offset exceeds the total number of items
+            if (pageable.getOffset() > handles.size()) {
+                // Calculate the last valid page number
+                int lastPage = handles.size() / pageable.getPageSize();
+                pageable = PageRequest.of(lastPage, pageable.getPageSize(), pageable.getSort());
+            }
+
             // Convert handles to page of handle rest
             return converter.toRestPage(handles, pageable, utils.obtainProjection());
         } catch (SQLException e) {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  1  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
There are no search results for some handles.
![image](https://github.com/user-attachments/assets/a8c3fecc-65ac-47d1-9686-dc63215220db)

## Problems
There is an issue with the pageable in the findAll endpoint. When we search for all results for the handle, the pageable is set to 20 in some cases. As a result, an exception occurs when trying to paginate the results, because the pageable is larger than the size of the result.

## Solution
Calculate the pageable based on the size of the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved pagination behavior to ensure that navigating beyond the available content no longer results in errors or empty displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->