### PR TITLE
UFAL/Matomo statistics - Use the bitstream name instead of the UUID in the tracking download url

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.statistics.clarin;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.util.LinkedHashMap;
@@ -98,7 +100,7 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
                 }
 
                 bitstreamUrl = configurationService.getProperty("dspace.ui.url") + "/bitstream/handle/" +
-                        item.getHandle() + "/" + bitstream.getName();
+                        item.getHandle() + "/" + URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
             } catch (IllegalArgumentException | BadRequestException | NotFoundException | SQLException e) {
                 log.error("Cannot get the Bitstream UUID from the URL {}: {}", matomoRequest.getActionUrl(),
                         e.getMessage(), e);

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -106,7 +106,7 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
                         e.getMessage(), e);
             }
 
-            // The bitstream URL is in the format `<DSPACE_UI_URL>/bitstream/handle/<ITEM_HANDLE>/<BITSTREAM_UUID>`
+            // The bitstream URL is in the format `<DSPACE_UI_URL>/bitstream/handle/<ITEM_HANDLE>/<BITSTREAM_NAME>`
             // if there is an error with the fetching the UUID, the original download URL is used
             matomoRequest.setDownloadUrl(bitstreamUrl);
             matomoRequest.setActionUrl(itemIdentifier);

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -12,7 +12,10 @@ import java.text.MessageFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -21,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
+import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
@@ -51,6 +55,9 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
     @Autowired
     ClarinItemService clarinItemService;
 
+    @Autowired
+    BitstreamService bitstreamService;
+
     /**
      * Site ID for the Bitstream downloading statistics
      */
@@ -79,10 +86,20 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
             // Set PageURL to handle identifier
             String bitstreamUrl = getFullURL(request);
             try {
+                // Get the Bitstream UUID from the URL
                 String bitstreamId = Utils.fetchUUIDFromUrl(matomoRequest.getActionUrl());
+                if (StringUtils.isBlank(bitstreamId)) {
+                    throw new BadRequestException("The Bitstream UUID is blank.");
+                }
+                // Get the bitstream using its UUID
+                Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
+                if (Objects.isNull(bitstream)) {
+                    throw new NotFoundException("The Bitstream with the UUID " + bitstreamId + " was not found.");
+                }
+
                 bitstreamUrl = configurationService.getProperty("dspace.ui.url") + "/bitstream/handle/" +
-                        item.getHandle() + "/" + bitstreamId;
-            } catch (IllegalArgumentException e) {
+                        item.getHandle() + "/" + bitstream.getName();
+            } catch (IllegalArgumentException | BadRequestException | NotFoundException | SQLException e) {
                 log.error("Cannot get the Bitstream UUID from the URL {}: {}", matomoRequest.getActionUrl(),
                         e.getMessage(), e);
             }

--- a/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
@@ -27,6 +27,7 @@ import org.dspace.app.statistics.clarin.ClarinMatomoBitstreamTracker;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
+import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
@@ -66,6 +67,9 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
     private ItemService itemService;
 
     @Mock
+    private BitstreamService bitstreamService;
+
+    @Mock
     private Bitstream bitstream;
 
     @InjectMocks
@@ -83,12 +87,13 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
         UUID bitstreamId = UUID.randomUUID();
         mockRequest("/bitstreams/" + bitstreamId + "/download");
         mockBitstreamAndItem(bitstreamId);
+        when(bitstreamService.find(context, bitstreamId)).thenReturn(bitstream);
         when(matomoTracker.sendRequestAsync(any(MatomoRequest.class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
         clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, false);
 
-        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstreamId;
+        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstream.getName();
         verifyMatomoRequest(expectedUrl, "Bitstream Download / Single File");
     }
 
@@ -111,12 +116,13 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
         UUID bitstreamId = UUID.randomUUID();
         mockRequest("/bitstreams/" + bitstreamId + "/download");
         mockBitstreamAndItem(bitstreamId);
+        when(bitstreamService.find(context, bitstreamId)).thenReturn(bitstream);
         when(matomoTracker.sendRequestAsync(any(MatomoRequest.class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
         clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, true);
 
-        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstreamId;
+        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstream.getName();
         verifyMatomoRequest(expectedUrl, "Bitstream Download / Zip Archive");
     }
 

--- a/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -80,6 +82,7 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
     @Before
     public void setUp() {
         context = new Context();
+        when(bitstream.getName()).thenReturn("Test bitstream");
     }
 
     @Test
@@ -93,7 +96,8 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
 
         clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, false);
 
-        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstream.getName();
+        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" +
+                URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
         verifyMatomoRequest(expectedUrl, "Bitstream Download / Single File");
     }
 
@@ -122,7 +126,8 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
 
         clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, true);
 
-        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstream.getName();
+        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" +
+                URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
         verifyMatomoRequest(expectedUrl, "Bitstream Download / Zip Archive");
     }
 
@@ -152,6 +157,21 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
 
         // Verify that no tracking request was sent
         verify(matomoTracker, times(0)).sendRequestAsync(any(MatomoRequest.class));
+    }
+
+    @Test
+    public void testTrackBitstreamDownloadWithNullBitstream() throws SQLException {
+        UUID bitstreamId = UUID.randomUUID();
+        mockRequest("/bitstreams/" + bitstreamId + "/download");
+        mockBitstreamAndItem(bitstreamId);
+        when(bitstreamService.find(context, bitstreamId)).thenReturn(null);
+        when(matomoTracker.sendRequestAsync(any(MatomoRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, false);
+
+        String expectedUrl = BASE_URL + "/bitstreams/" + bitstreamId + "/download";
+        verifyMatomoRequest(expectedUrl, "Bitstream Download / Single File");
     }
 
     private void mockRequest(String requestURI) {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced download tracking now handles invalid or missing resource identifiers gracefully, delivering more informative error messages.
	- Download URLs have been updated to display file names for greater clarity.
- **Tests**
	- Updated validations ensure the improved download tracking behaves as expected.
	- Added a new test to handle scenarios with null Bitstream objects, ensuring correct URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->