### PR TITLE
Ufal dtq sync 2025-05-15

### DIFF
--- a/Acknowledgment-ReadMe.md
+++ b/Acknowledgment-ReadMe.md
@@ -1,0 +1,13 @@
+<p align="left">
+  <img src="https://webcentrum.muni.cz/media/3831863/seda_eosc.png" alt="EOSC CZ Logo" height="90">
+</p>
+
+---
+
+This project output was developed with financial contributions from the [EOSC CZ](https://www.eosc.cz/projekty/narodni-podpora-pro-eosc) initiative through the project **National Repository Platform for Research Data** (CZ.02.01.01/00/23_014/0008787), funded by the Programme Johannes Amos Comenius (P JAC) of the Ministry of Education, Youth and Sports of the Czech Republic (MEYS).
+
+---
+
+<p align="left">
+  <img src="https://webcentrum.muni.cz/media/3832168/seda_eu-msmt_eng.png" alt="EU and MŠMT Logos" height="90">
+</p>

--- a/dspace-api/src/main/java/org/dspace/administer/FileDownloaderConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/FileDownloaderConfiguration.java
@@ -50,7 +50,7 @@ public class FileDownloaderConfiguration extends ScriptConfiguration<FileDownloa
      */
     @Override
     public boolean isAllowedToExecute(Context context, List<DSpaceCommandLineParameter> commandLineParameters) {
-        return true;
+        return context.getCurrentUser() != null;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/administer/FileDownloaderConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/FileDownloaderConfiguration.java
@@ -7,8 +7,12 @@
  */
 package org.dspace.administer;
 
+import java.util.List;
+
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 
 public class FileDownloaderConfiguration extends ScriptConfiguration<FileDownloader> {
@@ -33,6 +37,20 @@ public class FileDownloaderConfiguration extends ScriptConfiguration<FileDownloa
     @Override
     public void setDspaceRunnableClass(Class<FileDownloader> dspaceRunnableClass) {
         this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+    /**
+     * This script is allowed to execute to any authorized user. Further access control mechanism then checks,
+     * if the current user is authorized to download a file to the item specified in command line parameters.
+     *
+     * @param context   The relevant DSpace context
+     * @param commandLineParameters the parameters that will be used to start the process if known,
+     *        <code>null</code> otherwise
+     * @return          A boolean indicating whether the script is allowed to execute or not
+     */
+    @Override
+    public boolean isAllowedToExecute(Context context, List<DSpaceCommandLineParameter> commandLineParameters) {
+        return true;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoTracker.java
@@ -53,8 +53,7 @@ public class ClarinMatomoTracker {
      */
     public void trackPage(Context context, HttpServletRequest request, Item item, String pageName) {
         log.debug("Matomo tracks " + pageName);
-        // `&bots=1` because we want to track downloading by bots
-        String pageURL = getFullURL(request) + "&bots=1";
+        String pageURL = getFullURL(request);
 
         MatomoRequest matomoRequest = createMatomoRequest(request, pageName, pageURL);
         if (Objects.isNull(matomoRequest)) {
@@ -116,18 +115,6 @@ public class ClarinMatomoTracker {
         matomoRequest.setCurrentHour(now.get(Calendar.HOUR_OF_DAY));
         matomoRequest.setCurrentMinute(now.get(Calendar.MINUTE));
         matomoRequest.setCurrentSecond(now.get(Calendar.SECOND));
-        matomoRequest.setReferrerUrl(configurationService.getProperty("dspace.ui.url"));
-        matomoRequest.setPluginPDF(true);
-        matomoRequest.setPluginQuicktime(false);
-        matomoRequest.setPluginRealPlayer(false);
-        matomoRequest.setPluginWindowsMedia(false);
-        matomoRequest.setPluginDirector(false);
-        matomoRequest.setPluginFlash(false);
-        matomoRequest.setPluginJava(false);
-        matomoRequest.setPluginGears(false);
-        matomoRequest.setPluginSilverlight(false);
-        matomoRequest.setParameter("cookie", 1);
-        matomoRequest.setDeviceResolution("1920x1080");
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -178,7 +178,10 @@ public class AuthorizeServiceImpl implements AuthorizeService {
         // CLARIN
         // This function throws exception if the authorization fails - if it is not reported, the license
         // restrictions are OK
-        if (o.getType() == Constants.BITSTREAM && !isAdmin(c)) {
+        //
+        // the license confirmation is excluded when bitstream is edited,
+        // or when user has admin permission on bitstream object
+        if (o.getType() == Constants.BITSTREAM && action != Constants.WRITE && !isAdmin(c, o)) {
             authorizationBitstreamUtils.authorizeBitstream(c, (Bitstream) o);
         }
         // CLARIN

--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -34,6 +33,7 @@ import org.dspace.core.Context;
 import org.dspace.discovery.IsoLangCodes;
 import org.dspace.embargo.service.EmbargoService;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.event.Event;
 import org.dspace.identifier.Identifier;
 import org.dspace.identifier.IdentifierException;
@@ -63,6 +63,8 @@ public class InstallItemServiceImpl implements InstallItemService {
     protected IdentifierService identifierService;
     @Autowired(required = true)
     protected ItemService itemService;
+    @Autowired(required = true)
+    protected GroupService groupService;
     @Autowired(required = true)
     protected SupervisionOrderService supervisionOrderService;
     @Autowired(required = false)
@@ -114,7 +116,7 @@ public class InstallItemServiceImpl implements InstallItemService {
 
         //Allow submitter to edit item
         if (isCollectionAllowedForSubmitterEditing(item.getOwningCollection()) &&
-                isInSubmitGroup(item.getSubmitter(), item.getOwningCollection().getID())) {
+                isInSubmitGroup(c, item.getSubmitter(), item.getOwningCollection())) {
             createResourcePolicy(c, item, Constants.WRITE);
         }
 
@@ -379,17 +381,16 @@ public class InstallItemServiceImpl implements InstallItemService {
     }
 
     /**
-     * Checks if the given EPerson is in a submitter of the collection.
+     * Checks if the given ePerson is in the submit group of the collection.
      * A submit group is identified by the name containing "SUBMIT" and the collection UUID.
      *
-     * @param eperson      the EPerson whose is checked
-     * @param collectionUUID the UUID of the collection to check group names
-     * @return true if the EPerson is in a submitter, false otherwise
+     * @param context           The current DSpace context.
+     * @param ePerson           the EPerson that is checked to be member of the collection submit group
+     * @param collection        the collection
+     * @return true if the EPerson is a member (direct or indirect) of a submit group, false otherwise
      */
-    private boolean isInSubmitGroup(EPerson eperson, UUID collectionUUID) {
-        return eperson.getGroups().stream()
-                .anyMatch(group -> group.getName().contains("SUBMIT") &&
-                        group.getName().contains(collectionUUID.toString()));
+    private boolean isInSubmitGroup(Context context, EPerson ePerson, Collection collection) throws SQLException {
+        return groupService.isMember(context, ePerson, "COLLECTION_" + collection.getID() + "_SUBMIT");
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/PreviewContentDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/PreviewContentDAOImpl.java
@@ -42,12 +42,12 @@ public class PreviewContentDAOImpl extends AbstractHibernateDAO<PreviewContent> 
     @Override
     public List<PreviewContent> hasPreview(Context context, Bitstream bitstream) throws SQLException {
         // select only data from the previewcontent table whose ID is not a child in the preview2preview table
-        Query query = createQuery(context,
-                "SELECT pc FROM " + PreviewContent.class.getSimpleName() + " pc " +
-                        "JOIN pc.bitstream b " +
-                        "WHERE b.id = :bitstream_id " +
-                        "AND pc.id NOT IN (SELECT child.id FROM " + PreviewContent.class.getSimpleName() + " parent " +
-                        "JOIN parent.sub child)"
+        Query query = getHibernateSession(context).createNativeQuery(
+                "SELECT pc.* FROM previewcontent pc " +
+                        "JOIN bitstream b ON pc.bitstream_id = b.uuid " +
+                        "WHERE b.uuid = :bitstream_id " +
+                        "AND NOT EXISTS (SELECT 1 FROM preview2preview p2p WHERE pc.previewcontent_id = p2p.child_id)",
+                PreviewContent.class
         );
         query.setParameter("bitstream_id", bitstream.getID());
         query.setHint("org.hibernate.cacheable", Boolean.TRUE);

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -368,9 +368,9 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return addMetadataValue(item, "person", "email", null, email);
     }
 
-    public ItemBuilder withCCLicense(String uri) throws SQLException, AuthorizeException {
-        creativeCommonsService.updateLicense(context, uri, item);
-        return this;
+    public ItemBuilder withClarinLicense(String licenseName, String licenseUri) {
+        this.addMetadataValue(item, "dc", "rights", null, licenseName);
+        return this.addMetadataValue(item, "dc", "rights", "uri", licenseUri);
     }
 
     @Override

--- a/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/ClarinMatomoBitstreamTrackerTest.java
@@ -52,6 +52,7 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
     private static final String HANDLE = "123456789/1";
     private static final String BASE_URL = "http://example.com";
     private static final String LOCALHOST_URL = "http://localhost:4000";
+    private static final UUID ITEM_UUID = UUID.randomUUID();
 
     @Mock
     private ConfigurationService configurationService;
@@ -187,6 +188,7 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
         Item item = mock(Item.class);
         when(item.getHandle()).thenReturn(HANDLE);
         when(clarinItemService.findByBitstreamUUID(context, bitstreamId)).thenReturn(Collections.singletonList(item));
+        when(item.getID()).thenReturn(ITEM_UUID);
 
         MetadataValue metadataValue = mock(MetadataValue.class);
         when(metadataValue.getValue()).thenReturn("http://hdl.handle.net/" + HANDLE);
@@ -202,6 +204,7 @@ public class ClarinMatomoBitstreamTrackerTest extends AbstractDSpaceTest {
         MatomoRequest sentRequest = captor.getValue();
         assertNotNull(sentRequest);
         assertEquals(pageName, sentRequest.getActionName());
-        assertEquals("Action URL should match the request URL", expectedUrl, sentRequest.getDownloadUrl());
+        assertEquals("Action URL should match the request URL", expectedUrl, sentRequest.getActionUrl());
+        assertEquals("Item handle should be set as a dimension", HANDLE, sentRequest.getDimensions().get(1L));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleUploadBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleUploadBitstreamControllerIT.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,13 +27,20 @@ import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.test.AbstractEntityIntegrationTest;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.ClarinLicenseBuilder;
+import org.dspace.builder.ClarinLicenseLabelBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.content.clarin.ClarinLicense;
+import org.dspace.content.clarin.ClarinLicenseLabel;
+import org.dspace.content.service.clarin.ClarinLicenseLabelService;
+import org.dspace.content.service.clarin.ClarinLicenseService;
 import org.dspace.core.Constants;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -41,12 +49,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 public class BundleUploadBitstreamControllerIT extends AbstractEntityIntegrationTest {
 
     @Autowired
     private AuthorizeService authorizeService;
+
+    @Autowired
+    private ClarinLicenseLabelService clarinLicenseLabelService;
+
+    @Autowired
+    private ClarinLicenseService clarinLicenseService;
 
     @Test
     public void uploadBitstreamAllPossibleFieldsProperties() throws Exception {
@@ -385,6 +400,112 @@ public class BundleUploadBitstreamControllerIT extends AbstractEntityIntegration
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("_embedded.bitstreams", Matchers.hasItem(
                                 BitstreamMatcher.matchBitstreamEntry(UUID.fromString(bitstreamId), file.getSize()))));
+    }
+
+    @Test
+    public void uploadBitstreamToItemWithClarinLicense() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // create ClarinLicenseLabel
+        ClarinLicenseLabel firstCLicenseLabel = ClarinLicenseLabelBuilder.createClarinLicenseLabel(context).build();
+        firstCLicenseLabel.setLabel("PUB");
+        firstCLicenseLabel.setTitle("Publicly Available");
+        firstCLicenseLabel.setExtended(false);
+        clarinLicenseLabelService.update(context, firstCLicenseLabel);
+
+        // create ClarinLicense
+        ClarinLicense firstCLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
+        firstCLicense.setName("Apache License 2.0");
+        firstCLicense.setConfirmation(ClarinLicense.Confirmation.ASK_ALWAYS);
+        firstCLicense.setDefinition("http://opensource.org/licenses/Apache-2.0");
+
+        // add ClarinLicenseLabel to the ClarinLicense
+        firstCLicense.setLicenseLabels(Set.of(firstCLicenseLabel));
+        clarinLicenseService.update(context, firstCLicense);
+
+        context.setCurrentUser(admin);
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withClarinLicense("Apache License 2.0", "http://opensource.org/licenses/Apache-2.0")
+                .build();
+
+        Bundle bundle = BundleBuilder.createBundle(context, item)
+                .withName("ORIGINAL")
+                .build();
+
+        context.setCurrentUser(eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        String input = "Hello, World!";
+
+        MockMultipartFile file = new MockMultipartFile("file", "hello.txt", MediaType.TEXT_PLAIN_VALUE,
+                input.getBytes());
+
+        ObjectMapper mapper = new ObjectMapper();
+        BitstreamRest bitstreamRest = new BitstreamRest();
+        String properties = mapper.writeValueAsString(bitstreamRest);
+
+        context.restoreAuthSystemState();
+
+        // user has READ/WRITE/ADD permissions on item and bundle
+        authorizeService.addPolicy(context, bundle, Constants.ADD, eperson);
+        authorizeService.addPolicy(context, bundle, Constants.WRITE, eperson);
+        authorizeService.addPolicy(context, item, Constants.ADD, eperson);
+        authorizeService.addPolicy(context, item, Constants.WRITE, eperson);
+
+        uploadFileToBundle(token, bundle, file, properties)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bundleName", is("ORIGINAL")))
+                .andExpect(jsonPath("$.uuid", notNullValue())).andReturn();
+
+        // user has READ/WRITE/ADD permissions only on item
+        authorizeService.removeAllPolicies(context, bundle);
+
+        uploadFileToBundle(token, bundle, file, properties)
+                .andExpect(status().isForbidden());
+
+        // user has missing ADD permission on bundle
+        authorizeService.addPolicy(context, bundle, Constants.READ, eperson);
+        authorizeService.addPolicy(context, bundle, Constants.WRITE, eperson);
+
+        uploadFileToBundle(token, bundle, file, properties)
+                .andExpect(status().isForbidden());
+
+        // user has ADMIN permission on item
+        authorizeService.removeAllPolicies(context, bundle);
+        authorizeService.removeAllPolicies(context, item);
+        authorizeService.addPolicy(context, item, Constants.ADMIN, eperson);
+
+        uploadFileToBundle(token, bundle, file, properties)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bundleName", is("ORIGINAL")))
+                .andExpect(jsonPath("$.uuid", notNullValue())).andReturn();
+
+        getClient(token).perform(get("/api/core/bundles/" + bundle.getID() + "/bitstreams")
+                        .param("projection", "full"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(2)));
+    }
+
+    private ResultActions uploadFileToBundle(String token,
+                                             DSpaceObject bundle,
+                                             MockMultipartFile file,
+                                             String properties) throws Exception {
+        return getClient(token).perform(
+                MockMvcRequestBuilders.multipart("/api/core/bundles/" + bundle.getID() + "/bitstreams")
+                        .file(file)
+                        .param("properties", properties));
     }
 
     // TODO This test doesn't work either as it seems that only the first file is ever transfered into the request

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
@@ -98,7 +98,6 @@ public class ClarinWorkflowItemRestRepositoryIT extends AbstractControllerIntegr
                 .withIssueDate("2017-10-17")
                 .withAuthor("Doe, John")
                 .withSubject("ExtraEntry")
-                .withCCLicense("http://creativecommons.org/licenses/by-nc-sa/4.0/")
                 .build();
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -2806,8 +2806,17 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                     .withPassword("dspace")
                     .build();
 
-            Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName(colName)
-                    .withSubmitterGroup(submitter).build();
+            Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName(colName).build();
+
+            // here the submitter(EPerson) is not a direct member of the collection SUBMIT group
+            // but member of the "collection-submitters" group that is a subgroup of the SUBMIT group
+            Group submitGroup = GroupBuilder.createCollectionSubmitterGroup(context, col1).build();
+
+            GroupBuilder.createGroup(context)
+                    .withParent(submitGroup)
+                    .withName("collection-submitters")
+                    .addMember(submitter)
+                    .build();
 
             context.setCurrentUser(submitter);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
@@ -129,9 +129,18 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void findAllScriptsGenericLoggedInUserTest() throws Exception {
         String token = getAuthToken(eperson.getEmail(), password);
 
+        ScriptConfiguration<?> fileDownloaderScriptConfiguration =
+                scriptConfigurations.stream()
+                        .filter(scriptConfiguration
+                                -> scriptConfiguration.getName().equals("file-downloader"))
+                        .findAny().orElseThrow();
+
         getClient(token).perform(get("/api/system/scripts"))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.page.totalElements", is(0)));
+                        .andExpect(jsonPath("$.page.totalElements", is(1)))
+                        .andExpect(jsonPath("$._embedded.scripts", Matchers.hasItem(
+                                ScriptMatcher.matchScript(fileDownloaderScriptConfiguration.getName(),
+                                        fileDownloaderScriptConfiguration.getDescription()))));
     }
 
     @Test


### PR DESCRIPTION
This contains the following changes

- https://github.com/ufal/clarin-dspace/pull/1211 - The query should be faster like this
- https://github.com/ufal/clarin-dspace/pull/1209 - Track downloads as pageviews
- https://github.com/ufal/clarin-dspace/pull/1205 - Issue 1196: prevent error 500 for non admin user uploading file to bundle
- https://github.com/ufal/clarin-dspace/pull/1202 - Issue 1200: allow.edit.metadata property should also work for submitters that are members of collection SUBMIT subgroup 
- https://github.com/ufal/clarin-dspace/pull/1199 - Issue 1157: allow to access File Downloader for any authorized user
- acknowledgment of the funding project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new acknowledgment README file with logos and funding information.

- **Bug Fixes**
  - Improved authorization checks for bitstream actions, refining license confirmation logic.
  - Updated Matomo tracking to better handle bot requests and URL/action parameters.

- **Refactor**
  - Streamlined group membership checks for submitters.
  - Switched to native SQL for preview content queries, improving performance and accuracy.

- **Tests**
  - Enhanced and expanded test coverage for file downloading, bitstream uploads, and group membership scenarios.
  - Updated and added tests for Clarin license handling and Matomo tracking behavior.
  - Adjusted test expectations for script availability for logged-in users.

- **Chores**
  - Removed unused imports and legacy test methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->