### PR TITLE
Check if type is html

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -107,7 +107,8 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                 String url = previewContentService.composePreviewURL(context, item, bitstream, contextPath);
                 List<FileInfo> fileInfos = new ArrayList<>();
                 boolean canPreview = previewContentService.canPreview(context, bitstream);
-                if (canPreview) {
+                String mimeType = bitstream.getFormat(context).getMIMEType();
+                if (Objects.equals("text/html", mimeType) || canPreview) {
                     try {
                         List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
                         // Generate new content if we didn't find any

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -121,7 +121,8 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                                 // Do not store HTML content in the database because it could be longer than the limit
                                 // of the database column
                                 if (!fileInfos.isEmpty() &&
-                                    !StringUtils.equals(TEXT_HTML_MIME_TYPE, bitstream.getFormat(context).getMIMEType())) {
+                                    !StringUtils.equals(TEXT_HTML_MIME_TYPE,
+                                            bitstream.getFormat(context).getMIMEType())) {
                                     for (FileInfo fi : fileInfos) {
                                         previewContentService.createPreviewContent(context, bitstream, fi);
                                     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -109,7 +109,9 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                 List<FileInfo> fileInfos = new ArrayList<>();
                 boolean canPreview = previewContentService.canPreview(context, bitstream);
                 String mimeType = bitstream.getFormat(context).getMIMEType();
-                if ((mimeType != null && mimeType.startsWith("text/html")) || canPreview) {
+                // HTML content could be longer than the limit, so we do not store it in the DB.
+                // It has to be generated even if properties is false.
+                if (StringUtils.equals(mimeType, TEXT_HTML_MIME_TYPE) || canPreview) {
                     try {
                         List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
                         // Generate new content if we didn't find any

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Component;
 @Component(MetadataBitstreamWrapperRest.CATEGORY + "." + MetadataBitstreamWrapperRest.NAME)
 public class MetadataBitstreamRestRepository extends DSpaceRestRepository<MetadataBitstreamWrapperRest, Integer> {
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataBitstreamRestRepository.class);
+    private static String TEXT_HTML_MIME_TYPE = "text/html";
 
     @Autowired
     HandleService handleService;
@@ -108,7 +109,7 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                 List<FileInfo> fileInfos = new ArrayList<>();
                 boolean canPreview = previewContentService.canPreview(context, bitstream);
                 String mimeType = bitstream.getFormat(context).getMIMEType();
-                if (Objects.equals("text/html", mimeType) || canPreview) {
+                if ((mimeType != null && mimeType.startsWith("text/html")) || canPreview) {
                     try {
                         List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);
                         // Generate new content if we didn't find any
@@ -120,7 +121,7 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                                 // Do not store HTML content in the database because it could be longer than the limit
                                 // of the database column
                                 if (!fileInfos.isEmpty() &&
-                                    !StringUtils.equals("text/html", bitstream.getFormat(context).getMIMEType())) {
+                                    !StringUtils.equals(TEXT_HTML_MIME_TYPE, bitstream.getFormat(context).getMIMEType())) {
                                     for (FileInfo fi : fileInfos) {
                                         previewContentService.createPreviewContent(context, bitstream, fi);
                                     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -110,7 +110,7 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
                 boolean canPreview = previewContentService.canPreview(context, bitstream);
                 String mimeType = bitstream.getFormat(context).getMIMEType();
                 // HTML content could be longer than the limit, so we do not store it in the DB.
-                // It has to be generated even if properties is false.
+                // It has to be generated even if property is false.
                 if (StringUtils.equals(mimeType, TEXT_HTML_MIME_TYPE) || canPreview) {
                     try {
                         List<PreviewContent> prContents = previewContentService.hasPreview(context, bitstream);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -218,7 +218,7 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileSize")
                         .value(hasItem(is((int) bitstream.getSizeBytes()))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].canPreview")
-                        .value(Matchers.containsInAnyOrder(Matchers.is(canPreview))))
+                        .value(Matchers.containsInAnyOrder(Matchers.is(true))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileInfo").exists())
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].checksum")
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(bitstream.getChecksum()))));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -173,6 +173,56 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
     }
 
     @Test
+    public void previewingIsDisabledByCfgForHtml() throws Exception {
+        boolean canPreview = configurationService.getBooleanProperty("file.preview.enabled", true);
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
+        Item item = ItemBuilder.createItem(context, col)
+                .withAuthor(AUTHOR)
+                .build();
+
+        // create empty THUMBNAIL bundle
+        bundleService.create(context, item, "THUMBNAIL");
+
+        String bitstreamContent = "ThisIsSomeDummyText";
+        InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8);
+        Bitstream bitstream = BitstreamBuilder.
+                createBitstream(context, item, is)
+                .withName("Bitstream")
+                .withDescription("Description")
+                .withMimeType("text/html")
+                .build();
+        // Disable previewing
+        configurationService.setProperty("file.preview.enabled", false);
+        // There is no restriction, so the user could preview the file
+        getClient().perform(get(METADATABITSTREAM_SEARCH_BY_HANDLE_ENDPOINT)
+                        .param("handle", item.getHandle())
+                        .param("fileGrpType", FILE_GRP_TYPE))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams").exists())
+                .andExpect(jsonPath("$._embedded.metadatabitstreams").isArray())
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].name")
+                        .value(Matchers.containsInAnyOrder(Matchers.containsString("Bitstream"))))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].description")
+                        .value(Matchers.containsInAnyOrder(
+                                Matchers.containsString(bitstream.getFormatDescription(context)))))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].format")
+                        .value(Matchers.containsInAnyOrder(Matchers.containsString(
+                                bitstream.getFormat(context).getMIMEType()))))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileSize")
+                        .value(hasItem(is((int) bitstream.getSizeBytes()))))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].canPreview")
+                        .value(Matchers.containsInAnyOrder(Matchers.is(false))))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileInfo").exists())
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].checksum")
+                        .value(Matchers.containsInAnyOrder(Matchers.containsString(bitstream.getChecksum()))))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].href")
+                        .value(Matchers.containsInAnyOrder(Matchers.containsString(url))));
+
+        configurationService.setProperty("file.preview.enabled", canPreview);
+    }
+
+    @Test
     public void findByHandleEmptyFileGrpType() throws Exception {
         getClient().perform(get(METADATABITSTREAM_SEARCH_BY_HANDLE_ENDPOINT)
                 .param("handle", publicItem.getHandle())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -34,6 +34,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.service.BundleService;
+import org.dspace.content.service.PreviewContentService;
 import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
 import org.dspace.core.Constants;
 import org.dspace.services.ConfigurationService;
@@ -64,6 +65,9 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
 
     @Autowired
     ConfigurationService configurationService;
+
+    @Autowired
+    PreviewContentService previewContentService;
 
     @Before
     public void setup() throws Exception {
@@ -168,14 +172,15 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(bts.getChecksum()))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].href")
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(url))));
-
+        assert (previewContentService.hasPreview(context, bts).isEmpty());
         configurationService.setProperty("file.preview.enabled", canPreview);
     }
 
     @Test
     public void previewingIsDisabledByCfgForHtml() throws Exception {
         boolean canPreview = configurationService.getBooleanProperty("file.preview.enabled", true);
-        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
+        context.turnOffAuthorisationSystem();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection2").build();
         Item item = ItemBuilder.createItem(context, col)
                 .withAuthor(AUTHOR)
                 .build();
@@ -191,6 +196,7 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                 .withDescription("Description")
                 .withMimeType("text/html")
                 .build();
+        context.restoreAuthSystemState();
         // Disable previewing
         configurationService.setProperty("file.preview.enabled", false);
         // There is no restriction, so the user could preview the file
@@ -215,10 +221,7 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                         .value(Matchers.containsInAnyOrder(Matchers.is(false))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileInfo").exists())
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].checksum")
-                        .value(Matchers.containsInAnyOrder(Matchers.containsString(bitstream.getChecksum()))))
-                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].href")
-                        .value(Matchers.containsInAnyOrder(Matchers.containsString(url))));
-
+                        .value(Matchers.containsInAnyOrder(Matchers.containsString(bitstream.getChecksum()))));
         configurationService.setProperty("file.preview.enabled", canPreview);
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -11,6 +11,7 @@ import static org.dspace.app.rest.utils.Utils.DEFAULT_PAGE_SIZE;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -172,8 +173,9 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(bts.getChecksum()))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].href")
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(url))));
-        assert (previewContentService.hasPreview(context, bts).isEmpty());
+        assertTrue(previewContentService.hasPreview(context, bts).isEmpty());
         configurationService.setProperty("file.preview.enabled", canPreview);
+        context.restoreAuthSystemState();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -218,10 +218,12 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileSize")
                         .value(hasItem(is((int) bitstream.getSizeBytes()))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].canPreview")
-                        .value(Matchers.containsInAnyOrder(Matchers.is(false))))
+                        .value(Matchers.containsInAnyOrder(Matchers.is(canPreview))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileInfo").exists())
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].checksum")
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(bitstream.getChecksum()))));
+        ItemBuilder.deleteItem(item.getID());
+        CollectionBuilder.deleteCollection(col.getID());
         configurationService.setProperty("file.preview.enabled", canPreview);
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -218,7 +218,7 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileSize")
                         .value(hasItem(is((int) bitstream.getSizeBytes()))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].canPreview")
-                        .value(Matchers.containsInAnyOrder(Matchers.is(true))))
+                        .value(Matchers.containsInAnyOrder(Matchers.is(false))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].fileInfo").exists())
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].checksum")
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(bitstream.getChecksum()))));


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem Description
When the preview-generation configuration property is set to false, file previews are not created. However, in the case of large HTML files, the preview content may exceed database limits, preventing it from being saved. Consequently, the preview is never generated or available.

## Proposed Solution
Allow preview generation for HTML files regardless of the preview-generation configuration setting, to ensure the preview is at least created even if it cannot be stored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preview content is now generated for files with the "text/html" format, expanding support for HTML file previews.
- **Bug Fixes**
  - Improved handling of preview availability when previewing is disabled via configuration, ensuring accurate metadata display for HTML bitstreams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->