### PR TITLE
UFAL/Matomo bitstream tracker has error when bitstream name was null

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -7,17 +7,12 @@
  */
 package org.dspace.app.statistics.clarin;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -26,7 +21,6 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
-import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
@@ -57,9 +51,6 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
     @Autowired
     ClarinItemService clarinItemService;
 
-    @Autowired
-    BitstreamService bitstreamService;
-
     /**
      * Site ID for the Bitstream downloading statistics
      */
@@ -88,25 +79,15 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
             // Set PageURL to handle identifier
             String bitstreamUrl = getFullURL(request);
             try {
-                // Get the Bitstream UUID from the URL
                 String bitstreamId = Utils.fetchUUIDFromUrl(matomoRequest.getActionUrl());
-                if (StringUtils.isBlank(bitstreamId)) {
-                    throw new BadRequestException("The Bitstream UUID is blank.");
-                }
-                // Get the bitstream using its UUID
-                Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
-                if (Objects.isNull(bitstream)) {
-                    throw new NotFoundException("The Bitstream with the UUID " + bitstreamId + " was not found.");
-                }
-
                 bitstreamUrl = configurationService.getProperty("dspace.ui.url") + "/bitstream/handle/" +
-                        item.getHandle() + "/" + URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException | BadRequestException | NotFoundException | SQLException e) {
+                        item.getHandle() + "/" + bitstreamId;
+            } catch (IllegalArgumentException e) {
                 log.error("Cannot get the Bitstream UUID from the URL {}: {}", matomoRequest.getActionUrl(),
                         e.getMessage(), e);
             }
 
-            // The bitstream URL is in the format `<DSPACE_UI_URL>/bitstream/handle/<ITEM_HANDLE>/<BITSTREAM_NAME>`
+            // The bitstream URL is in the format `<DSPACE_UI_URL>/bitstream/handle/<ITEM_HANDLE>/<BITSTREAM_UUID>`
             // if there is an error with the fetching the UUID, the original download URL is used
             matomoRequest.setDownloadUrl(bitstreamUrl);
             matomoRequest.setActionUrl(itemIdentifier);

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -14,6 +14,7 @@ import java.text.MessageFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 
@@ -91,15 +92,15 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
                 if (StringUtils.isBlank(bitstreamId)) {
                     throw new BadRequestException("The Bitstream UUID is blank.");
                 }
-//                // Get the bitstream using its UUID
-//                Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
-//                if (Objects.isNull(bitstream)) {
-//                    throw new NotFoundException("The Bitstream with the UUID " + bitstreamId + " was not found.");
-//                }
+                // Get the bitstream using its UUID
+                Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
+                if (Objects.isNull(bitstream)) {
+                    throw new BadRequestException("The Bitstream with the UUID " + bitstreamId + " was not found.");
+                }
 
                 bitstreamUrl = configurationService.getProperty("dspace.ui.url") + "/bitstream/handle/" +
                         item.getHandle() + "/" + URLEncoder.encode("bitstream.getName()", StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException | BadRequestException e) {
+            } catch (IllegalArgumentException | BadRequestException | SQLException e) {
                 log.error("Cannot get the Bitstream UUID from the URL {}: {}", matomoRequest.getActionUrl(),
                         e.getMessage(), e);
             }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -27,6 +28,7 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
+import org.dspace.core.Utils;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -84,11 +86,11 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
             // Set PageURL to handle identifier
             String bitstreamUrl = getFullURL(request);
             try {
-//                // Get the Bitstream UUID from the URL
-//                String bitstreamId = Utils.fetchUUIDFromUrl(matomoRequest.getActionUrl());
-//                if (StringUtils.isBlank(bitstreamId)) {
-//                    throw new BadRequestException("The Bitstream UUID is blank.");
-//                }
+                // Get the Bitstream UUID from the URL
+                String bitstreamId = Utils.fetchUUIDFromUrl(matomoRequest.getActionUrl());
+                if (StringUtils.isBlank(bitstreamId)) {
+                    throw new BadRequestException("The Bitstream UUID is blank.");
+                }
 //                // Get the bitstream using its UUID
 //                Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
 //                if (Objects.isNull(bitstream)) {
@@ -97,7 +99,7 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
 
                 bitstreamUrl = configurationService.getProperty("dspace.ui.url") + "/bitstream/handle/" +
                         item.getHandle() + "/" + URLEncoder.encode("bitstream.getName()", StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | BadRequestException e) {
                 log.error("Cannot get the Bitstream UUID from the URL {}: {}", matomoRequest.getActionUrl(),
                         e.getMessage(), e);
             }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import javax.naming.NameNotFoundException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 
@@ -95,12 +96,17 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
                 // Get the bitstream using its UUID
                 Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
                 if (Objects.isNull(bitstream)) {
-                    throw new BadRequestException("The Bitstream with the UUID " + bitstreamId + " was not found.");
+                    throw new BadRequestException("The Bitstream: UUID = " + bitstreamId + " was not found.");
+                }
+
+                if (StringUtils.isBlank(bitstream.getName())) {
+                    throw new NameNotFoundException("The Bitstream: UUID = " + bitstreamId +
+                            " bitstream.getName() is null.");
                 }
 
                 bitstreamUrl = configurationService.getProperty("dspace.ui.url") + "/bitstream/handle/" +
-                        item.getHandle() + "/" + URLEncoder.encode("bitstream.getName()", StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException | BadRequestException | SQLException e) {
+                        item.getHandle() + "/" + URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException | BadRequestException | SQLException | NameNotFoundException e) {
                 log.error("Cannot get the Bitstream UUID from the URL {}: {}", matomoRequest.getActionUrl(),
                         e.getMessage(), e);
             }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -14,10 +14,7 @@ import java.text.MessageFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -30,7 +27,6 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
-import org.dspace.core.Utils;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -88,20 +84,20 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
             // Set PageURL to handle identifier
             String bitstreamUrl = getFullURL(request);
             try {
-                // Get the Bitstream UUID from the URL
-                String bitstreamId = Utils.fetchUUIDFromUrl(matomoRequest.getActionUrl());
-                if (StringUtils.isBlank(bitstreamId)) {
-                    throw new BadRequestException("The Bitstream UUID is blank.");
-                }
-                // Get the bitstream using its UUID
-                Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
-                if (Objects.isNull(bitstream)) {
-                    throw new NotFoundException("The Bitstream with the UUID " + bitstreamId + " was not found.");
-                }
+//                // Get the Bitstream UUID from the URL
+//                String bitstreamId = Utils.fetchUUIDFromUrl(matomoRequest.getActionUrl());
+//                if (StringUtils.isBlank(bitstreamId)) {
+//                    throw new BadRequestException("The Bitstream UUID is blank.");
+//                }
+//                // Get the bitstream using its UUID
+//                Bitstream bitstream = bitstreamService.find(context, UUID.fromString(bitstreamId));
+//                if (Objects.isNull(bitstream)) {
+//                    throw new NotFoundException("The Bitstream with the UUID " + bitstreamId + " was not found.");
+//                }
 
                 bitstreamUrl = configurationService.getProperty("dspace.ui.url") + "/bitstream/handle/" +
-                        item.getHandle() + "/" + URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException | BadRequestException | NotFoundException | SQLException e) {
+                        item.getHandle() + "/" + URLEncoder.encode("bitstream.getName()", StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException e) {
                 log.error("Cannot get the Bitstream UUID from the URL {}: {}", matomoRequest.getActionUrl(),
                         e.getMessage(), e);
             }

--- a/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
@@ -15,8 +15,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +27,6 @@ import org.dspace.app.statistics.clarin.ClarinMatomoBitstreamTracker;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
-import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
@@ -69,9 +66,6 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
     private ItemService itemService;
 
     @Mock
-    private BitstreamService bitstreamService;
-
-    @Mock
     private Bitstream bitstream;
 
     @InjectMocks
@@ -82,7 +76,6 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
     @Before
     public void setUp() {
         context = new Context();
-        when(bitstream.getName()).thenReturn("Test bitstream");
     }
 
     @Test
@@ -90,14 +83,12 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
         UUID bitstreamId = UUID.randomUUID();
         mockRequest("/bitstreams/" + bitstreamId + "/download");
         mockBitstreamAndItem(bitstreamId);
-        when(bitstreamService.find(context, bitstreamId)).thenReturn(bitstream);
         when(matomoTracker.sendRequestAsync(any(MatomoRequest.class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
         clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, false);
 
-        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" +
-                URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
+        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstreamId;
         verifyMatomoRequest(expectedUrl, "Bitstream Download / Single File");
     }
 
@@ -120,14 +111,12 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
         UUID bitstreamId = UUID.randomUUID();
         mockRequest("/bitstreams/" + bitstreamId + "/download");
         mockBitstreamAndItem(bitstreamId);
-        when(bitstreamService.find(context, bitstreamId)).thenReturn(bitstream);
         when(matomoTracker.sendRequestAsync(any(MatomoRequest.class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
         clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, true);
 
-        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" +
-                URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
+        String expectedUrl = LOCALHOST_URL + "/bitstream/handle/" + HANDLE + "/" + bitstreamId;
         verifyMatomoRequest(expectedUrl, "Bitstream Download / Zip Archive");
     }
 
@@ -157,21 +146,6 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
 
         // Verify that no tracking request was sent
         verify(matomoTracker, times(0)).sendRequestAsync(any(MatomoRequest.class));
-    }
-
-    @Test
-    public void testTrackBitstreamDownloadWithNullBitstream() throws SQLException {
-        UUID bitstreamId = UUID.randomUUID();
-        mockRequest("/bitstreams/" + bitstreamId + "/download");
-        mockBitstreamAndItem(bitstreamId);
-        when(bitstreamService.find(context, bitstreamId)).thenReturn(null);
-        when(matomoTracker.sendRequestAsync(any(MatomoRequest.class)))
-                .thenReturn(CompletableFuture.completedFuture(null));
-
-        clarinMatomoBitstreamTracker.trackBitstreamDownload(context, request, bitstream, false);
-
-        String expectedUrl = BASE_URL + "/bitstreams/" + bitstreamId + "/download";
-        verifyMatomoRequest(expectedUrl, "Bitstream Download / Single File");
     }
 
     private void mockRequest(String requestURI) {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for resource retrieval. Users now receive clearer and more precise notifications when a resource is missing or contains invalid details, enhancing overall feedback clarity during resource access issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->