### PR TITLE
UFAL/File preview - Added the method for extracting the file into try catch block

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
@@ -209,16 +209,15 @@ public class PreviewContentServiceImpl implements PreviewContentService {
             fileInfos.add(new FileInfo(data, false));
         } else {
             String data = "";
-            if (bitstream.getFormat(context).getMIMEType().equals("application/zip")) {
-                data = extractFile(inputStream, ARCHIVE_TYPE_ZIP);
+            Map<String, String> archiveTypes = Map.of(
+                    "application/zip", ARCHIVE_TYPE_ZIP,
+                    "application/x-tar", ARCHIVE_TYPE_TAR
+            );
+
+            String mimeType = bitstream.getFormat(context).getMIMEType();
+            if (archiveTypes.containsKey(mimeType)) {
                 try {
-                    fileInfos = FileTreeViewGenerator.parse(data);
-                } catch (Exception e) {
-                    log.error("Cannot extract file content because: {}", e.getMessage());
-                }
-            } else if (bitstream.getFormat(context).getMIMEType().equals("application/x-tar")) {
-                data = extractFile(inputStream, ARCHIVE_TYPE_TAR);
-                try {
+                    data = extractFile(inputStream, archiveTypes.get(mimeType));
                     fileInfos = FileTreeViewGenerator.parse(data);
                 } catch (Exception e) {
                     log.error("Cannot extract file content because: {}", e.getMessage());


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When the `file-preview` job is run it stopped on the `java.io.UncheckedIOException: java.util.zip.ZipException: loc: wrong sig ->b92a11f8` exception.
Added it into try try catch block to continue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the logic for handling compressed file formats to improve maintainability without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->