### PR TITLE
UFAL/Items file metadata not correctly updated

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -266,7 +266,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
     @Override
     public void delete(Context context, Bitstream bitstream) throws SQLException, AuthorizeException {
 
-        // changed to a check on delete
+        // Changed to a check on delete
         // Check authorisation
         authorizeService.authorizeAction(context, bitstream, Constants.DELETE);
         log.info(LogHelper.getHeader(context, "delete_bitstream",
@@ -278,26 +278,26 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         // Remove bitstream itself
         bitstream.setDeleted(true);
         update(context, bitstream);
-        // Update Item's metadata about bitstreams
-        clarinItemService.updateItemFilesMetadata(context, bitstream);
 
-        //Remove our bitstream from all our bundles
+        // Remove our bitstream from all our bundles
         final List<Bundle> bundles = bitstream.getBundles();
         for (Bundle bundle : bundles) {
             authorizeService.authorizeAction(context, bundle, Constants.REMOVE);
-            //We also need to remove the bitstream id when it's set as bundle's primary bitstream
+            // We also need to remove the bitstream id when it's set as bundle's primary bitstream
             if (bitstream.equals(bundle.getPrimaryBitstream())) {
                 bundle.unsetPrimaryBitstreamID();
             }
             bundle.removeBitstream(bitstream);
         }
-        //Remove all bundles from the bitstream object, clearing the connection in 2 ways
+        // Update Item's metadata about bitstreams
+        clarinItemService.updateItemFilesMetadata(context, bitstream);
+        // Remove all bundles from the bitstream object, clearing the connection in 2 ways
         bundles.clear();
 
         // Remove policies only after the bitstream has been updated (otherwise the current user has not WRITE rights)
         authorizeService.removeAllPolicies(context, bitstream);
 
-        // detach the license from the bitstream
+        // Detach the license from the bitstream
         clarinLicenseResourceMappingService.detachLicenses(context, bitstream);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -242,7 +242,6 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         if (owningItem != null) {
             itemService.updateLastModified(context, owningItem);
             itemService.update(context, owningItem);
-            clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
         }
 
         // In the event that the bitstream to remove is actually
@@ -265,6 +264,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
             bundle.removeBitstream(bitstream);
             bitstream.getBundles().remove(bundle);
         }
+        clarinItemService.updateItemFilesMetadata(context, owningItem, bundle);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -155,6 +155,11 @@ public class ClarinItemServiceImpl implements ClarinItemService {
             return;
         }
 
+        if (Objects.isNull(item)) {
+            log.error("Cannot update the item files metadata because the item is null.");
+            return;
+        }
+
         int totalNumberOfFiles = 0;
         long totalSizeofFiles = 0;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest;
 
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
@@ -2498,6 +2499,15 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
         // Verify that only the three bitstreams were deleted and the fourth one still exists
         Assert.assertTrue(bitstreamNotFound(token, bitstream1, bitstream2, bitstream3));
         Assert.assertTrue(bitstreamExists(token, bitstream4));
+
+        // Verify that the item without bitstreams has updated `local.has.files` metadata
+        getClient(token).perform(get("/api/core/items/" + publicItem1.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.allOf(
+                        hasJsonPath("$.id", is(publicItem1.getID().toString())),
+                        hasJsonPath("$.uuid", is(publicItem1.getID().toString())),
+                        hasJsonPath("$.type", is("item")),
+                        hasJsonPath("$.metadata", MetadataMatcher.matchMetadata("local.has.files", "no", 0)))));
     }
 
     @Test


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
This issue causes that the file preview spinner was still loading where there weren't any file.
The issue: https://github.com/dataquest-dev/dspace-angular/issues/833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of updating item metadata after bitstream deletions or removals, ensuring metadata is always updated at the correct time.
  - Added safeguards to prevent errors when updating metadata if item information is missing.
- **Tests**
  - Enhanced bulk bitstream deletion tests to verify item metadata updates correctly reflect the absence of files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->