### PR TITLE
UFAL/Clarinuserregistration nullpoint exception

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseResourceUserAllowanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseResourceUserAllowanceServiceImpl.java
@@ -164,7 +164,6 @@ public class ClarinLicenseResourceUserAllowanceServiceImpl implements ClarinLice
         }
 
         UUID userRegistrationEpersonUUID = clrua.getUserRegistration().getPersonID();
-
         if (Objects.nonNull(currentUser) && currentUser.getID().equals(userRegistrationEpersonUUID)) {
             return;
         }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseResourceUserAllowanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseResourceUserAllowanceServiceImpl.java
@@ -164,7 +164,8 @@ public class ClarinLicenseResourceUserAllowanceServiceImpl implements ClarinLice
         }
 
         UUID userRegistrationEpersonUUID = clrua.getUserRegistration().getPersonID();
-        if (currentUser.getID().equals(userRegistrationEpersonUUID)) {
+
+        if (Objects.nonNull(currentUser) && currentUser.getID().equals(userRegistrationEpersonUUID)) {
             return;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CLRUAUUserRegistrationLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CLRUAUUserRegistrationLinkRepository.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 
+import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.app.rest.model.ClarinLicenseResourceUserAllowanceRest;
 import org.dspace.app.rest.model.ClarinUserRegistrationRest;
 import org.dspace.app.rest.projection.Projection;
@@ -39,11 +40,16 @@ public class CLRUAUUserRegistrationLinkRepository extends AbstractDSpaceRestRepo
     public ClarinUserRegistrationRest getUserRegistration(@Nullable HttpServletRequest request,
                                                      Integer clruaID,
                                                      @Nullable Pageable optionalPageable,
-                                                     Projection projection) throws SQLException, AuthorizeException {
+                                                     Projection projection)
+            throws SQLException, RESTAuthorizationException {
         Context context = obtainContext();
 
-        ClarinLicenseResourceUserAllowance clarinLicenseResourceUserAllowance =
-                clarinLicenseResourceUserAllowanceService.find(context, clruaID);
+        ClarinLicenseResourceUserAllowance clarinLicenseResourceUserAllowance;
+        try {
+            clarinLicenseResourceUserAllowance = clarinLicenseResourceUserAllowanceService.find(context, clruaID);
+        } catch (AuthorizeException e) {
+            throw new RESTAuthorizationException(e);
+        }
         if (Objects.isNull(clarinLicenseResourceUserAllowance)) {
             throw new ResourceNotFoundException("The ClarinLicenseResourceUserAllowance for id: " + clruaID +
                     " couldn't be found");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CLRUAUserMetadataLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CLRUAUserMetadataLinkRepository.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.app.rest.model.ClarinLicenseResourceUserAllowanceRest;
 import org.dspace.app.rest.model.ClarinUserMetadataRest;
 import org.dspace.app.rest.projection.Projection;
@@ -42,11 +43,16 @@ public class CLRUAUserMetadataLinkRepository extends AbstractDSpaceRestRepositor
     public Page<ClarinUserMetadataRest> getUserMetadata(@Nullable HttpServletRequest request,
                                                         Integer clruaID,
                                                         @Nullable Pageable optionalPageable,
-                                                        Projection projection) throws SQLException, AuthorizeException {
+                                                        Projection projection)
+            throws SQLException, RESTAuthorizationException {
         Context context = obtainContext();
-
-        ClarinLicenseResourceUserAllowance clarinLicenseResourceUserAllowance =
-                clarinLicenseResourceUserAllowanceService.find(context, clruaID);
+        ClarinLicenseResourceUserAllowance clarinLicenseResourceUserAllowance;
+        try {
+            clarinLicenseResourceUserAllowance =
+                    clarinLicenseResourceUserAllowanceService.find(context, clruaID);
+        } catch (AuthorizeException e) {
+            throw new RESTAuthorizationException(e);
+        }
         if (Objects.isNull(clarinLicenseResourceUserAllowance)) {
             throw new ResourceNotFoundException("The ClarinLicenseResourceUserAllowance for if: " + clruaID +
                     " couldn't be found");


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The endpoints: ..server/api/core/clarinlruallowances/330/userMetadata(userRegistration) throw nullpoint exception.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authorization checks to prevent errors when the current user is not set.
  - Enhanced error handling by converting authorization exceptions into REST-specific exceptions for better API consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->