### PR TITLE
ufal/renamed property dspace.url to dspace.ui.url

### DIFF
--- a/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
+++ b/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
@@ -97,7 +97,7 @@ public class DSpaceApi {
         }
 
         String url = configurationService.getProperty("dspace.ui.url");
-        url = url + (url.endsWith("/") ? "" : "/") + "handle/" + pid;
+        url = generateItemURLWithUUID(url, dso);
 
         /*
          * request modification of the PID to point to the correct URL, which
@@ -112,5 +112,20 @@ public class DSpaceApi {
             throw new IOException("Failed to map PID " + pid + " to " + url
                     + " (" + e.toString() + ")");
         }
+    }
+
+    /**
+     * Generate a URL for the given DSpaceObject. The URL consist of the base URL and the ID of the DSpace object.
+     * E.g. `http://localhost:4000/items/<UUID>`
+     * @param url base URL of the DSpace instance
+     * @param dSpaceObject the DSpace object for which the URL is generated
+     * @return the generated URL
+     */
+    public static String generateItemURLWithUUID(String url, DSpaceObject dSpaceObject) {
+        if (dSpaceObject == null) {
+            log.error("DSpaceObject is null, cannot generate URL");
+            return url;
+        }
+        return url + (url.endsWith("/") ? "" : "/") + "items/" + dSpaceObject.getID();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
+++ b/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
@@ -96,7 +96,7 @@ public class DSpaceApi {
             return;
         }
 
-        String url = configurationService.getProperty("dspace.url");
+        String url = configurationService.getProperty("dspace.ui.url");
         url = url + (url.endsWith("/") ? "" : "/") + "handle/" + pid;
 
         /*

--- a/dspace-api/src/test/java/org/dspace/handle/PIDConfigurationTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/PIDConfigurationTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.dspace.AbstractUnitTest;
+import org.dspace.api.DSpaceApi;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -99,9 +100,9 @@ public class PIDConfigurationTest extends AbstractUnitTest {
         // now check that we have 2 community configurations in the test local.cfg
         assertEquals(2, pidConfiguration.getPIDCommunityConfigurations().size());
     }
-//
+
     @Test
-    public  void testInitCommunityConfigSubprefix() {
+    public void testInitCommunityConfigSubprefix() {
         PIDConfiguration pidConfiguration = PIDConfiguration.getInstance();
         // get the first one and check the subprefix is 1
         PIDCommunityConfiguration pidCommunityConfiguration = pidConfiguration.getPIDCommunityConfiguration(
@@ -110,7 +111,7 @@ public class PIDConfigurationTest extends AbstractUnitTest {
     }
 
     @Test
-    public  void testInitCommunityConfigMapShouldNotBeShared() throws NoSuchFieldException, IllegalAccessException {
+    public void testInitCommunityConfigMapShouldNotBeShared() throws NoSuchFieldException, IllegalAccessException {
         PIDConfiguration pidConfiguration = PIDConfiguration.getInstance();
         PIDCommunityConfiguration pidCommunityConfiguration1 =
                 pidConfiguration.getPIDCommunityConfiguration(
@@ -124,5 +125,27 @@ public class PIDConfigurationTest extends AbstractUnitTest {
         Map<String, String> configMap = (Map<String, String>) field.get(pidCommunityConfiguration1);
         configMap.put("type", "epic");
         assertEquals("Com2 should still have local type", "local", pidCommunityConfiguration2.getType());
+    }
+
+    @Test
+    public void testGeneratingItemURL() {
+        String repositoryUrl = "http://localhost:4000/";
+        String expectedUrl = repositoryUrl + "items/" + publicItem.getID();
+
+        String url = DSpaceApi.generateItemURLWithUUID(repositoryUrl, publicItem);
+        assertEquals(expectedUrl, url);
+
+        // Test with no trailing slash
+        repositoryUrl = "http://localhost:4000";
+
+        url = DSpaceApi.generateItemURLWithUUID(repositoryUrl, publicItem);
+        assertEquals(expectedUrl, url);
+
+        // Test with namespace
+        repositoryUrl = "http://localhost:4000/namespace";
+        expectedUrl = repositoryUrl + "/items/" + publicItem.getID();
+
+        url = DSpaceApi.generateItemURLWithUUID(repositoryUrl, publicItem);
+        assertEquals(expectedUrl, url);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
@@ -88,7 +88,7 @@ public class HdlResolverRestController {
      * </br>
      * Example:
      *      <ul>
-     *          <li>Request: GET - http://{dspace.url}/hdlresolver/handleIdExample/1</li>
+     *          <li>Request: GET - http://{dspace.ui.url}/hdlresolver/handleIdExample/1</li>
      *          <li>Response: 200 - ["http://localhost/handle/hanldeIdExample1"]
      *      </ul>
      *
@@ -118,7 +118,7 @@ public class HdlResolverRestController {
      * </br>
      * Example:
      *      <ul>
-     *          <li>Request: GET - http://{dspace.url}/listprefixes</li>
+     *          <li>Request: GET - http://{dspace.ui.url}/listprefixes</li>
      *          <li>Response: 200 - ["123456789","prefix1","prefix2"]
      *      </ul>
      *
@@ -144,7 +144,7 @@ public class HdlResolverRestController {
      * </br>
      * Example:
      *      <ul>
-     *          <li>Request: GET - http://{dspace.url}/listhandles/prefix</li>
+     *          <li>Request: GET - http://{dspace.ui.url}/listhandles/prefix</li>
      *          <li>Response: 200 - ["prefix/zero","prefix1/one","prefix2/two"]
      *      </ul>
      *


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
There are some uses of the property 'dspace.url'. Use 'dspace.ui.url' instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the configuration to use the UI-specific URL for constructing final handle links.

- **Documentation**
  - Revised API documentation examples to reflect the new UI URL for clarity.

- **Tests**
  - Added a new test to validate the functionality of generating item URLs.
  - Standardized method signatures in existing tests for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->