### PR TITLE
UFAL/Resource type to Data Cite DOI

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -511,12 +511,42 @@
         <xsl:choose>
             <xsl:when test="//dspace:field[@mdschema='dc' and @element='type'][1]">
                 <xsl:variable name="types" select="tokenize(//dspace:field[@mdschema='dc' and @element='type'][1]/text(),';')"/>
-                <xsl:element name="resourceType">
-                    <xsl:attribute name="resourceTypeGeneral">
-                        <xsl:value-of select="$types[1]"/>
-                    </xsl:attribute>
-                    <xsl:value-of select="$types[2]" />
-                </xsl:element>
+                <xsl:variable name="typeValue" select="$types[1]" />
+                <xsl:choose>
+                    <xsl:when test="$typeValue = 'corpus'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'corpus'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test="$typeValue = 'lexicalConceptualResource'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'lexicalConceptualResource'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test="$typeValue = 'languageDescription'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'languageDescription'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test="$typeValue = 'toolService'">
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                            <xsl:value-of select="'toolService'"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <!-- If the type is not one of the new ones, proceed with other predefined types -->
+                    <xsl:otherwise>
+                        <xsl:element name="resourceType">
+                            <xsl:attribute name="resourceTypeGeneral">
+                                <xsl:value-of select="$types[1]"/>
+                            </xsl:attribute>
+                            <xsl:value-of select="$types[2]" />
+                        </xsl:element>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:element name="resourceType">


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Since we define the type of resource when an item is created, if we want to enable DOI functionality, we need to add these types to DataCite.
Please divide PR [#883](https://github.com/dataquest-dev/DSpace/pull/883/files#diff-7e58ca80d450c8e6e21a459019fa6c989921bd80154339f9f66f59c0e75b3aea) into two separate PRs:
The first should contain the general changes.
The second should include only the changes necessary for enabling DOI support.

