### PR TITLE
added local.relation.IS to local-types.xml

### DIFF
--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -99,6 +99,13 @@
 
   <dc-type>
     <schema>local</schema>
+    <element>relation</element>
+    <qualifier>IS</qualifier>
+    <scope_note>Link back to Information system</scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>local</schema>
     <element>size</element>
     <qualifier>info</qualifier>
   </dc-type>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Missing local.relation.IS metadata field
https://github.com/dataquest-dev/dspace-customers/issues/214
