### PR TITLE
Property to allow composing file previews

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -114,7 +114,7 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                         // Generate new content if we didn't find any
                         if (prContents.isEmpty()) {
                             boolean allowComposePreviewContent = configurationService.getBooleanProperty
-                                    ("allow.compose.file-preview", false);
+                                    ("create.file-preview.on-item-page-load", false);
                             if (allowComposePreviewContent) {
                                 fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
                                 // Do not store HTML content in the database because it could be longer than the limit

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -107,16 +107,15 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
             for (Bitstream bitstream : bitstreams) {
                 String url = previewContentService.composePreviewURL(context, item, bitstream, contextPath);
                 List<FileInfo> fileInfos = new ArrayList<>();
-                boolean allowComposePreviewContent = configurationService.getBooleanProperty
-                        ("allow.compose.file-preview", false);
-                boolean canPreview = false;
-                if (allowComposePreviewContent) {
-                    canPreview = previewContentService.canPreview(context, bitstream);
-                    if (canPreview) {
-                        try {
-                            List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
-                            // Generate new content if we didn't find any
-                            if (prContents.isEmpty()) {
+                boolean canPreview = previewContentService.canPreview(context, bitstream);
+                if (canPreview) {
+                    try {
+                        List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
+                        // Generate new content if we didn't find any
+                        if (prContents.isEmpty()) {
+                            boolean allowComposePreviewContent = configurationService.getBooleanProperty
+                                    ("allow.compose.file-preview", false);
+                            if (allowComposePreviewContent) {
                                 fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
                                 // Do not store HTML content in the database because it could be longer than the limit
                                 // of the database column
@@ -125,16 +124,16 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                                         previewContentService.createPreviewContent(context, bitstream, fi);
                                     }
                                 }
-                            } else {
-                                fileInfos = new ArrayList<>();
-                                for (PreviewContent pc : prContents) {
-                                    fileInfos.add(previewContentService.createFileInfo(pc));
-                                }
                             }
-                        } catch (Exception e) {
-                            log.error("Cannot create preview content for bitstream: {} because: {}",
-                                    bitstream.getID(), e.getMessage(), e);
+                        } else {
+                            fileInfos = new ArrayList<>();
+                            for (PreviewContent pc : prContents) {
+                                fileInfos.add(previewContentService.createFileInfo(pc));
+                            }
                         }
+                    } catch (Exception e) {
+                        log.error("Cannot create preview content for bitstream: {} because: {}",
+                                bitstream.getID(), e.getMessage(), e);
                     }
                 }
                 MetadataBitstreamWrapper bts = new MetadataBitstreamWrapper(bitstream, fileInfos,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -32,6 +32,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.PreviewContentService;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
+import org.dspace.services.ConfigurationService;
 import org.dspace.util.FileInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -57,6 +58,9 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
 
     @Autowired
     PreviewContentService previewContentService;
+
+    @Autowired
+    ConfigurationService configurationService;
 
     @SearchRestMethod(name = "byHandle")
     public Page<MetadataBitstreamWrapperRest> findByHandle(@Parameter(value = "handle", required = true) String handle,
@@ -103,29 +107,34 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
             for (Bitstream bitstream : bitstreams) {
                 String url = previewContentService.composePreviewURL(context, item, bitstream, contextPath);
                 List<FileInfo> fileInfos = new ArrayList<>();
-                boolean canPreview = previewContentService.canPreview(context, bitstream);
-                if (canPreview) {
-                    try {
-                        List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
-                        // Generate new content if we didn't find any
-                        if (prContents.isEmpty()) {
-                            fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
-                            // Do not store HTML content in the database because it could be longer than the limit
-                            // of the database column
-                            if (!StringUtils.equals("text/html", bitstream.getFormat(context).getMIMEType())) {
-                                for (FileInfo fi : fileInfos) {
-                                    previewContentService.createPreviewContent(context, bitstream, fi);
+                boolean allowComposePreviewContent = configurationService.getBooleanProperty
+                        ("allow.compose.file-preview", false);
+                boolean canPreview = false;
+                if (allowComposePreviewContent) {
+                    canPreview = previewContentService.canPreview(context, bitstream);
+                    if (canPreview) {
+                        try {
+                            List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
+                            // Generate new content if we didn't find any
+                            if (prContents.isEmpty()) {
+                                fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
+                                // Do not store HTML content in the database because it could be longer than the limit
+                                // of the database column
+                                if (!StringUtils.equals("text/html", bitstream.getFormat(context).getMIMEType())) {
+                                    for (FileInfo fi : fileInfos) {
+                                        previewContentService.createPreviewContent(context, bitstream, fi);
+                                    }
+                                }
+                            } else {
+                                fileInfos = new ArrayList<>();
+                                for (PreviewContent pc : prContents) {
+                                    fileInfos.add(previewContentService.createFileInfo(pc));
                                 }
                             }
-                        } else {
-                            fileInfos = new ArrayList<>();
-                            for (PreviewContent pc : prContents) {
-                                fileInfos.add(previewContentService.createFileInfo(pc));
-                            }
+                        } catch (Exception e) {
+                            log.error("Cannot create preview content for bitstream: {} because: {}",
+                                    bitstream.getID(), e.getMessage(), e);
                         }
-                    } catch (Exception e) {
-                        log.error("Cannot create preview content for bitstream: {} because: {}",
-                                bitstream.getID(), e.getMessage(), e);
                     }
                 }
                 MetadataBitstreamWrapper bts = new MetadataBitstreamWrapper(bitstream, fileInfos,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -84,7 +84,7 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                 .build();
 
         // Allow composing of file preview in the config
-        configurationService.setProperty("allow.compose.file-preview", true);
+        configurationService.setProperty("create.file-preview.on-item-page-load", true);
 
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -83,6 +83,9 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                 .withMimeType("application/x-gzip")
                 .build();
 
+        // Allow composing of file preview in the config
+        configurationService.setProperty("allow.compose.file-preview", true);
+
         context.restoreAuthSystemState();
 
         if (StringUtils.isBlank(url)) {

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -310,5 +310,5 @@ autocomplete.custom.allowed = solr-author_ac,solr-publisher_ac,solr-dataProvider
 #allow.edit.metadata =
 
 #### FILE-PREVIEW ####
-# Allow composing file-preview content
-allow.compose.file-preview = false
+# Create file preview when item page is loading
+create.file-preview.on-item-page-load = false

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -308,3 +308,7 @@ autocomplete.custom.allowed = solr-author_ac,solr-publisher_ac,solr-dataProvider
 #### name || id
 ### these collections allow submitters to edit metadata of their items
 #allow.edit.metadata =
+
+#### FILE-PREVIEW ####
+# Allow composing file-preview content
+allow.compose.file-preview = false


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
We want to prevent users from triggering file preview generation when opening an item if a specific configuration property is not enabled. Allowing this behavior can lead to issues, especially when items contain large files—generating previews may take too long, and opening the same item multiple times could trigger concurrent preview generation processes before the first one has completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable option to enable or disable file preview generation for bitstreams. By default, this feature is turned off and can be activated through a new setting in the configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->