### PR TITLE
UFAL/For the EPIC use the handle URL, not the `items/UUID`

### DIFF
--- a/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
+++ b/dspace-api/src/main/java/org/dspace/api/DSpaceApi.java
@@ -97,7 +97,7 @@ public class DSpaceApi {
         }
 
         String url = configurationService.getProperty("dspace.ui.url");
-        url = generateItemURLWithUUID(url, dso);
+        url = generateItemURLWithHandle(url, dso);
 
         /*
          * request modification of the PID to point to the correct URL, which
@@ -115,17 +115,18 @@ public class DSpaceApi {
     }
 
     /**
-     * Generate a URL for the given DSpaceObject. The URL consist of the base URL and the ID of the DSpace object.
-     * E.g. `http://localhost:4000/items/<UUID>`
+     * Generate a URL with the handle for the given DSpaceObject.
+     * The URL consist of the base URL and the handle of the DSpace object.
+     * E.g. `http://localhost:4000/handle/<ITEMS_HANDLE>`
      * @param url base URL of the DSpace instance
      * @param dSpaceObject the DSpace object for which the URL is generated
      * @return the generated URL
      */
-    public static String generateItemURLWithUUID(String url, DSpaceObject dSpaceObject) {
+    public static String generateItemURLWithHandle(String url, DSpaceObject dSpaceObject) {
         if (dSpaceObject == null) {
             log.error("DSpaceObject is null, cannot generate URL");
             return url;
         }
-        return url + (url.endsWith("/") ? "" : "/") + "items/" + dSpaceObject.getID();
+        return url + (url.endsWith("/") ? "" : "/") + "handle/" + dSpaceObject.getHandle();
     }
 }

--- a/dspace-api/src/test/java/org/dspace/handle/PIDConfigurationTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/PIDConfigurationTest.java
@@ -130,22 +130,22 @@ public class PIDConfigurationTest extends AbstractUnitTest {
     @Test
     public void testGeneratingItemURL() {
         String repositoryUrl = "http://localhost:4000/";
-        String expectedUrl = repositoryUrl + "items/" + publicItem.getID();
+        String expectedUrl = repositoryUrl + "handle/" + publicItem.getHandle();
 
-        String url = DSpaceApi.generateItemURLWithUUID(repositoryUrl, publicItem);
+        String url = DSpaceApi.generateItemURLWithHandle(repositoryUrl, publicItem);
         assertEquals(expectedUrl, url);
 
         // Test with no trailing slash
         repositoryUrl = "http://localhost:4000";
 
-        url = DSpaceApi.generateItemURLWithUUID(repositoryUrl, publicItem);
+        url = DSpaceApi.generateItemURLWithHandle(repositoryUrl, publicItem);
         assertEquals(expectedUrl, url);
 
         // Test with namespace
         repositoryUrl = "http://localhost:4000/namespace";
-        expectedUrl = repositoryUrl + "/items/" + publicItem.getID();
+        expectedUrl = repositoryUrl + "/handle/" + publicItem.getHandle();
 
-        url = DSpaceApi.generateItemURLWithUUID(repositoryUrl, publicItem);
+        url = DSpaceApi.generateItemURLWithHandle(repositoryUrl, publicItem);
         assertEquals(expectedUrl, url);
     }
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated item URLs to use handle-based paths instead of UUIDs, ensuring URLs now include the item's handle.
- **Tests**
	- Adjusted tests to verify the new handle-based URL format for items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->