### PR TITLE
UFAL/Display community and collection handle

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/ClarinVersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/ClarinVersionedHandleIdentifierProvider.java
@@ -61,6 +61,10 @@ public class ClarinVersionedHandleIdentifierProvider extends IdentifierProvider 
      * Prefix registered to no one
      */
     static final String EXAMPLE_PREFIX = "123456789";
+    /**
+     * Wild card for Dublin Core metadata qualifiers/languages
+     */
+    public static final String ANY = "*";
 
     private static final char DOT = '.';
 
@@ -195,9 +199,7 @@ public class ClarinVersionedHandleIdentifierProvider extends IdentifierProvider 
             // versioned (e.g. 123456789/100) one
             // just register it.
             createNewIdentifier(context, dso, identifier);
-            if (dso instanceof Item) {
-                populateHandleMetadata(context, (Item) dso, identifier);
-            }
+            populateHandleMetadata(context, dso, identifier);
         } catch (SQLException ex) {
             throw new RuntimeException("Unable to create handle '"
                     + identifier + "' for "
@@ -360,10 +362,9 @@ public class ClarinVersionedHandleIdentifierProvider extends IdentifierProvider 
         // identifiers which are not from type handle and add the new handle.
         DSpaceObjectService<DSpaceObject> dsoService = contentServiceFactory.getDSpaceObjectService(dso);
         List<MetadataValue> identifiers = dsoService.getMetadata(dso,
-                MetadataSchemaEnum.DC.getName(), "identifier", "uri",
-                Item.ANY);
+                MetadataSchemaEnum.DC.getName(), "identifier", "uri", ANY);
         dsoService.clearMetadata(context, dso, MetadataSchemaEnum.DC.getName(),
-                "identifier", "uri", Item.ANY);
+                "identifier", "uri", ANY);
         for (MetadataValue identifier : identifiers) {
             if (this.supports(identifier.getValue())) {
                 // ignore handles

--- a/dspace-api/src/main/java/org/dspace/identifier/ClarinVersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/ClarinVersionedHandleIdentifierProvider.java
@@ -199,7 +199,9 @@ public class ClarinVersionedHandleIdentifierProvider extends IdentifierProvider 
             // versioned (e.g. 123456789/100) one
             // just register it.
             createNewIdentifier(context, dso, identifier);
-            populateHandleMetadata(context, dso, identifier);
+            if (dso instanceof Item || dso instanceof Collection || dso instanceof Community) {
+                populateHandleMetadata(context, dso, identifier);
+            }
         } catch (SQLException ex) {
             throw new RuntimeException("Unable to create handle '"
                     + identifier + "' for "

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -1226,6 +1226,46 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
     }
 
     @Test
+    public void createWithHandleTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        configurationService.setProperty("handle.prefix", "123456789");
+        context.restoreAuthSystemState();
+
+        AtomicReference<String> handle = new AtomicReference<>();
+
+        ObjectMapper mapper = new ObjectMapper();
+        CollectionRest collectionRest = new CollectionRest();
+        // We send a name but the created collection should set this to the title
+        collectionRest.setName("Collection");
+        String handleStr = "123456789/test";
+        collectionRest.setHandle(handleStr);
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+        getClient(authToken).perform(post("/api/core/collections")
+                        .content(mapper.writeValueAsBytes(collectionRest))
+                        .param("parent", parentCommunity.getID().toString())
+                        .contentType(contentType)
+                        .param("embed", CollectionMatcher.getEmbedsParameter()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$", Matchers.allOf(
+                        hasJsonPath("$.handle", is(handleStr)))))
+                // capture "handle" returned in JSON response and check against the metadata
+                .andDo(result -> handle.set(
+                        read(result.getResponse().getContentAsString(), "$.handle")))
+                .andExpect(jsonPath("$",
+                        hasJsonPath("$.metadata", Matchers.allOf(
+                                        matchMetadataNotEmpty("dc.identifier.uri"),
+                                        matchMetadataStringEndsWith("dc.identifier.uri", handle.get())
+                                )
+                        )));
+    }
+
+    @Test
     public void createTestByAuthorizedUser() throws Exception {
         context.turnOffAuthorisationSystem();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -1233,7 +1233,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         parentCommunity = CommunityBuilder.createCommunity(context)
                 .withName("Parent Community")
                 .build();
-        configurationService.setProperty("handle.prefix", "123456789");
+        configurationService.setProperty("handle.prefix", "test");
         context.restoreAuthSystemState();
 
         AtomicReference<String> handle = new AtomicReference<>();
@@ -1243,7 +1243,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         CollectionRest collectionRest = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
-        String handleStr = "123456789/test";
+        String handleStr = "test/collection";
         collectionRest.setHandle(handleStr);
 
         String authToken = getAuthToken(admin.getEmail(), password);
@@ -1270,7 +1270,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         } finally {
             // Delete the created community (cleanup after ourselves!)
             if (idRef.get() != null) {
-                CommunityBuilder.deleteCommunity(idRef.get());
+                CollectionBuilder.deleteCollection(idRef.get());
             }
         }
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -1237,6 +1237,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         context.restoreAuthSystemState();
 
         AtomicReference<String> handle = new AtomicReference<>();
+        AtomicReference<UUID> idRef = new AtomicReference<>();
 
         ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
@@ -1246,23 +1247,32 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         collectionRest.setHandle(handleStr);
 
         String authToken = getAuthToken(admin.getEmail(), password);
-        getClient(authToken).perform(post("/api/core/collections")
-                        .content(mapper.writeValueAsBytes(collectionRest))
-                        .param("parent", parentCommunity.getID().toString())
-                        .contentType(contentType)
-                        .param("embed", CollectionMatcher.getEmbedsParameter()))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$", Matchers.allOf(
-                        hasJsonPath("$.handle", is(handleStr)))))
-                // capture "handle" returned in JSON response and check against the metadata
-                .andDo(result -> handle.set(
-                        read(result.getResponse().getContentAsString(), "$.handle")))
-                .andExpect(jsonPath("$",
-                        hasJsonPath("$.metadata", Matchers.allOf(
-                                        matchMetadataNotEmpty("dc.identifier.uri"),
-                                        matchMetadataStringEndsWith("dc.identifier.uri", handle.get())
-                                )
-                        )));
+        try {
+            getClient(authToken).perform(post("/api/core/collections")
+                            .content(mapper.writeValueAsBytes(collectionRest))
+                            .param("parent", parentCommunity.getID().toString())
+                            .contentType(contentType)
+                            .param("embed", CollectionMatcher.getEmbedsParameter()))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$", Matchers.allOf(
+                            hasJsonPath("$.handle", is(handleStr)))))
+                    // capture "handle" returned in JSON response and check against the metadata
+                    .andDo(result -> handle.set(
+                            read(result.getResponse().getContentAsString(), "$.handle")))
+                    .andDo(result -> idRef.set(
+                            UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))))
+                    .andExpect(jsonPath("$",
+                            hasJsonPath("$.metadata", Matchers.allOf(
+                                            matchMetadataNotEmpty("dc.identifier.uri"),
+                                            matchMetadataStringEndsWith("dc.identifier.uri", handle.get())
+                                    )
+                            )));
+        } finally {
+            // Delete the created community (cleanup after ourselves!)
+            if (idRef.get() != null) {
+                CommunityBuilder.deleteCommunity(idRef.get());
+            }
+        }
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -223,7 +223,9 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         String authToken = getAuthToken(admin.getEmail(), password);
         AtomicReference<String> handle = new AtomicReference<>();
+        AtomicReference<UUID> idRef = new AtomicReference<>();
 
+        try {
         getClient(authToken).perform(post("/api/core/communities")
                         .content(mapper.writeValueAsBytes(comm))
                         .contentType(contentType)
@@ -237,12 +239,20 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                 // capture "handle" returned in JSON response and check against the metadata
                 .andDo(result -> handle.set(
                         read(result.getResponse().getContentAsString(), "$.handle")))
+                .andDo(result -> idRef.set(
+                        UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))))
                 .andExpect(jsonPath("$",
                         hasJsonPath("$.metadata", Matchers.allOf(
                                         matchMetadataNotEmpty("dc.identifier.uri"),
                                         matchMetadataStringEndsWith("dc.identifier.uri", handleStr)
                                 )
                         )));
+        } finally {
+            // Delete the created community (cleanup after ourselves!)
+            if (idRef.get() != null) {
+                CommunityBuilder.deleteCommunity(idRef.get());
+            }
+        }
 
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -210,6 +210,72 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
     }
 
     @Test
+    public void createWithHandleTest() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        CommunityRest comm = new CommunityRest();
+        // We send a name but the created community should set this to the title
+        comm.setName("Test Community");
+
+        MetadataRest metadataRest = new MetadataRest();
+        MetadataValueRest title = new MetadataValueRest();
+        title.setValue("Title Text");
+        metadataRest.put("dc.title", title);
+
+        comm.setMetadata(metadataRest);
+
+        context.turnOffAuthorisationSystem();
+        configurationService.setProperty("handle.prefix", "123456789");
+        context.restoreAuthSystemState();
+        String handleStr = "123456789/test";
+        comm.setHandle(handleStr);
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        // Capture the UUID of the created Community (see andDo() below)
+        AtomicReference<UUID> idRef = new AtomicReference<>();
+        AtomicReference<String> handle = new AtomicReference<>();
+
+        try {
+            getClient(authToken).perform(post("/api/core/communities")
+                            .content(mapper.writeValueAsBytes(comm))
+                            .contentType(contentType)
+                            .param("embed", CommunityMatcher.getNonAdminEmbeds()))
+                    .andExpect(status().isCreated())
+                    .andExpect(content().contentType(contentType))
+                    .andExpect(jsonPath("$", CommunityMatcher.matchNonAdminEmbeds()))
+                    .andExpect(jsonPath("$", Matchers.allOf(
+                            hasJsonPath("$.id", not(empty())),
+                            hasJsonPath("$.uuid", not(empty())),
+                            hasJsonPath("$.name", is("Title Text")),
+                            hasJsonPath("$.handle", is(handleStr)),
+                            hasJsonPath("$._links.self.href", not(empty())),
+                            hasJsonPath("$.metadata", Matchers.allOf(
+                                            matchMetadata("dc.title", "Title Text")
+
+                                    )
+                            )
+                    )))
+
+                    // capture "handle" returned in JSON response and check against the metadata
+                    .andDo(result -> handle.set(
+                            read(result.getResponse().getContentAsString(), "$.handle")))
+                    // capture "id" returned in JSON response
+                    .andDo(result -> idRef
+                            .set(UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))))
+                    .andExpect(jsonPath("$",
+                            hasJsonPath("$.metadata", Matchers.allOf(
+                                            matchMetadataNotEmpty("dc.identifier.uri"),
+                                            matchMetadataStringEndsWith("dc.identifier.uri", handle.get())
+                                    )
+                            )));
+        } finally {
+            // Delete the created community (cleanup after ourselves!)
+            CommunityBuilder.deleteCommunity(idRef.get());
+        }
+    }
+
+
+    @Test
     public void createSubCommunityUnAuthorizedTest() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -210,53 +210,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void createWithHandleTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        CommunityRest comm = new CommunityRest();
-        // We send a name but the created community should set this to the title
-        comm.setName("Test Top-Level Community");
-        context.turnOffAuthorisationSystem();
-        configurationService.setProperty("handle.prefix", "123456789");
-        context.restoreAuthSystemState();
-        String handleStr = "123456789/test";
-        comm.setHandle(handleStr);
-
-        String authToken = getAuthToken(admin.getEmail(), password);
-        AtomicReference<String> handle = new AtomicReference<>();
-        AtomicReference<UUID> idRef = new AtomicReference<>();
-
-        try {
-        getClient(authToken).perform(post("/api/core/communities")
-                        .content(mapper.writeValueAsBytes(comm))
-                        .contentType(contentType)
-                        .param("embed", CommunityMatcher.getNonAdminEmbeds()))
-                .andExpect(status().isCreated())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$", CommunityMatcher.matchNonAdminEmbeds()))
-                .andExpect(jsonPath("$", Matchers.allOf(
-                        hasJsonPath("$.handle", is (handleStr))
-                )))
-                // capture "handle" returned in JSON response and check against the metadata
-                .andDo(result -> handle.set(
-                        read(result.getResponse().getContentAsString(), "$.handle")))
-                .andDo(result -> idRef.set(
-                        UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))))
-                .andExpect(jsonPath("$",
-                        hasJsonPath("$.metadata", Matchers.allOf(
-                                        matchMetadataNotEmpty("dc.identifier.uri"),
-                                        matchMetadataStringEndsWith("dc.identifier.uri", handleStr)
-                                )
-                        )));
-        } finally {
-            // Delete the created community (cleanup after ourselves!)
-            if (idRef.get() != null) {
-                CommunityBuilder.deleteCommunity(idRef.get());
-            }
-        }
-
-    }
-
-    @Test
     public void createSubCommunityUnAuthorizedTest() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -215,12 +215,10 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         CommunityRest comm = new CommunityRest();
         // We send a name but the created community should set this to the title
         comm.setName("Test Community");
-
         MetadataRest metadataRest = new MetadataRest();
         MetadataValueRest title = new MetadataValueRest();
         title.setValue("Title Text");
         metadataRest.put("dc.title", title);
-
         comm.setMetadata(metadataRest);
 
         context.turnOffAuthorisationSystem();
@@ -251,11 +249,9 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                             hasJsonPath("$._links.self.href", not(empty())),
                             hasJsonPath("$.metadata", Matchers.allOf(
                                             matchMetadata("dc.title", "Title Text")
-
                                     )
                             )
                     )))
-
                     // capture "handle" returned in JSON response and check against the metadata
                     .andDo(result -> handle.set(
                             read(result.getResponse().getContentAsString(), "$.handle")))
@@ -275,7 +271,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
             }
         }
     }
-
 
     @Test
     public void createSubCommunityUnAuthorizedTest() throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -224,9 +224,9 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         comm.setMetadata(metadataRest);
 
         context.turnOffAuthorisationSystem();
-        configurationService.setProperty("handle.prefix", "123456789");
+        configurationService.setProperty("handle.prefix", "test");
         context.restoreAuthSystemState();
-        String handleStr = "123456789/test";
+        String handleStr = "test/community";
         comm.setHandle(handleStr);
 
         String authToken = getAuthToken(admin.getEmail(), password);
@@ -270,7 +270,9 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                             )));
         } finally {
             // Delete the created community (cleanup after ourselves!)
-            CommunityBuilder.deleteCommunity(idRef.get());
+            if (idRef.get() != null) {
+                CommunityBuilder.deleteCommunity(idRef.get());
+            }
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -210,6 +210,43 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
     }
 
     @Test
+    public void createWithHandleTest() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        CommunityRest comm = new CommunityRest();
+        // We send a name but the created community should set this to the title
+        comm.setName("Test Top-Level Community");
+        context.turnOffAuthorisationSystem();
+        configurationService.setProperty("handle.prefix", "123456789");
+        context.restoreAuthSystemState();
+        String handleStr = "123456789/test";
+        comm.setHandle(handleStr);
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+        AtomicReference<String> handle = new AtomicReference<>();
+
+        getClient(authToken).perform(post("/api/core/communities")
+                        .content(mapper.writeValueAsBytes(comm))
+                        .contentType(contentType)
+                        .param("embed", CommunityMatcher.getNonAdminEmbeds()))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$", CommunityMatcher.matchNonAdminEmbeds()))
+                .andExpect(jsonPath("$", Matchers.allOf(
+                        hasJsonPath("$.handle", is (handleStr))
+                )))
+                // capture "handle" returned in JSON response and check against the metadata
+                .andDo(result -> handle.set(
+                        read(result.getResponse().getContentAsString(), "$.handle")))
+                .andExpect(jsonPath("$",
+                        hasJsonPath("$.metadata", Matchers.allOf(
+                                        matchMetadataNotEmpty("dc.identifier.uri"),
+                                        matchMetadataStringEndsWith("dc.identifier.uri", handleStr)
+                                )
+                        )));
+
+    }
+
+    @Test
     public void createSubCommunityUnAuthorizedTest() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem Description
Handles for communities and collections are not displayed after import.

## Analysis
When communities and collections are created during import, their handles are registered but not populated in the metadata because of a check that only processes Item objects.

## Fix
Removed the Item check to allow handle metadata to be populated for communities and collections as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of metadata qualifiers and languages for better consistency and maintainability. No visible changes to user-facing features.
- **Tests**
  - Added integration tests for creating communities and collections with specified handles, ensuring handle assignment and metadata accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->