### PR TITLE
UFAL/Configuration for DOI

### DIFF
--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -231,7 +231,7 @@ event.consumer.doi.filters = Item+Modify_Metadata
 # Adding doi here makes DSpace send metadata updates to your doi registration agency.
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
-event.dispatcher.default.consumers = versioning, discovery, eperson
+event.dispatcher.default.consumers = versioning, discovery, eperson, doi
 
 # Edit Item - Status option
 identifiers.item-status.register-doi = false

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -56,7 +56,7 @@
         <property name="filter" ref="doi-filter" />
     </bean>
     -->
-    <!--
+
     <bean id="org.dspace.identifier.DOIIdentifierProvider"
         class="org.dspace.identifier.VersionedDOIIdentifierProvider"
         scope="singleton">
@@ -65,7 +65,6 @@
         <property name="DOIConnector"
             ref="org.dspace.identifier.doi.DOIConnector" />
     </bean>
-    -->
 
     <!-- An optional logical item filter can be included in provider configuration based
     on the filters defined in item-filters.xml, eg. -->
@@ -90,7 +89,7 @@
          e.g. EZID is part of DataCite but provides their own APIs. The following
          DataCiteConnector won't work if EZID is your registration agency.
     -->
-    <!-- Uncomment this to use the DataCite API directly as DOIConnector.
+    <!-- Uncomment this to use the DataCite API directly as DOIConnector.-->
     <bean id="org.dspace.identifier.doi.DOIConnector"
         class="org.dspace.identifier.doi.DataCiteConnector"
         scope="singleton">
@@ -100,7 +99,6 @@
         <property name='DATACITE_METADATA_PATH' value='/metadata/' />
         <property name='disseminationCrosswalkName' value="DataCite" />
     </bean>
-    -->
 
     <!-- Provider to mint and register DOIs using EZID as the registrar.
     -->


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The DOI identifier is not allowed by configs. Allow it based on https://wiki.lyrasis.org/display/DSDOC7x/DOI+Digital+Object+Identifier#DOIDigitalObjectIdentifier-CommandLineInterface. Create cron job for registration and metadata creating.
For it to work, changes from this PR also need to be applied: https://github.com/dataquest-dev/DSpace/pull/975


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enabled processing of DOI-related events in the default event dispatcher configuration.
  - Activated the DOI identifier provider in the system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->