### PR TITLE
UFAL/File preview - Return empty list if an error has occured

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -125,7 +125,7 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                         }
                     } catch (Exception e) {
                         log.error("Cannot create preview content for bitstream: {} because: {}",
-                                bitstream.getID(), e.getMessage());
+                                bitstream.getID(), e.getMessage(), e);
                     }
                 }
                 MetadataBitstreamWrapper bts = new MetadataBitstreamWrapper(bitstream, fileInfos,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -102,25 +102,30 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
 
             for (Bitstream bitstream : bitstreams) {
                 String url = previewContentService.composePreviewURL(context, item, bitstream, contextPath);
-                List<FileInfo> fileInfos = null;
+                List<FileInfo> fileInfos = new ArrayList<>();
                 boolean canPreview = previewContentService.canPreview(context, bitstream);
                 if (canPreview) {
-                    List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
-                    // Generate new content if we didn't find any
-                    if (prContents.isEmpty()) {
-                        fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
-                        // Do not store HTML content in the database because it could be longer than the limit
-                        // of the database column
-                        if (!StringUtils.equals("text/html", bitstream.getFormat(context).getMIMEType())) {
-                            for (FileInfo fi : fileInfos) {
-                                previewContentService.createPreviewContent(context, bitstream, fi);
+                    try {
+                        List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
+                        // Generate new content if we didn't find any
+                        if (prContents.isEmpty()) {
+                            fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
+                            // Do not store HTML content in the database because it could be longer than the limit
+                            // of the database column
+                            if (!StringUtils.equals("text/html", bitstream.getFormat(context).getMIMEType())) {
+                                for (FileInfo fi : fileInfos) {
+                                    previewContentService.createPreviewContent(context, bitstream, fi);
+                                }
+                            }
+                        } else {
+                            fileInfos = new ArrayList<>();
+                            for (PreviewContent pc : prContents) {
+                                fileInfos.add(previewContentService.createFileInfo(pc));
                             }
                         }
-                    } else {
-                        fileInfos = new ArrayList<>();
-                        for (PreviewContent pc : prContents) {
-                            fileInfos.add(previewContentService.createFileInfo(pc));
-                        }
+                    } catch (Exception e) {
+                        log.error("Cannot create preview content for bitstream: {} because: {}",
+                                bitstream.getID(), e.getMessage());
                     }
                 }
                 MetadataBitstreamWrapper bts = new MetadataBitstreamWrapper(bitstream, fileInfos,


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced file preview generation and error handling to mitigate issues during preview creation. Users will benefit from uninterrupted access to accurate file previews even when challenges occur behind the scenes.

- **Refactor**
  - Optimized the background process for preview content by eliminating redundant steps, resulting in more efficient operations. These refinements contribute to a smoother, more predictable overall experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->