### PR TITLE
ufal/embargo during submission not recorded in provenance

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
@@ -55,6 +55,17 @@ public interface ProvenanceService {
                                      BulkAccessControlInput accessControl);
 
     /**
+     * Add a provenance message to the item when a bitstream policy is set
+     *
+     * @param context DSpace context object
+     * @param bitstream bitstream to which the policy is set
+     * @param item item to which the bitstream belongs
+     * @param accConditionsStr the access control input as string
+     */
+    void setBitstreamPolicies(Context context, Bitstream bitstream, Item item,
+                              String accConditionsStr);
+
+    /**
      * Add a provenance message to the item when an item's license is edited
      *
      * @param context DSpace context object

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
@@ -58,8 +58,8 @@ public interface ProvenanceService {
      * Add a provenance message to the item when a bitstream policy is set
      *
      * @param context DSpace context object
-     * @param bitstream bitstream to which the policy is set
-     * @param item item to which the bitstream belongs
+     * @param bitstream to which the policy is set
+     * @param item to which the bitstream belongs
      * @param accConditionsStr the access control input as string
      */
     void setBitstreamPolicies(Context context, Bitstream bitstream, Item item,

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -98,13 +98,24 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                                      BulkAccessControlInput accessControl) {
         String accConditionsStr = extractAccessConditions(accessControl.getBitstream().getAccessConditions());
         if (StringUtils.isNotBlank(accConditionsStr)) {
-            String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ACCESS_CONDITION.getTemplate(),
-                    accConditionsStr, "bitstream", bitstream.getID());
-            try {
-                addProvenanceMetadata(context, item, msg);
-            } catch (SQLException | AuthorizeException e) {
-                log.error("Unable to add new provenance metadata when setting bitstream policies.", e);
-            }
+            this.setBitstreamPolicies(context, bitstream, item, accConditionsStr);
+        }
+    }
+
+    @Override
+    public void setBitstreamPolicies(Context context, Bitstream bitstream, Item item, String accConditionsStr) {
+        String msg = messageProvider.getMessage(
+                context,
+                ProvenanceMessageTemplates.ACCESS_CONDITION.getTemplate(),
+                accConditionsStr,
+                "bitstream",
+                bitstream.getID()
+        );
+
+        try {
+            addProvenanceMetadata(context, item, msg);
+        } catch (SQLException | AuthorizeException e) {
+            log.error("Unable to add new provenance metadata when setting bitstream policies.", e);
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
@@ -82,7 +82,6 @@ public class BitstreamResourcePolicyAddPatchOperation extends AddPatchOperation<
                             name = newAccessCondition.getName();
                             provenanceService.setBitstreamPolicies(context, bitstream, item, name);
                         }
-                        context.commit();
                     }
                 }
                 idx++;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
@@ -23,6 +23,7 @@ import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.core.ProvenanceService;
 import org.dspace.submit.model.UploadConfiguration;
 import org.dspace.submit.model.UploadConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,9 @@ public class BitstreamResourcePolicyAddPatchOperation extends AddPatchOperation<
 
     @Autowired
     ItemService itemService;
+
+    @Autowired
+    ProvenanceService provenanceService;
 
     @Autowired
     private ResourcePolicyService resourcePolicyService;
@@ -73,6 +77,12 @@ public class BitstreamResourcePolicyAddPatchOperation extends AddPatchOperation<
                     if (CollectionUtils.isNotEmpty(newAccessConditions)) {
                         BitstreamResourcePolicyUtils.findApplyResourcePolicy(context, uploadConfig, bitstream,
                                                                              newAccessConditions);
+                        String name;
+                        for (AccessConditionDTO newAccessCondition : newAccessConditions) {
+                            name = newAccessCondition.getName();
+                            provenanceService.setBitstreamPolicies(context, bitstream, item, name);
+                        }
+                        context.commit();
                     }
                 }
                 idx++;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -11,6 +11,7 @@ import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -22,6 +23,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,6 +58,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.content.service.ItemService;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
@@ -78,6 +83,9 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
 
     @Autowired
     private XmlWorkflowFactory xmlWorkflowFactory;
+
+    @Autowired
+    private ItemService itemService;
 
     @Before
     @Override
@@ -963,6 +971,79 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
                     Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(witem,
                             "New Title", "2017-10-17", "ExtraEntry"))))
         ;
+    }
+
+    @Test
+    public void patchEmbargoTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community with one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                .withWorkflowGroup(2, eperson).build();
+
+        //2. create a normal user to use as submitter
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                .withEmail("submitter@example.com")
+                .withPassword("dspace")
+                .build();
+
+        context.setCurrentUser(submitter);
+
+        //3. a claimed task with workflow item in edit step
+        ClaimedTask claimedTask = ClaimedTaskBuilder.createClaimedTask(context, col1, eperson)
+                .withTitle("Workflow Item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withSubject("ExtraEntry")
+                .build();
+        claimedTask.setStepID("editstep");
+        claimedTask.setActionID("editaction");
+
+        XmlWorkflowItem witem = claimedTask.getWorkflowItem();
+
+        String bitstreamContent = "0123456789";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, Charset.defaultCharset())) {
+
+            Bitstream bitstream = BitstreamBuilder.createBitstream(context, witem.getItem(), is)
+                    .withName("Test bitstream")
+                    .withDescription("This is a bitstream to test range requests")
+                    .withMimeType("text/plain")
+                    .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+
+        List<Operation> operations = new ArrayList<Operation>();
+        Map<String, String> embargoValue = new HashMap<String, String>();
+        embargoValue.put("name", "embargo");
+        ZonedDateTime embargoDate = ZonedDateTime.now(ZoneOffset.UTC).plusDays(1);
+        String formattedDate = embargoDate.format(DateTimeFormatter.ISO_INSTANT);
+        embargoValue.put("startDate", formattedDate);
+        List<Map<String, String>> embargoArray = new ArrayList<>();
+        embargoArray.add(embargoValue);
+        operations.add(new AddOperation("/sections/upload/files/0/accessConditions", embargoArray));
+
+        String patchBody = getPatchContent(operations);
+
+        getClient(authToken).perform(patch("/api/workflow/workflowitems/" + witem.getID())
+                        .content(patchBody)
+                        .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        Item item = itemService.find(context, witem.getItem().getID());
+        boolean hasEmbargoProvenance = item.getMetadata().stream()
+                .anyMatch(metadataValue ->
+                        "dc.description.provenance".equals(metadataValue.getMetadataField().toString('.')) &&
+                                metadataValue.getValue() != null &&
+                                metadataValue.getValue().toLowerCase().contains("embargo")
+                );
+        assertTrue("The item should have provenance metadata containing 'embargo'.", hasEmbargoProvenance);
     }
 
     @Test


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      | 5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The embargo is not recorded to provenance during submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provenance information is now automatically recorded when new access conditions are applied to bitstreams.

- **Bug Fixes**
  - Ensured provenance metadata is consistently added after updating bitstream access policies.

- **Tests**
  - Added integration test to verify embargo access conditions add appropriate provenance metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->