### PR TITLE
internal/Bitstream HEAD response

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -153,6 +153,7 @@ public class BitstreamRestController {
                 .withBufferSize(BUFFER_SIZE)
                 .withFileName(name)
                 .withChecksum(bit.getChecksum())
+                .withLength(bit.getSizeBytes())
                 .withMimetype(mimetype)
                 .with(request)
                 .with(response);
@@ -189,6 +190,12 @@ public class BitstreamRestController {
                 if (s3DirectDownload) {
                     return redirectToS3DownloadUrl(httpHeaders, name, bit.getInternalId());
                 }
+
+                if (RequestMethod.HEAD.name().equals(request.getMethod())) {
+                    log.debug("HEAD request - no response body");
+                    return ResponseEntity.ok().headers(httpHeaders).build();
+                }
+
                 return ResponseEntity.ok().headers(httpHeaders).body(bitstreamResource);
             }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -220,6 +220,18 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         context.restoreAuthSystemState();
 
             //** WHEN **
+            // we want to know what we are downloading before we download it
+            getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       //** THEN **
+                       .andExpect(status().isOk())
+
+                       //The Content Length must match the full length
+                       .andExpect(header().longValue("Content-Length", bitstreamContent.getBytes().length))
+                       .andExpect(header().string("Content-Type", "text/plain;charset=UTF-8"))
+                       .andExpect(header().string("ETag", "\"" + bitstream.getChecksum() + "\""))
+                       .andExpect(content().bytes(new byte[] {}));
+
+            //** WHEN **
             //We download the bitstream
             getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
 
@@ -245,7 +257,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                        .andExpect(status().isNotModified());
 
             //The download and head request should also be logged as a statistics record
-            checkNumberOfStatsRecords(bitstream, 2);
+            checkNumberOfStatsRecords(bitstream, 3);
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -98,7 +98,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.MvcResult;
 
 /**
  * Integration test to test the /api/core/bitstreams/[id]/* endpoints

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -98,6 +98,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
 
 /**
  * Integration test to test the /api/core/bitstreams/[id]/* endpoints
@@ -1413,5 +1414,42 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
             configurationService.setProperty("s3.download.direct.enabled", false);
             configurationService.setProperty("assetstore.s3.bucketName", null);
         }
+    }
+
+    @Test
+    public void testBitstreamContentTypeIsCorrect() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community and one collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+
+        //2. A public item with a bitstream
+        String bitstreamContent = "0123456789";
+
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            Item item = ItemBuilder.createItem(context, col1)
+                    .withTitle("Test item")
+                    .build();
+
+            bitstream = BitstreamBuilder.createBitstream(context, item, is)
+                    .withName("testfile.txt")
+                    .withMimeType("text/plain")
+                    .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        MvcResult result = getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Content-Type"))
+                .andExpect(header().string("Content-Type", "text/plain;charset=UTF-8"))
+                .andExpect(header().exists("Content-Disposition"))
+                .andExpect(header().exists("ETag"))
+                .andReturn();
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -1415,41 +1415,4 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
             configurationService.setProperty("assetstore.s3.bucketName", null);
         }
     }
-
-    @Test
-    public void testBitstreamContentTypeIsCorrect() throws Exception {
-        context.turnOffAuthorisationSystem();
-
-        //** GIVEN **
-        //1. A community-collection structure with one parent community and one collections.
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
-
-        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
-
-        //2. A public item with a bitstream
-        String bitstreamContent = "0123456789";
-
-        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
-            Item item = ItemBuilder.createItem(context, col1)
-                    .withTitle("Test item")
-                    .build();
-
-            bitstream = BitstreamBuilder.createBitstream(context, item, is)
-                    .withName("testfile.txt")
-                    .withMimeType("text/plain")
-                    .build();
-        }
-
-        context.restoreAuthSystemState();
-
-        MvcResult result = getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content"))
-                .andExpect(status().isOk())
-                .andExpect(header().exists("Content-Type"))
-                .andExpect(header().string("Content-Type", "text/plain;charset=UTF-8"))
-                .andExpect(header().exists("Content-Disposition"))
-                .andExpect(header().exists("ETag"))
-                .andReturn();
-    }
 }


### PR DESCRIPTION
[Port dspace-7_x] Return headers for HEAD request

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When the HEAD request was called, it responded with default values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit support for HTTP HEAD requests on bitstream endpoints, returning appropriate headers without a response body.

- **Bug Fixes**
  - Improved handling of response headers to ensure `Content-Length` and `Content-Disposition` are set only when appropriate.

- **Tests**
  - Enhanced and added tests to verify correct header responses and behavior for HEAD requests on bitstream endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->