### PR TITLE
UFAL/The process output is not displayed because of S3 direct download

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
@@ -47,6 +47,15 @@ public class BitstreamBuilder extends AbstractDSpaceObjectBuilder<Bitstream> {
         return builder.create(context, item, is);
     }
 
+    public static BitstreamBuilder createBitstream(Context context, Item item, InputStream is, boolean hasBundle)
+            throws SQLException, AuthorizeException, IOException {
+        BitstreamBuilder builder = new BitstreamBuilder(context);
+        if (hasBundle) {
+           return builder.create(context, item, is, true);
+        }
+        return builder.create(context, item, is, false);
+    }
+
     public static BitstreamBuilder createBitstream(Context context, Bundle bundle, InputStream is)
             throws SQLException, AuthorizeException, IOException {
         BitstreamBuilder builder = new BitstreamBuilder(context);
@@ -74,6 +83,19 @@ public class BitstreamBuilder extends AbstractDSpaceObjectBuilder<Bitstream> {
         Bundle originalBundle = getOriginalBundle(item);
 
         bitstream = bitstreamService.create(context, originalBundle, is);
+
+        return this;
+    }
+
+    private BitstreamBuilder create(Context context, Item item, InputStream is, boolean hasBundle)
+            throws SQLException, AuthorizeException, IOException {
+        if (hasBundle) {
+            return create(context, item, is);
+        }
+        this.context = context;
+        this.item = item;
+
+        bitstream = bitstreamService.create(context, is);
 
         return this;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static org.dspace.app.rest.utils.ContextUtil.obtainContext;
 import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID;
+import static org.dspace.core.Constants.CONTENT_BUNDLE_NAME;
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import java.io.IOException;
@@ -192,7 +193,7 @@ public class BitstreamRestController {
                     // not correctly downloaded and displayed in the UI when using presigned URLs. E.g., the
                     // process output.
                     boolean hasOriginalBundle = bit.getBundles().stream()
-                            .anyMatch(bundle -> "ORIGINAL".equals(bundle.getName()));
+                            .anyMatch(bundle -> CONTENT_BUNDLE_NAME.equals(bundle.getName()));
 
                     if (hasOriginalBundle) {
                         return redirectToS3DownloadUrl(httpHeaders, name, bit.getInternalId());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -184,11 +184,20 @@ public class BitstreamRestController {
             context.complete();
 
             boolean s3DirectDownload = configurationService.getBooleanProperty("s3.download.direct.enabled");
+
             //Send the data
             if (httpHeadersInitializer.isValid()) {
                 HttpHeaders httpHeaders = httpHeadersInitializer.initialiseHeaders();
                 if (s3DirectDownload) {
-                    return redirectToS3DownloadUrl(httpHeaders, name, bit.getInternalId());
+                    // Download only files which are stored in the `ORIGINAL` bundle, because some specific files are
+                    // not correctly downloaded and displayed in the UI when using presigned URLs. E.g., the
+                    // process output.
+                    boolean hasOriginalBundle = bit.getBundles().stream()
+                            .anyMatch(bundle -> "ORIGINAL".equals(bundle.getName()));
+
+                    if (hasOriginalBundle) {
+                        return redirectToS3DownloadUrl(httpHeaders, name, bit.getInternalId());
+                    }
                 }
 
                 if (RequestMethod.HEAD.name().equals(request.getMethod())) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -184,7 +184,6 @@ public class BitstreamRestController {
             context.complete();
 
             boolean s3DirectDownload = configurationService.getBooleanProperty("s3.download.direct.enabled");
-
             //Send the data
             if (httpHeadersInitializer.isValid()) {
                 HttpHeaders httpHeaders = httpHeadersInitializer.initialiseHeaders();


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download handling to ensure only files in the "ORIGINAL" bundle use S3 direct download links; other files are now served directly, preventing issues with certain file types.
- **New Features**
  - Added support for creating bitstreams with an explicit option to bypass bundle association.
- **Tests**
  - Added a test to confirm that files not in the "ORIGINAL" bundle are correctly served without S3 redirect when direct download is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->