### PR TITLE
UFAL/Copy fix - bitstream name encoding in the URL

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/sword2/Swordv2IT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/sword2/Swordv2IT.java
@@ -258,7 +258,8 @@ public class Swordv2IT extends AbstractWebClientIntegrationTest {
         // Add required headers
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-        headers.setContentDisposition(ContentDisposition.attachment().filename("example.zip").build());
+        // Test the file with spaces or special characters in the name
+        headers.setContentDisposition(ContentDisposition.attachment().filename("example .zip").build());
         headers.set("Packaging", "http://purl.org/net/sword/package/METSDSpaceSIP");
         headers.setAccept(List.of(MediaType.APPLICATION_ATOM_XML));
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.sword2;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -386,10 +388,10 @@ public class SwordUrlManager {
 
             if (handle != null && !"".equals(handle)) {
                 bsLink = bsLink + "/bitstream/" + handle + "/" +
-                    bitstream.getSequenceID() + "/" + bitstream.getName();
+                    bitstream.getSequenceID() + "/" + URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
             } else {
                 bsLink = bsLink + "/retrieve/" + bitstream.getID() + "/" +
-                    bitstream.getName();
+                    URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
             }
 
             return bsLink;
@@ -401,7 +403,7 @@ public class SwordUrlManager {
     public String getActionableBitstreamUrl(Bitstream bitstream)
         throws DSpaceSwordException {
         return this.getSwordBaseUrl() + "/edit-media/bitstream/" +
-            bitstream.getID() + "/" + bitstream.getName();
+            bitstream.getID() + "/" + URLEncoder.encode(bitstream.getName(), StandardCharsets.UTF_8);
     }
 
     public boolean isActionableBitstreamUrl(Context context, String url) {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of file uploads with spaces or special characters in filenames to ensure correct processing and URL generation.
- **Tests**
	- Updated tests to verify support for filenames containing spaces or special characters during file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->