### PR TITLE
UFAL/Added dead and deadSince to handle rest

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/HandleClarinServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleClarinServiceImpl.java
@@ -112,10 +112,9 @@ public class HandleClarinServiceImpl implements HandleClarinService {
     @Override
     public Handle createExternalHandle(Context context, String handleStr, String url, Boolean dead, Date deadSince)
             throws SQLException, AuthorizeException {
-        // Check authorisation: Only admins may create DC types
         if (!authorizeService.isAdmin(context)) {
             throw new AuthorizeException(
-                    "Only administrators may modify the handle registry");
+                    "Only administrators may modify the external handle.");
         }
         Handle handle = this.createExternalHandle(context, handleStr, url);
         handle.setDead(dead);
@@ -127,10 +126,9 @@ public class HandleClarinServiceImpl implements HandleClarinService {
     @Override
     public Handle createExternalHandle(Context context, String handleStr, String url)
             throws SQLException, AuthorizeException {
-        // Check authorisation: Only admins may create DC types
         if (!authorizeService.isAdmin(context)) {
             throw new AuthorizeException(
-                    "Only administrators may modify the handle registry");
+                    "Only administrators may modify the external handle.");
         }
 
         String handleId;

--- a/dspace-api/src/main/java/org/dspace/handle/HandleClarinServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleClarinServiceImpl.java
@@ -110,6 +110,21 @@ public class HandleClarinServiceImpl implements HandleClarinService {
     }
 
     @Override
+    public Handle createExternalHandle(Context context, String handleStr, String url, Boolean dead, Date deadSince)
+            throws SQLException, AuthorizeException {
+        // Check authorisation: Only admins may create DC types
+        if (!authorizeService.isAdmin(context)) {
+            throw new AuthorizeException(
+                    "Only administrators may modify the handle registry");
+        }
+        Handle handle = this.createExternalHandle(context, handleStr, url);
+        handle.setDead(dead);
+        handle.setDeadSince(deadSince);
+        this.save(context, handle);
+        return handle;
+    }
+
+    @Override
     public Handle createExternalHandle(Context context, String handleStr, String url)
             throws SQLException, AuthorizeException {
         // Check authorisation: Only admins may create DC types

--- a/dspace-api/src/main/java/org/dspace/handle/service/HandleClarinService.java
+++ b/dspace-api/src/main/java/org/dspace/handle/service/HandleClarinService.java
@@ -8,6 +8,7 @@
 package org.dspace.handle.service;
 
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.List;
 
 import org.dspace.authorize.AuthorizeException;
@@ -77,6 +78,21 @@ public interface HandleClarinService {
     public Handle createExternalHandle(Context context, String handleStr, String url)
             throws SQLException, AuthorizeException;
 
+    /**
+     * Creates a new external handle.
+     * External handle has to have entered URL.
+     *
+     * @param context             DSpace context object
+     * @param handleStr           String
+     * @param url                 String
+     * @param dead                Boolean
+     * @param deadSince           Date
+     * @return new Handle
+     * @throws SQLException       if database error
+     * @throws AuthorizeException if authorization error
+     */
+    public Handle createExternalHandle(Context context, String handleStr, String url, Boolean dead, Date deadSince)
+            throws SQLException, AuthorizeException;
     /**
      * Delete the handle.
      *

--- a/dspace-api/src/main/java/org/dspace/handle/service/HandleClarinService.java
+++ b/dspace-api/src/main/java/org/dspace/handle/service/HandleClarinService.java
@@ -79,20 +79,22 @@ public interface HandleClarinService {
             throws SQLException, AuthorizeException;
 
     /**
-     * Creates a new external handle.
-     * External handle has to have entered URL.
+     * Creates a new external Handle with the given handle string, URL, and optional dead status and date.
+     * Only administrators are authorized to create external handles.
+     * The created handle is saved and returned.
      *
-     * @param context             DSpace context object
-     * @param handleStr           String
-     * @param url                 String
-     * @param dead                Boolean
-     * @param deadSince           Date
-     * @return new Handle
-     * @throws SQLException       if database error
-     * @throws AuthorizeException if authorization error
+     * @param context    the DSpace context
+     * @param handleStr  the string representation of the handle
+     * @param url        the URL to associate with the handle
+     * @param dead       whether the handle is marked as dead
+     * @param deadSince  the date since the handle has been dead
+     * @return the newly created Handle
+     * @throws SQLException        if a database error occurs
+     * @throws AuthorizeException  if the current user is not an administrator
      */
     public Handle createExternalHandle(Context context, String handleStr, String url, Boolean dead, Date deadSince)
             throws SQLException, AuthorizeException;
+
     /**
      * Delete the handle.
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/HandleRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/HandleRest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
+import java.util.Date;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -33,6 +34,10 @@ public class HandleRest extends BaseObjectRest<Integer> {
 
     private UUID resourceId;
 
+    private Boolean dead;
+
+    private Date deadSince;
+
     public String getHandle() {
         return handle;
     }
@@ -49,6 +54,14 @@ public class HandleRest extends BaseObjectRest<Integer> {
         return resourceId;
     }
 
+    public Boolean getDead() {
+        return dead;
+    }
+
+    public Date getDeadSince() {
+        return deadSince;
+    }
+
     public void setHandle(String handle) {
         this.handle = handle;
     }
@@ -63,7 +76,14 @@ public class HandleRest extends BaseObjectRest<Integer> {
 
     public void setResourceId(UUID resourceId) {
         this.resourceId = resourceId;
+    }
 
+    public void setDead(Boolean dead) {
+        this.dead = dead;
+    }
+
+    public void setDeadSince(Date deadSince) {
+        this.deadSince = deadSince;
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HandleRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HandleRestRepository.java
@@ -163,7 +163,7 @@ public class HandleRestRepository extends  DSpaceRestRepository<HandleRest, Inte
                 throw new UnprocessableEntityException("Can not create handle. Required fields are empty.");
             }
             handle = handleClarinService.createExternalHandle(context, handleRest.getHandle(),
-                   handleRest.getUrl());
+                   handleRest.getUrl(), handleRest.getDead(), handleRest.getDeadSince());
             // Save created handle
             handleClarinService.save(context, handle);
         } catch (SQLException e) {
@@ -228,7 +228,8 @@ public class HandleRestRepository extends  DSpaceRestRepository<HandleRest, Inte
      */
     @PreAuthorize("hasAuthority('ADMIN')")
     private void updateHandle(Context context, Handle handleObject, String newHandleStr,
-                              DSpaceObject handleDso, String url, boolean archive) throws AuthorizeException {
+                              DSpaceObject handleDso, String url, boolean archive)
+            throws AuthorizeException {
         // End update if handleObject is null
         if ( Objects.isNull(handleObject)) {
             log.warn("Could not find handle record for " + newHandleStr);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HandleRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HandleRestRepository.java
@@ -228,8 +228,7 @@ public class HandleRestRepository extends  DSpaceRestRepository<HandleRest, Inte
      */
     @PreAuthorize("hasAuthority('ADMIN')")
     private void updateHandle(Context context, Handle handleObject, String newHandleStr,
-                              DSpaceObject handleDso, String url, boolean archive)
-            throws AuthorizeException {
+                              DSpaceObject handleDso, String url, boolean archive) throws AuthorizeException {
         // End update if handleObject is null
         if ( Objects.isNull(handleObject)) {
             log.warn("Could not find handle record for " + newHandleStr);


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The handle attributes dead and deadSince were not imported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a "dead" status and the date since a handle is dead when creating or updating handles via the REST API.
  - The REST API now exposes "dead" and "deadSince" fields for handles, allowing users to view and manage these attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->