### PR TITLE
UFAL/S3 - The problem to download a big file - it does not show the progress

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -10,6 +10,7 @@ package org.dspace.storage.bitstore;
 import static java.lang.String.valueOf;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -105,6 +106,11 @@ public class S3BitStoreService extends BaseBitStoreService {
 
     private String endpoint;
     private boolean pathStyleAccessEnabled;
+
+    /**
+     * The maximum size of individual chunk to download from S3 when a file is accessed. Default 5Mb
+     */
+    private long bufferSize = 5 * 1024 * 1024;
 
     /**
      * container for all the assets
@@ -289,20 +295,7 @@ public class S3BitStoreService extends BaseBitStoreService {
         if (isRegisteredBitstream(key)) {
             key = key.substring(REGISTERED_FLAG.length());
         }
-        try {
-            File tempFile = File.createTempFile("s3-disk-copy-" + UUID.randomUUID(), "temp");
-            tempFile.deleteOnExit();
-
-            GetObjectRequest getObjectRequest = new GetObjectRequest(bucketName, key);
-
-            Download download = tm.download(getObjectRequest, tempFile);
-            download.waitForCompletion();
-
-            return new DeleteOnCloseFileInputStream(tempFile);
-        } catch (AmazonClientException | InterruptedException e) {
-            log.error("get(" + key + ")", e);
-            throw new IOException(e);
-        }
+        return new S3LazyInputStream(key, bufferSize, bitstream.getSizeBytes());
     }
 
     /**
@@ -669,4 +662,84 @@ public class S3BitStoreService extends BaseBitStoreService {
         return internalId.startsWith(REGISTERED_FLAG);
     }
 
+    public void setBufferSize(long bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+
+    /**
+     * This inner class represent an InputStream that uses temporary files to
+     * represent chunk of the object downloaded from S3. When the input stream is
+     * read the class look first to the current chunk and download a new one once if
+     * the current one as been fully read. The class is responsible to close a chunk
+     * as soon as a new one is retrieved, the last chunk is closed when the input
+     * stream itself is closed or the last byte is read (the first of the two)
+     */
+    public class S3LazyInputStream extends InputStream {
+        private InputStream currentChunkStream;
+        private String objectKey;
+        private long endOfChunk = -1;
+        private long chunkMaxSize;
+        private long currPos = 0;
+        private long fileSize;
+
+        public S3LazyInputStream(String objectKey, long chunkMaxSize, long fileSize) throws IOException {
+            this.objectKey = objectKey;
+            this.chunkMaxSize = chunkMaxSize;
+            this.endOfChunk = 0;
+            this.fileSize = fileSize;
+            downloadChunk();
+        }
+
+        @Override
+        public int read() throws IOException {
+            // is the current chunk completely read and other are available?
+            if (currPos == endOfChunk && currPos < fileSize) {
+                currentChunkStream.close();
+                downloadChunk();
+            }
+
+            int byteRead = currPos < endOfChunk ? currentChunkStream.read() : -1;
+            // do we get any data or are we at the end of the file?
+            if (byteRead != -1) {
+                currPos++;
+            } else {
+                currentChunkStream.close();
+            }
+            return byteRead;
+        }
+
+        /**
+         * This method download the next chunk from S3
+         *
+         * @throws IOException
+         * @throws FileNotFoundException
+         */
+        private void downloadChunk() throws IOException, FileNotFoundException {
+            // Create a DownloadFileRequest with the desired byte range
+            long startByte = currPos; // Start byte (inclusive)
+            long endByte = Long.min(startByte + chunkMaxSize - 1, fileSize - 1); // End byte (inclusive)
+            GetObjectRequest getRequest = new GetObjectRequest(bucketName, objectKey)
+                    .withRange(startByte, endByte);
+
+            File currentChunkFile = File.createTempFile("s3-disk-copy-" + UUID.randomUUID(), "temp");
+            currentChunkFile.deleteOnExit();
+            try {
+                Download download = tm.download(getRequest, currentChunkFile);
+                download.waitForCompletion();
+                currentChunkStream = new DeleteOnCloseFileInputStream(currentChunkFile);
+                endOfChunk = endOfChunk + download.getProgress().getBytesTransferred();
+            } catch (AmazonClientException | InterruptedException e) {
+                currentChunkFile.delete();
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (currentChunkStream != null) {
+                currentChunkStream.close();
+            }
+        }
+
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -197,7 +197,7 @@ public class S3BitStoreService extends BaseBitStoreService {
     @Override
     public void init() throws IOException {
 
-        if (this.isInitialized()) {
+        if (this.isInitialized() || !this.isEnabled()) {
             return;
         }
 

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -64,7 +64,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 
-
 /**
  * @author Luca Giamminonni (luca.giamminonni at 4science.com)
  */
@@ -83,7 +82,6 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     private File s3Directory;
 
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-
 
     @Before
     public void setup() throws Exception {
@@ -408,7 +406,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testDoNotInitializeConfigured() throws Exception {
         String assetstores3enabledOldValue = configurationService.getProperty("assetstore.s3.enabled");
-        configurationService.setProperty("assetstore.s3.enabled", "false");
+        configurationService.setProperty("assetstore.s3.enabled", false);
         s3BitStoreService = new S3BitStoreService(amazonS3Client);
         s3BitStoreService.init();
         assertFalse(s3BitStoreService.isInitialized());


### PR DESCRIPTION
The code is cherry-picked from the upstream.
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Check the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved file download performance from S3 by introducing a streaming mechanism that downloads files in configurable chunks, reducing memory usage and wait times for large files.

- **Bug Fixes**
	- Enhanced error handling during file downloads to ensure temporary files are cleaned up in case of failures.

- **Tests**
	- Expanded test coverage for different file sizes and chunking scenarios.
	- Added tests to confirm service behavior when S3 storage is disabled via configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->