### PR TITLE
UFAL/Submission autocomplete search is case sensitive

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SuggestionRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SuggestionRestController.java
@@ -262,15 +262,16 @@ public class SuggestionRestController extends AbstractDSpaceRestRepository {
                                           List<VocabularyEntryRest> results) {
         searchResult.getFacetResult(autocompleteCustom).forEach(facetResult -> {
             String displayedValue = facetResult.getDisplayedValue();
-            if (displayedValue.contains(searchValue)) {
-                // Create a new VocabularyEntryRest object
-                VocabularyEntryRest vocabularyEntryRest = new VocabularyEntryRest();
-                vocabularyEntryRest.setDisplay(displayedValue);
-                vocabularyEntryRest.setValue(displayedValue);
-
-                // Add the filtered value to the results
-                results.add(vocabularyEntryRest);
+            if (!displayedValue.contains(searchValue) && !displayedValue.toLowerCase().contains(searchValue)) {
+                return;
             }
+            // Create a new VocabularyEntryRest object
+            VocabularyEntryRest vocabularyEntryRest = new VocabularyEntryRest();
+            vocabularyEntryRest.setDisplay(displayedValue);
+            vocabularyEntryRest.setValue(displayedValue);
+
+            // Add the filtered value to the results
+            results.add(vocabularyEntryRest);
         });
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SuggestionRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SuggestionRestController.java
@@ -262,7 +262,9 @@ public class SuggestionRestController extends AbstractDSpaceRestRepository {
                                           List<VocabularyEntryRest> results) {
         searchResult.getFacetResult(autocompleteCustom).forEach(facetResult -> {
             String displayedValue = facetResult.getDisplayedValue();
-            if (!displayedValue.contains(searchValue) && !displayedValue.toLowerCase().contains(searchValue)) {
+            if (!displayedValue.contains(searchValue) &&
+                    !displayedValue.toLowerCase().contains(searchValue) &&
+                    !displayedValue.toLowerCase().contains(searchValue.toLowerCase())) {
                 return;
             }
             // Create a new VocabularyEntryRest object

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SuggestionRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SuggestionRestController.java
@@ -262,9 +262,7 @@ public class SuggestionRestController extends AbstractDSpaceRestRepository {
                                           List<VocabularyEntryRest> results) {
         searchResult.getFacetResult(autocompleteCustom).forEach(facetResult -> {
             String displayedValue = facetResult.getDisplayedValue();
-            if (!displayedValue.contains(searchValue) &&
-                    !displayedValue.toLowerCase().contains(searchValue) &&
-                    !displayedValue.toLowerCase().contains(searchValue.toLowerCase())) {
+            if (!displayedValue.toLowerCase().contains(searchValue.toLowerCase())) {
                 return;
             }
             // Create a new VocabularyEntryRest object

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SuggestionRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SuggestionRestControllerIT.java
@@ -153,6 +153,27 @@ public class SuggestionRestControllerIT extends AbstractControllerIntegrationTes
      * Compose specific query from the definition and the search value.
      */
     @Test
+    public void testSearchBySpecificQueryFromSolrNoCaseSensitive() throws Exception {
+        String userToken = getAuthToken(eperson.getEmail(), password);
+        getClient(userToken).perform(
+                        get("/api/suggestions?autocompleteCustom=solr-title_ac?query=title_ac:**&searchValue=" +
+                                ITEM_TITLE.substring(0, 4).toLowerCase()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$.page.totalElements", is(1)))
+                .andExpect(jsonPath("$._embedded.vocabularyEntryRests", Matchers.hasItem(
+                        allOf(
+                                hasJsonPath("$.display", is(ITEM_TITLE)),
+                                hasJsonPath("$.value", is(ITEM_TITLE)),
+                                hasJsonPath("$.type", is("vocabularyEntry"))
+                        ))));
+    }
+
+    /**
+     * Should return suggestions from the solr `title_ac` index.
+     * Compose specific query from the definition and the search value.
+     */
+    @Test
     public void testSearchBySpecificQueryFromSolr_noresults() throws Exception {
         String userToken = getAuthToken(eperson.getEmail(), password);
         getClient(userToken).perform(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SuggestionRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SuggestionRestControllerIT.java
@@ -153,7 +153,7 @@ public class SuggestionRestControllerIT extends AbstractControllerIntegrationTes
      * Compose specific query from the definition and the search value.
      */
     @Test
-    public void testSearchBySpecificQueryFromSolrNoCaseSensitive() throws Exception {
+    public void testSearchBySpecificQueryFromSolrNoCaseSensitiveSuggestion() throws Exception {
         String userToken = getAuthToken(eperson.getEmail(), password);
         getClient(userToken).perform(
                         get("/api/suggestions?autocompleteCustom=solr-title_ac?query=title_ac:**&searchValue=" +
@@ -168,6 +168,40 @@ public class SuggestionRestControllerIT extends AbstractControllerIntegrationTes
                                 hasJsonPath("$.type", is("vocabularyEntry"))
                         ))));
     }
+
+    /**
+     * Should return suggestions from the solr `title_ac` index.
+     * Compose specific query from the definition and the search value.
+     */
+    @Test
+    public void testSearchBySpecificQueryFromSolrNoCaseSensitiveSearchVal() throws Exception {
+        String itemTitle = "TEst";
+        String itemSubTitle = "Tes";
+        context.turnOffAuthorisationSystem();
+        Item item = ItemBuilder.createItem(context, col)
+                .withTitle(itemTitle)
+                .withMetadata("dc", "subject", null, SUBJECT_SEARCH_VALUE )
+                .build();
+        context.restoreAuthSystemState();
+        String userToken = getAuthToken(eperson.getEmail(), password);
+        try {
+            getClient(userToken).perform(
+                            get("/api/suggestions?autocompleteCustom=solr-title_ac?query=title_ac:**&searchValue=" +
+                                    itemSubTitle))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(contentType))
+                    .andExpect(jsonPath("$.page.totalElements", is(1)))
+                    .andExpect(jsonPath("$._embedded.vocabularyEntryRests", Matchers.hasItem(
+                            allOf(
+                                    hasJsonPath("$.display", is(itemTitle)),
+                                    hasJsonPath("$.value", is(itemTitle)),
+                                    hasJsonPath("$.type", is("vocabularyEntry"))
+                            ))));
+        } finally {
+            ItemBuilder.deleteItem(item.getID());
+        }
+    }
+
 
     /**
      * Should return suggestions from the solr `title_ac` index.


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  13  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When Solr generates suggestions, the input "mil" returns "Maximilan", and "Mil" returns "Milan". However, we need "mil" to also return "Milan" — but not for "Mil" to return "Maximilan".



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved suggestion filtering to be case-insensitive, enhancing search accuracy.
- **Tests**
  - Added integration tests to ensure suggestions work correctly regardless of case in search queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->