### PR TITLE
UFAL/Fixed browse - the results are not lowercase

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -1422,7 +1422,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
 
                    //Verify that the index filters to the "Universe" entries and Counts 2 Items.
                    .andExpect(jsonPath("$._embedded.entries",
-                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("Universe".toLowerCase(), 2)
+                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("Universe", 2)
                                        )))
                    //Verify startsWith parameter is included in the links
                     .andExpect(jsonPath("$._links.self.href", containsString("?startsWith=U")));
@@ -1447,7 +1447,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Verify that the index filters to the "Turing, Alan'" items.
                    .andExpect(jsonPath("$._embedded.entries",
                                        contains(BrowseEntryResourceMatcher.matchBrowseEntry(
-                                               "Turing, Alan Mathison".toLowerCase(), 1)
+                                               "Turing, Alan Mathison", 1)
                                        )))
                    //Verify that the startsWith paramater is included in the links
                     .andExpect(jsonPath("$._links.self.href", containsString("?startsWith=T")));
@@ -1471,7 +1471,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Verify that the index filters to the "Computing'" items.
                    .andExpect(jsonPath("$._embedded.entries",
                                        contains(BrowseEntryResourceMatcher.matchBrowseEntry(
-                                               "Computing".toLowerCase(), 3)
+                                               "Computing", 3)
                                        )))
                    //Verify that the startsWith paramater is included in the links
                     .andExpect(jsonPath("$._links.self.href", containsString("?startsWith=C")));
@@ -1547,11 +1547,11 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    // and diacritics are ignored in sorting
                    .andExpect(jsonPath("$._embedded.entries",
                                        contains(BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Alonso, Nombre".toLowerCase(), 1),
+                                                        "Alonso, Nombre", 1),
                                                 BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Álvarez, Nombre".toLowerCase(), 1),
+                                                        "Álvarez, Nombre", 1),
                                                 BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Azuaga, Nombre".toLowerCase(), 1)
+                                                        "Azuaga, Nombre", 1)
                                                )))
 
                    //Verify startsWith parameter is included in the links
@@ -1576,9 +1576,9 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Verify that the index filters to the "Ögren, Name"" and "Ortiz, Nombre"
                    .andExpect(jsonPath("$._embedded.entries",
                                        contains(BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Ögren, Name".toLowerCase(), 1),
+                                                        "Ögren, Name", 1),
                                                 BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Ortiz, Nombre".toLowerCase(), 1)
+                                                        "Ortiz, Nombre", 1)
                                                )))
                    //Verify that the startsWith paramater is included in the links
                    .andExpect(jsonPath("$._links.self.href", containsString("?startsWith=Ó")));
@@ -1604,11 +1604,11 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    // it is sorted ignoring diacritics
                    .andExpect(jsonPath("$._embedded.entries",
                                        contains(BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Telecomunicaciones".toLowerCase(), 1),
+                                                        "Telecomunicaciones", 1),
                                                 BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Teléfono".toLowerCase(), 1),
+                                                        "Teléfono", 1),
                                                 BrowseEntryResourceMatcher.matchBrowseEntry(
-                                                        "Televisor".toLowerCase(), 1)
+                                                        "Televisor", 1)
                                                )))
                    //Verify that the startsWith paramater is included in the links
                    .andExpect(jsonPath("$._links.self.href", containsString("?startsWith=Tele")));
@@ -1631,7 +1631,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
 
                    //Verify that the index filters to the "Guion"
                    .andExpect(jsonPath("$._embedded.entries",
-                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("Guion".toLowerCase(), 1)
+                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("Guion", 1)
                                                )))
                    //Verify that the startsWith paramater is included in the links
                    .andExpect(jsonPath("$._links.self.href", containsString("?startsWith=Guión")));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinDiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinDiscoveryRestControllerIT.java
@@ -358,8 +358,8 @@ public class ClarinDiscoveryRestControllerIT extends AbstractControllerIntegrati
                 // up in different items
                 //These authors are order according to count. Only two show up because of the prefix.
                 .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                        FacetValueMatcher.entryAuthor("Smith, Maria".toLowerCase()),
-                        FacetValueMatcher.entryAuthor("Smith, Donald".toLowerCase())
+                        FacetValueMatcher.entryAuthor("Smith, Maria"),
+                        FacetValueMatcher.entryAuthor("Smith, Donald")
                 )))
         ;
     }

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -202,12 +202,6 @@
         </analyzer>
     </fieldType>
 
-    <fieldType name="noLowKeywordFilter" class="solr.TextField" sortMissingLast="true" omitNorms="true">
-        <analyzer>
-            <tokenizer class="solr.KeywordTokenizerFactory"/>
-        </analyzer>
-    </fieldType>
-
     <!--
      SpellCheck analysis config based off of http://wiki.apache.org/solr/
      SpellCheckingAnalysis

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -197,7 +197,7 @@
             <!--Treats the entire field as a single token, regardless of its content-->
             <tokenizer class="solr.KeywordTokenizerFactory"/>
 
-            <filter class="solr.LowerCaseFilterFactory" />
+            <!--<filter class="solr.LowerCaseFilterFactory" />-->
             <filter class="solr.TrimFilterFactory" />
         </analyzer>
     </fieldType>
@@ -313,7 +313,7 @@
 	<dynamicField name="*_acid" type="keywordFilter" indexed="true" stored="true" omitNorms="true" multiValued="true"/>
 
     <!--Dynamic field used for sidebar filters & SOLR browse by value -->
-    <dynamicField name="*_filter" type="noLowKeywordFilter" indexed="true" stored="true" multiValued="true" omitNorms="true" />
+    <dynamicField name="*_filter" type="keywordFilter" indexed="true" stored="true" multiValued="true" omitNorms="true" />
     <!--Dynamic field used to index the facet/filter value, split on each word to end,
         so that the facet search can search all words in a facet-->
     <dynamicField name="*_prefix" type="keywordFilter" indexed="true" stored="true" multiValued="true" omitNorms="true" />


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated search configuration to standardize handling of filter fields, ensuring consistent treatment of keyword filters without automatic lowercasing.

- **Chores**
  - Removed unused field types and updated dynamic field mappings for improved schema clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->