### PR TITLE
Fix parts identifiers resolution

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/HandleClarinServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleClarinServiceImpl.java
@@ -255,6 +255,7 @@ public class HandleClarinServiceImpl implements HandleClarinService {
         }
 
         // <UFAL>
+        String partIdentifier = extractPartIdentifier(handleStr);
         handleStr = stripPartIdentifier(handleStr);
 
         // Find handle
@@ -275,7 +276,6 @@ public class HandleClarinServiceImpl implements HandleClarinService {
             // External handle
             url = handle.getUrl();
         }
-        String partIdentifier = extractPartIdentifier(handleStr);
         url = appendPartIdentifierToUrl(url, partIdentifier);
 
         log.debug("Resolved {} to {}", handle, url);

--- a/dspace-api/src/test/java/org/dspace/handle/HandleClarinServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/handle/HandleClarinServiceImplIT.java
@@ -139,4 +139,14 @@ public class HandleClarinServiceImplIT extends AbstractIntegrationTestWithDataba
         boolean isDead = handleClarinService.isDead(context, itemHandle.getHandle());
         Assert.assertTrue(isDead);
     }
+
+    @Test
+    public void resolveToUrlWithPartsIdentifier() throws SQLException {
+        String url = handleClarinService.resolveToURL(context, itemHandle.getHandle() + "@format=cmdi");
+        //Part identifier on handle should be added to URL
+        //eg. `@format=cmdi` should be added as `?format=cmdi` in the URL
+        Assert.assertTrue("URL of handle with parts identifier should contain query string. But was " + url,
+                url.contains("?format=cmdi"));
+
+    }
 }


### PR DESCRIPTION
`handleStr` was reassigned from stripPartIdentifier, so when it got to `extractPartIdentifier(handleStr)` there was nothing left to extract.

Just moving the extract before strip fixes it.

Includes a test.

https://github.com/ufal/clarin-dspace/issues/1176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved URL generation for handles with embedded identifiers, ensuring the correct identifier is retained and appended to the resulting URL.
  
- **Tests**
  - Added a new test case to verify that handles with additional identifiers produce URLs with the expected query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->