### PR TITLE
UFAL/New type in data cite for doi

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
     Document   : DIM2DataCite.xsl
     Created on : January 23, 2013, 1:26 PM
@@ -11,9 +10,9 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
-		xmlns="http://datacite.org/schema/kernel-4"
+                xmlns="http://datacite.org/schema/kernel-4"
                 version="2.0">
-    
+
     <!-- CONFIGURATION -->
     <!-- The parameters prefix, publisher, datamanager and hostinginstitution
          moved to DSpace's configuration. They will be substituted automatically.
@@ -21,7 +20,7 @@
          Please take a look into the DSpace documentation for details on how to
          change those. -->
     <!-- DO NOT CHANGE ANYTHING BELOW THIS LINE EXCEPT YOU REALLY KNOW WHAT YOU ARE DOING! -->
-    
+
     <!-- We need the prefix to determine DOIs that were minted by ourself. -->
     <xsl:param name="prefix">10.5072/dspace-</xsl:param>
     <!-- The content of the following parameter will be used as element publisher. -->
@@ -32,12 +31,9 @@
     <xsl:param name="hostinginstitution"><xsl:value-of select="$publisher" /></xsl:param>
     <!-- Please take a look into the DataCite schema documentation if you want to know how to use these elements.
          http://schema.datacite.org -->
-
     <xsl:output method="xml" indent="yes" encoding="utf-8" />
-
     <!-- Don't copy everything by default! -->
     <xsl:template match="@* | text()" />
-
     <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
         <!--
             org.dspace.identifier.doi.DataCiteConnector uses this XSLT to
@@ -48,12 +44,10 @@
         -->
         <resource xmlns="http://datacite.org/schema/kernel-4"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.5/metadata.xsd">
-
+                  xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.5/metadata.xsd">
             <!--
                 MANDATORY PROPERTIES
             -->
-
             <!--
                 DataCite (1)
                 Template Call for DOI identifier.
@@ -61,16 +55,15 @@
             -->
             <!--
                 dc.identifier.uri may contain more than one DOI, e.g. if the
-                repository contains an item that is published by a publishing 
+                repository contains an item that is published by a publishing
                 company as well. We have to ensure to use URIs of our prefix
                 as primary identifiers only.
             -->
             <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and starts-with(., concat('http://dx.doi.org/', $prefix))]" />
             <!-- either that or it adds the identifier in org.dspace.identifier.doi.DataCiteConnector#addDOI  -->
-
             <!--
                 DataCite (2)
-                Add creator information. 
+                Add creator information.
                 Occ: 1-n
             -->
             <creators>
@@ -85,10 +78,9 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </creators>
-
             <!--
                 DataCite (3)
-                Add Title information. 
+                Add Title information.
 		Occ: 1-n
             -->
             <titles>
@@ -101,7 +93,6 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </titles>
-
             <!--
                 DataCite (4)
                 Add Publisher information from configuration above
@@ -118,7 +109,6 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:element>
-
             <!--
                 DataCite (5)
                 Add PublicationYear information
@@ -139,31 +129,27 @@
                     <xsl:otherwise>0000</xsl:otherwise>
                 </xsl:choose>
             </publicationYear>
-
             <!--
                 DataCite (10)
                 Template call for ResourceType
                 DataCite allows the ResourceType to ouccre not more than once.
             -->
             <xsl:call-template name="resourceType" />
-
             <!--
                 OPTIONAL PROPERTIES
             -->
-
             <!--
                 DataCite (6)
                 Template Call for subjects.
                 Occ: 0-n
                 Format: open
                 Attribute: subjectSchema (optional), schemeURI (optional)
-            -->  
+            -->
             <xsl:if test="//dspace:field[@mdschema='dc' and @element='subject']">
                 <subjects>
                     <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='subject']" />
                 </subjects>
             </xsl:if>
-
             <!--
                 DataCite (7)
                 Add contributorType from configuration above.
@@ -171,7 +157,7 @@
                 Occ: 0-n
                 Format: personal name: family, given
                 Required Attribute: contributorType - controlled list
-            --> 
+            -->
             <contributors>
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">DataManager</xsl:attribute>
@@ -188,42 +174,39 @@
                 <xsl:apply-templates select="//dspace:field[@mdschema='local' and @element='contact' and @qualifier='person']" />
                 <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'][not(@qualifier='author')]" />
             </contributors>
-
             <!--
                 DataCite (8)
                 Template Call for Dates
                 Occ: 0-n
                 Required Attribute: dataType - controlled list
-            --> 
-            <xsl:if test="//dspace:field[@mdschema='dc' and @element='date' and 
-                        (@qualifier='accessioned' 
-                         or @qualifier='available' 
-                         or @qualifier='copyright' 
-                         or @qualifier='created' 
-                         or @qualifier='issued' 
+            -->
+            <xsl:if test="//dspace:field[@mdschema='dc' and @element='date' and
+                        (@qualifier='accessioned'
+                         or @qualifier='available'
+                         or @qualifier='copyright'
+                         or @qualifier='created'
+                         or @qualifier='issued'
                          or @qualifier='submitted'
                          or @qualifier='updated')]" >
                 <xsl:element name="dates">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='date' and 
-                        (@qualifier='accessioned' 
-                         or @qualifier='available' 
-                         or @qualifier='copyright' 
-                         or @qualifier='created' 
-                         or @qualifier='issued' 
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='date' and
+                        (@qualifier='accessioned'
+                         or @qualifier='available'
+                         or @qualifier='copyright'
+                         or @qualifier='created'
+                         or @qualifier='issued'
                          or @qualifier='submitted'
                          or @qualifier='updated')]" />
                 </xsl:element>
             </xsl:if>
-
-            <!-- 
+            <!--
                 DataCite (9)
                 Templacte Call for Language
                 Occ: 0-1
                 Format: IETF BCP 47 or ISO 639-1
             -->
             <xsl:apply-templates select="(//dspace:field[@mdschema='dc' and @element='language' and (@qualifier='iso' or @qualifier='rfc3066')])[1]" />
-
-            <!-- 
+            <!--
                 DataCite (11)
                 Add alternativeIdentifiers.
                 This element is important as it is used to recognize for which
@@ -238,32 +221,28 @@
                     <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))] | //dspace:field[@mdschema='datacite' and @element='alternateIdentifier']" />
                 </xsl:element>
             </xsl:if>
-
             <xsl:if test="//dspace:field[@mdschema='datacite' and @element='relation' and @qualifier]">
                 <relatedIdentifiers>
                     <xsl:apply-templates select="//dspace:field[@mdschema='datacite' and @element='relation']" />
                 </relatedIdentifiers>
             </xsl:if>
-
             <!--
                 DataCite (12)
                 Add sizes.
             -->
-            <xsl:if test="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']">             
+            <xsl:if test="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']">
                 <xsl:element name="sizes">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']" />      
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']" />
                 </xsl:element>
             </xsl:if>
-
             <!-- DataCite (13)
                  Add formats.
             -->
             <xsl:if test="//dspace:field[@mdschema='dc' and @element='format'][not(@qualifier='extent')]">
                 <xsl:element name="formats">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format'][not(@qualifier='extent')]" />       
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format'][not(@qualifier='extent')]" />
                 </xsl:element>
             </xsl:if>
-
             <!--
                 DataCite (16)
                 Rights.
@@ -275,7 +254,6 @@
                     <xsl:call-template name="rights" />
                 </xsl:element>
             </xsl:if>
-
             <!--
                 DataCite (17)
                 Add descriptions.
@@ -287,7 +265,7 @@
                     <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='description' and (@qualifier='abstract' or @qualifier='tableofcontents' or not(@qualifier))]" />
                 </xsl:element>
             </xsl:if>
-            
+
             <!--
                 DataCite (18)
                 GeoLocation
@@ -295,25 +273,20 @@
             -->
             <xsl:if test="//dspace:field[@mdschema='dc' and @element='coverage' and @qualifier='spatial']">
                 <geoLocations>
-                        <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='coverage' and @qualifier='spatial']" />
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='coverage' and @qualifier='spatial']" />
                 </geoLocations>
             </xsl:if>
-
             <xsl:if test="//dspace:field[@mdschema='local' and @element='sponsor']">
                 <fundingReferences>
                     <xsl:apply-templates select="//dspace:field[@mdschema='local' and @element='sponsor']" />
                 </fundingReferences>
             </xsl:if>
-
-
         </resource>
     </xsl:template>
-
-
     <!-- Add doi identifier information. -->
     <!--
         dc.identifier.uri may contain more than one DOI, e.g. if the
-        repository contains an item that is published by a publishing 
+        repository contains an item that is published by a publishing
         company as well. We have to ensure to use URIs of our prefix
         as primary identifiers only.
     -->
@@ -322,7 +295,6 @@
             <xsl:value-of select="substring(., 19)"/>
         </identifier>
     </xsl:template>
-
     <!-- DataCite (2) :: Creator -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']">
         <creator>
@@ -336,15 +308,14 @@
             </xsl:if>
         </creator>
     </xsl:template>
-
     <!-- DataCite (3) :: Title -->
     <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
         <xsl:element name="title">
             <xsl:if test="@qualifier='alternative'">
                 <xsl:attribute name="titleType">AlternativeTitle</xsl:attribute>
             </xsl:if>
-            <!-- DSpace does include niehter a dc.title.subtitle nor a 
-                 dc.title.translated. If necessary, please create those in the 
+            <!-- DSpace does include niehter a dc.title.subtitle nor a
+                 dc.title.translated. If necessary, please create those in the
                  metadata field registry. -->
             <xsl:if test="@qualifier='subtitle'">
                 <xsl:attribute name="titleType">Subtitle</xsl:attribute>
@@ -355,11 +326,9 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (6), DataCite (6.1)
         Adds subject and subjectScheme information
-
         "This term is intended to be used with non-literal values as defined in the
         DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).
         As of December 2007, the DCMI Usage Board is seeking a way to express
@@ -374,14 +343,13 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (7), DataCite (7.1)
         Adds contributor and contributorType information
     -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor'][not(@qualifier='author')]">
         <xsl:choose>
-            <xsl:when test="@qualifier='editor'"> 
+            <xsl:when test="@qualifier='editor'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Editor</xsl:attribute>
                     <contributorName>
@@ -389,7 +357,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="@qualifier='advisor'"> 
+            <xsl:when test="@qualifier='advisor'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">RelatedPerson</xsl:attribute>
                     <contributorName>
@@ -397,7 +365,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="@qualifier='illustrator'"> 
+            <xsl:when test="@qualifier='illustrator'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
@@ -405,7 +373,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="@qualifier='other'"> 
+            <xsl:when test="@qualifier='other'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
@@ -413,7 +381,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="not(@qualifier)"> 
+            <xsl:when test="not(@qualifier)">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
@@ -435,24 +403,23 @@
             </affiliation>
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (8), DataCite (8.1)
         Adds Date and dateType information
     -->
-    <xsl:template match="//dspace:field[@mdschema='dc' and @element='date' and 
-                        (@qualifier='accessioned' 
-                         or @qualifier='available' 
-                         or @qualifier='copyright' 
-                         or @qualifier='created' 
-                         or @qualifier='issued' 
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='date' and
+                        (@qualifier='accessioned'
+                         or @qualifier='available'
+                         or @qualifier='copyright'
+                         or @qualifier='created'
+                         or @qualifier='issued'
                          or @qualifier='submitted'
                          or @qualifier='updated')]">
-    	<xsl:if test="@qualifier='accessioned' 
-                        or @qualifier='available' 
-                        or @qualifier='copyright' 
-                        or @qualifier='created' 
-                        or @qualifier='issued' 
+        <xsl:if test="@qualifier='accessioned'
+                        or @qualifier='available'
+                        or @qualifier='copyright'
+                        or @qualifier='created'
+                        or @qualifier='issued'
                         or @qualifier='submitted'
                         or @qualifier='updated'">
             <xsl:element name="date">
@@ -472,7 +439,7 @@
                     <xsl:attribute name="dateType">Issued</xsl:attribute>
                 </xsl:if>
                 <!-- DSpace recommends to use dc.date.submitted for theses and/or
-                     dissertations. DataCite uses submitted for the "date the 
+                     dissertations. DataCite uses submitted for the "date the
                      creator submits the resource to the publisher". -->
                 <xsl:if test="@qualifier='submitted'">
                     <xsl:attribute name="dateType">Issued</xsl:attribute>
@@ -480,11 +447,10 @@
                 <xsl:if test="@qualifier='updated'">
                     <xsl:attribute name="dateType">Updated</xsl:attribute>
                 </xsl:if>
-	    	<xsl:value-of select="substring(., 1, 10)" />
+                <xsl:value-of select="substring(., 1, 10)" />
             </xsl:element>
-	</xsl:if>
+        </xsl:if>
     </xsl:template>
-
     <!--
         DataCite (9)
         Adds Language information
@@ -502,7 +468,6 @@
             </xsl:choose>
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (10), DataCite (10.1)
         Adds resourceType and resourceTypeGeneral information
@@ -511,6 +476,8 @@
         <xsl:choose>
             <xsl:when test="//dspace:field[@mdschema='dc' and @element='type'][1]">
                 <xsl:variable name="types" select="tokenize(//dspace:field[@mdschema='dc' and @element='type'][1]/text(),';')"/>
+
+                <!-- Check if the type is 'corpus' and handle it explicitly -->
                 <xsl:variable name="typeValue" select="$types[1]" />
                 <xsl:choose>
                     <xsl:when test="$typeValue = 'corpus'">
@@ -547,12 +514,6 @@
                         </xsl:element>
                     </xsl:otherwise>
                 </xsl:choose>
-                <xsl:element name="resourceType">
-                    <xsl:attribute name="resourceTypeGeneral">
-                        <xsl:value-of select="$types[1]"/>
-                    </xsl:attribute>
-                    <xsl:value-of select="$types[2]" />
-                </xsl:element>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:element name="resourceType">
@@ -562,12 +523,10 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-
     <!--
         DataCite (11), DataCite (11.1)
         Adds AlternativeIdentifier and alternativeIdentifierType information
         Adds all identifiers except the doi.
-
         This element is important as it is used to recognize for which DSpace
         objet a DOI is reserved for. The DataCiteConnector will test all
         AlternativeIdentifiers by using HandleManager.
@@ -582,7 +541,6 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-
     <xsl:template match="//dspace:field[@mdschema='datacite' and @element='alternateIdentifier']">
         <xsl:variable name="arr" select="tokenize(., ';')" />
         <xsl:element name="alternateIdentifier">
@@ -590,7 +548,6 @@
             <xsl:value-of select="$arr[2]" />
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (12), DataCite (12.1)
         Adds RelatedIdentifier and relatedIdentifierType information
@@ -629,7 +586,6 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (13)
         Adds Size information
@@ -639,7 +595,6 @@
             <xsl:value-of select="translate(., ';', ' ')" />
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (14)
         Adds Format information
@@ -650,14 +605,13 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-    
+
     <!--
         DataCite (15)
         Version information.
         As we currently do not link versions as related identifier, we skip
         the version information too.
     -->
-
     <!--
         DataCite (16)
         Adds Rights information
@@ -672,7 +626,6 @@
             <xsl:value-of select="//dspace:field[@mdschema='dc' and @element='rights' and not(@qualifier)]" />
         </rights>
     </xsl:template>
-
     <!--
         DataCite (17)
         Description
@@ -680,16 +633,15 @@
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='description' and (@qualifier='abstract' or @qualifier='tableofcontents' or not(@qualifier))]">
         <xsl:element name="description">
             <xsl:attribute name="descriptionType">
-           	<xsl:choose>
+                <xsl:choose>
                     <xsl:when test="@qualifier='abstract'">Abstract</xsl:when>
                     <xsl:when test="@qualifier='tableofcontents'">TableOfContents</xsl:when>
-               	    <xsl:otherwise>Other</xsl:otherwise>
+                    <xsl:otherwise>Other</xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (18)
         GeoLocation
@@ -701,7 +653,6 @@
             </geoLocationPlace>
         </xsl:element>
     </xsl:template>
-
     <!--
         DataCite (19)
         FundingReferences
@@ -720,5 +671,4 @@
             <awardTitle><xsl:value-of select="$arr[4]" /></awardTitle>
         </fundingReference>
     </xsl:template>
-
 </xsl:stylesheet>

--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -511,6 +511,42 @@
         <xsl:choose>
             <xsl:when test="//dspace:field[@mdschema='dc' and @element='type'][1]">
                 <xsl:variable name="types" select="tokenize(//dspace:field[@mdschema='dc' and @element='type'][1]/text(),';')"/>
+                <xsl:variable name="typeValue" select="$types[1]" />
+                <xsl:choose>
+                    <xsl:when test="$typeValue = 'corpus'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'corpus'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test="$typeValue = 'lexicalConceptualResource'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'lexicalConceptualResource'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test="$typeValue = 'languageDescription'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'languageDescription'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test="$typeValue = 'toolService'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'toolService'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <!-- If the type is not one of the new ones, proceed with other predefined types -->
+                    <xsl:otherwise>
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">
+                                <xsl:value-of select="$types[1]"/>
+                            </xsl:attribute>
+                            <xsl:value-of select="$types[2]" />
+                        </xsl:element>
+                    </xsl:otherwise>
+                </xsl:choose>
                 <xsl:element name="resourceType">
                     <xsl:attribute name="resourceTypeGeneral">
                         <xsl:value-of select="$types[1]"/>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Since we define the type of resource when an item is created, if we want to enable DOI functionality, we need to add these types to DataCite.
Please divide PR [#883](https://github.com/dataquest-dev/DSpace/pull/883/files#diff-7e58ca80d450c8e6e21a459019fa6c989921bd80154339f9f66f59c0e75b3aea) into two separate PRs:
The first should contain the general changes.
The second should include only the changes necessary for enabling DOI support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of specific resource types ("corpus", "lexicalConceptualResource", "languageDescription", "toolService") to ensure they are correctly represented in exported metadata.
- **Chores**
  - Updated logic to better map resource type values without affecting existing functionality for other types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->