### PR TITLE
UFAL/Translation of distribution license for collection to Czech

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -324,3 +324,6 @@ autocomplete.custom.allowed = solr-author_ac,solr-publisher_ac,solr-dataProvider
 ### these collections allow submitters to edit metadata of their items
 # property is not commented, because of tests
 allow.edit.metadata =
+
+# Support of Czech locale for distribution license
+webui.supported.locales = cs

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/LanguageSupportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/LanguageSupportIT.java
@@ -39,7 +39,7 @@ public class LanguageSupportIT extends AbstractControllerIntegrationTest {
     @Test
     public void checkDefaultLanguageAnonymousTest() throws Exception {
         getClient().perform(get("/api"))
-                   .andExpect(header().stringValues("Content-Language","en"));
+                   .andExpect(header().stringValues("Content-Language","en,cs"));
     }
 
     @Test

--- a/dspace/config/default_cs.license
+++ b/dspace/config/default_cs.license
@@ -1,0 +1,31 @@
+POZNÁMKA: VLOŽTE ZDE SVOU VLASTNÍ LICENCI
+Tento vzorový licenční text je poskytován pouze pro informační účely.
+
+NEVÝHRADNÍ LICENCE NA DISTRIBUCI
+
+Podpisem a odesláním této licence vy (autor/autoři nebo vlastník/vlastníci autorských práv) udělujete
+Univerzitě Karlově (UK) nevýhradní právo celosvětově reprodukovat,
+překládat (jak je definováno níže) a/nebo distribuovat vaše příspěvky (včetně abstraktů)
+v tištěné i elektronické podobě a za pomoci jakéhokoli média (včetně audia nebo videa, ale i jakýchkoliv jiných médií).
+
+Souhlasíte s tím, že UK může, pokud nezmění obsah,  převést váš příspěvek do jakéhokoli formátu
+nebo na jakékoli médium za účelem jeho uchování.
+
+Rovněž souhlasíte, že UK  si může ponechat více než jednu kopii tohoto příspěvku pro
+účely jeho bezpečnosti, zálohování a dlouhodobého uchovávání.
+
+Prohlašujete, že váš příspěvek k dílu je původní a že máte právo udělovat práva uvedená v této licenci k celému dílu.
+Prohlašujete také, že podle vašeho nejlepšího vědomí a svědomí, neporušujete tímto ničí autorská práva.
+
+V případě, že příspěvek obsahuje materiál, pro který nevlastníte autorská práva,
+prohlašujete, že jste obdržel(i) neomezené povolení
+vlastníka autorských práv udělit UK práva požadovaná touto licencí a že
+takový materiál ve vlastnictví třetí strany je zřetelně označen a citován
+v textu nebo obsahu vašeho příspěvku.
+
+POKUD JE PŘÍSPĚVEK ZALOŽEN NA PRÁCI, KTERÁ BYLA SPONZOROVÁNA NEBO PODPOROVÁNA JAKOUKOLI JINOU AGENTUROU NEBO ORGANIZACÍ,
+NEŽ JE UK, PROHLAŠUJETE, ŽE JSTE SPLNIL(I) VŠECHNA PRÁVA NA PŘEZKOUMÁNÍ A TAKÉ JINÉ ZÁVAZKY
+VYŽADOVANÉ TAKOVOUTO SMLOUVOU NEBO UJEDNÁNÍM.
+
+UK bude jasně identifikovat vaše jméno (jména) jako autora (autorů) nebo vlastníka (vlastníků)
+poskytnutého díla a nebude provádět žádné jiné změny tohoto díla než ty, které povoluje tato licence.


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1.5 |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The distribution license is not translated when the language is switched to Czech.
### Reported issues
The issue was solved based on this PR: https://github.com/DSpace/DSpace/pull/8966
with this translation: https://github.com/ufal/clarin-dspace/blob/clarin/dspace/config/licenses/alternative_cs.license


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for the Czech locale.
  - Introduced a Czech-language non-exclusive distribution license.

- **Chores**
  - Updated configuration to include Czech as a supported language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->