### PR TITLE
UFAL/Added date to title when creating new version

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DefaultItemVersionProvider extends AbstractVersionProvider implements ItemVersionProvider {
 
     Logger log = org.apache.logging.log4j.LogManager.getLogger(DefaultItemVersionProvider.class);
+    private static final String UNTITLED = "Untitled"; // Default title for items without a name
 
     @Autowired(required = true)
     protected WorkspaceItemService workspaceItemService;
@@ -135,7 +136,7 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
             String formattedDate = LocalDate.now().format(formatter);
             String itemName = itemNew.getName();
             if (itemName == null) {
-                itemName = "Untitled";
+                itemName = UNTITLED;
             }
             String titleWithDate = itemName + " (" + formattedDate + ")";
             // Set the item's title with the formatted date appended

--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -9,8 +9,8 @@ package org.dspace.versioning;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
@@ -131,8 +131,8 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
             // are added to the previous item in the VersionRestRepository.
             manageRelationMetadata(c, itemNew, previousItem);
 
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-            String formattedDate = formatter.format(new Date(System.currentTimeMillis()));
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            String formattedDate = LocalDate.now().format(formatter);
             String itemName = itemNew.getName();
             if (itemName == null) {
                 itemName = "Untitled";

--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -131,9 +131,8 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
             // are added to the previous item in the VersionRestRepository.
             manageRelationMetadata(c, itemNew, previousItem);
 
-            Date date = new Date();
             SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-            String formattedDate = formatter.format(date);
+            String formattedDate = formatter.format(new Date(System.currentTimeMillis()));
             String itemName = itemNew.getName();
             if (itemName == null) {
                 itemName = "Untitled";

--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -9,12 +9,15 @@ package org.dspace.versioning;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.Relationship;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.RelationshipService;
@@ -127,6 +130,15 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
             // Add metadata `dc.relation.replaces` to the new item. The metadata `dc.relation.isreplacedby`
             // are added to the previous item in the VersionRestRepository.
             manageRelationMetadata(c, itemNew, previousItem);
+
+            // Set title to Name (YYYY-MM-DD)
+            Date date = new Date();
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            String formattedDate = formatter.format(date);
+            // Set the item's title with the formatted date appended
+            String titleWithDate = itemNew.getName() + " (" + formattedDate + ")";
+            itemService.setMetadataSingleValue(c, itemNew, MetadataSchemaEnum.DC.getName(),
+                    "title", null, Item.ANY, titleWithDate);
 
             itemService.update(c, itemNew);
             return itemNew;

--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -131,12 +131,15 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
             // are added to the previous item in the VersionRestRepository.
             manageRelationMetadata(c, itemNew, previousItem);
 
-            // Set title to Name (YYYY-MM-DD)
             Date date = new Date();
             SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
             String formattedDate = formatter.format(date);
+            String itemName = itemNew.getName();
+            if (itemName == null) {
+                itemName = "Untitled";
+            }
+            String titleWithDate = itemName + " (" + formattedDate + ")";
             // Set the item's title with the formatted date appended
-            String titleWithDate = itemNew.getName() + " (" + formattedDate + ")";
             itemService.setMetadataSingleValue(c, itemNew, MetadataSchemaEnum.DC.getName(),
                     "title", null, Item.ANY, titleWithDate);
 

--- a/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
@@ -2118,7 +2118,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 //////////////////
                 // create items //
                 //////////////////
-
+                String person3itemDate = "person 3 (item) (" + formattedDate + ")";
                 // person 1.1
                 Item pe1_1 = ItemBuilder.createItem(context, collection)
                     .withTitle("person 1 (item)")
@@ -2400,7 +2400,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs5.get(1).getPlace());
 
                 assertTrue(mdvs5.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs5.get(2).getValue());
+                assertEquals(person3itemDate, mdvs5.get(2).getValue());
                 assertEquals(2, mdvs5.get(2).getPlace());
 
                 assertFalse(mdvs5.get(3) instanceof RelationshipMetadataValue);
@@ -2442,7 +2442,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs6.get(1).getPlace());
 
                 assertTrue(mdvs6.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs6.get(2).getValue());
+                assertEquals(person3itemDate, mdvs6.get(2).getValue());
                 assertEquals(2, mdvs6.get(2).getPlace());
 
                 ////////////////////////////////////////////////
@@ -2515,7 +2515,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs8.get(1).getPlace());
 
                 assertTrue(mdvs8.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs8.get(2).getValue());
+                assertEquals(person3itemDate, mdvs8.get(2).getValue());
                 assertEquals(2, mdvs8.get(2).getPlace());
 
                 assertFalse(mdvs8.get(3) instanceof RelationshipMetadataValue);
@@ -2620,7 +2620,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs10.get(1).getPlace());
 
                 assertTrue(mdvs10.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs10.get(2).getValue());
+                assertEquals(person3itemDate, mdvs10.get(2).getValue());
                 assertEquals(2, mdvs10.get(2).getPlace());
 
                 assertFalse(mdvs10.get(3) instanceof RelationshipMetadataValue);
@@ -2663,7 +2663,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs11.get(1).getPlace());
 
                 assertTrue(mdvs11.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs11.get(2).getValue());
+                assertEquals(person3itemDate, mdvs11.get(2).getValue());
                 assertEquals(2, mdvs11.get(2).getPlace());
 
                 ////////////////////////////////////////
@@ -2829,7 +2829,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs15.get(1).getPlace());
 
                 assertTrue(mdvs15.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs15.get(2).getValue());
+                assertEquals(person3itemDate, mdvs15.get(2).getValue());
                 assertEquals(2, mdvs15.get(2).getPlace());
 
                 assertFalse(mdvs15.get(3) instanceof RelationshipMetadataValue);
@@ -2872,7 +2872,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs16.get(1).getPlace());
 
                 assertTrue(mdvs16.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs16.get(2).getValue());
+                assertEquals(person3itemDate, mdvs16.get(2).getValue());
                 assertEquals(2, mdvs16.get(2).getPlace());
 
                 ////////////////////////////////////////

--- a/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
@@ -28,9 +28,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,8 +196,8 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
             .withCopyToRight(false)
             .build();
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        formattedDate = formatter.format(new Date(System.currentTimeMillis()));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        formattedDate = LocalDate.now().format(formatter);
     }
 
     protected Relationship getRelationship(

--- a/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
@@ -196,9 +196,8 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
             .withCopyToRight(false)
             .build();
 
-        Date date = new Date();
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        formattedDate = formatter.format(date);
+        formattedDate = formatter.format(new Date(System.currentTimeMillis()));
     }
 
     protected Relationship getRelationship(

--- a/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
@@ -28,7 +28,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +85,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         DSpaceServicesFactory.getInstance().getServiceManager().getServicesByType(SolrSearchCore.class).get(0);
     protected Community community;
     protected Collection collection;
+    protected String formattedDate;
     protected EntityType publicationEntityType;
     protected EntityType personEntityType;
     protected EntityType projectEntityType;
@@ -192,6 +195,10 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
             .withCopyToLeft(false)
             .withCopyToRight(false)
             .build();
+
+        Date date = new Date();
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        formattedDate = formatter.format(date);
     }
 
     protected Relationship getRelationship(
@@ -2394,7 +2401,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs5.get(1).getPlace());
 
                 assertTrue(mdvs5.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item)", mdvs5.get(2).getValue());
+                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs5.get(2).getValue());
                 assertEquals(2, mdvs5.get(2).getPlace());
 
                 assertFalse(mdvs5.get(3) instanceof RelationshipMetadataValue);
@@ -2436,7 +2443,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs6.get(1).getPlace());
 
                 assertTrue(mdvs6.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item)", mdvs6.get(2).getValue());
+                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs6.get(2).getValue());
                 assertEquals(2, mdvs6.get(2).getPlace());
 
                 ////////////////////////////////////////////////
@@ -2509,7 +2516,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs8.get(1).getPlace());
 
                 assertTrue(mdvs8.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item)", mdvs8.get(2).getValue());
+                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs8.get(2).getValue());
                 assertEquals(2, mdvs8.get(2).getPlace());
 
                 assertFalse(mdvs8.get(3) instanceof RelationshipMetadataValue);
@@ -2614,7 +2621,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs10.get(1).getPlace());
 
                 assertTrue(mdvs10.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item)", mdvs10.get(2).getValue());
+                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs10.get(2).getValue());
                 assertEquals(2, mdvs10.get(2).getPlace());
 
                 assertFalse(mdvs10.get(3) instanceof RelationshipMetadataValue);
@@ -2657,7 +2664,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs11.get(1).getPlace());
 
                 assertTrue(mdvs11.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item)", mdvs11.get(2).getValue());
+                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs11.get(2).getValue());
                 assertEquals(2, mdvs11.get(2).getPlace());
 
                 ////////////////////////////////////////
@@ -2823,7 +2830,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs15.get(1).getPlace());
 
                 assertTrue(mdvs15.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item)", mdvs15.get(2).getValue());
+                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs15.get(2).getValue());
                 assertEquals(2, mdvs15.get(2).getPlace());
 
                 assertFalse(mdvs15.get(3) instanceof RelationshipMetadataValue);
@@ -2866,7 +2873,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 assertEquals(1, mdvs16.get(1).getPlace());
 
                 assertTrue(mdvs16.get(2) instanceof RelationshipMetadataValue);
-                assertEquals("person 3 (item)", mdvs16.get(2).getValue());
+                assertEquals("person 3 (item) (" + formattedDate + ")", mdvs16.get(2).getValue());
                 assertEquals(2, mdvs16.get(2).getPlace());
 
                 ////////////////////////////////////////

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
@@ -1132,7 +1132,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
         //       this implies the relation.* fields change so the relevant items should be re-indexed
 
         context.turnOffAuthorisationSystem();
-
+        String publication1date = "publication 1 (" + formattedDate + ")";
         EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication")
             .build();
 
@@ -1362,7 +1362,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -1531,7 +1531,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -1540,7 +1540,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -1699,7 +1699,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -1708,7 +1708,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
     }
@@ -1719,7 +1719,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
         //       this implies the relation.* fields change so the relevant items should be re-indexed
 
         context.turnOffAuthorisationSystem();
-
+        String publication1date = "publication 1 (" + formattedDate + ")";
         EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication")
             .build();
 
@@ -1949,7 +1949,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -2125,7 +2125,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -2134,7 +2134,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -2293,7 +2293,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
 
@@ -2302,7 +2302,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
+                matchSearchResult(pub1_2, publication1date)
             )
         );
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
@@ -25,6 +25,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang3.function.FailableFunction;
@@ -80,7 +82,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * Some discovery configurations should show all versions, while others should only consider the latest versions.
  */
 public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
-
     @Autowired
     private SearchService searchService;
 
@@ -103,6 +104,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
     private RelationshipService relationshipService;
 
     protected Community community;
+    private String formattedDate;
 
     @Override
     @Before
@@ -116,6 +118,10 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             .build();
 
         context.restoreAuthSystemState();
+
+        Date date = new Date();
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        formattedDate = formatter.format(date);
     }
 
     @Override
@@ -1357,7 +1363,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 
@@ -1944,7 +1950,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
@@ -25,8 +25,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.apache.commons.lang3.function.FailableFunction;
@@ -119,8 +119,8 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
 
         context.restoreAuthSystemState();
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        formattedDate = formatter.format(new Date(System.currentTimeMillis()));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        formattedDate = LocalDate.now().format(formatter);
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryVersioningIT.java
@@ -119,9 +119,8 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
 
         context.restoreAuthSystemState();
 
-        Date date = new Date();
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        formattedDate = formatter.format(date);
+        formattedDate = formatter.format(new Date(System.currentTimeMillis()));
     }
 
     @Override
@@ -1532,7 +1531,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 
@@ -1541,7 +1540,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 
@@ -1691,7 +1690,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "project-relationships",
             (r) -> r.param("f.isPublicationOfProject", idPub1_2 + ",equals"),
             List.of(
-                matchSearchResult(pro1_2, "project 1")
+                matchSearchResult(pro1_2, "project 1 (" + formattedDate + ")")
             )
         );
 
@@ -1700,7 +1699,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 
@@ -1709,7 +1708,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
     }
@@ -2126,7 +2125,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 
@@ -2135,7 +2134,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 
@@ -2285,7 +2284,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "project-relationships",
             (r) -> r.param("f.isPublicationOfProject", idPub1_2 + ",equals"),
             List.of(
-                matchSearchResult(pro1_2, "project 1")
+                matchSearchResult(pro1_2, "project 1 (" + formattedDate + ")")
             )
         );
 
@@ -2294,7 +2293,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_1 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
 
@@ -2303,7 +2302,7 @@ public class DiscoveryVersioningIT extends AbstractControllerIntegrationTest {
             null, "publication-relationships",
             (r) -> r.param("f.isProjectOfPublication", idPro1_2 + ",equals"),
             List.of(
-                matchSearchResult(pub1_2, "publication 1")
+                matchSearchResult(pub1_2, "publication 1 (" + formattedDate + ")")
             )
         );
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionHistoryRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionHistoryRestRepositoryIT.java
@@ -98,9 +98,8 @@ public class VersionHistoryRestRepositoryIT extends AbstractControllerIntegratio
                           .build();
         context.restoreAuthSystemState();
 
-        Date date = new Date();
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        formattedDate = formatter.format(date);
+        formattedDate = formatter.format(new Date(System.currentTimeMillis()));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionHistoryRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionHistoryRestRepositoryIT.java
@@ -19,6 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.dspace.app.rest.matcher.VersionHistoryMatcher;
@@ -71,6 +73,8 @@ public class VersionHistoryRestRepositoryIT extends AbstractControllerIntegratio
     @Autowired
     private WorkspaceItemService workspaceItemService;
 
+    private String formattedDate;
+
     @Before
     public void setup() throws SQLException, AuthorizeException {
         context.turnOffAuthorisationSystem();
@@ -93,6 +97,10 @@ public class VersionHistoryRestRepositoryIT extends AbstractControllerIntegratio
                           .withSubject("ExtraEntry")
                           .build();
         context.restoreAuthSystemState();
+
+        Date date = new Date();
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        formattedDate = formatter.format(date);
     }
 
     @Test
@@ -383,7 +391,7 @@ public class VersionHistoryRestRepositoryIT extends AbstractControllerIntegratio
                              .andExpect(status().isOk())
                              .andExpect(jsonPath("$",Matchers.is(WorkspaceItemMatcher
                                         .matchItemWithTitleAndDateIssuedAndSubject(witem,
-                                         "Public test item", "2021-04-27", "ExtraEntry"))));
+                                         "Public test item (" + formattedDate + ")", "2021-04-27", "ExtraEntry"))));
     }
 
     @Test
@@ -554,7 +562,7 @@ public class VersionHistoryRestRepositoryIT extends AbstractControllerIntegratio
                                .andExpect(status().isOk())
                                .andExpect(jsonPath("$",Matchers.is(WorkspaceItemMatcher
                                           .matchItemWithTitleAndDateIssuedAndSubject(witem,
-                                           "Public test item", "2021-04-27", "ExtraEntry"))));
+                                           "Public test item (" + formattedDate + ")", "2021-04-27", "ExtraEntry"))));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionHistoryRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionHistoryRestRepositoryIT.java
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.dspace.app.rest.matcher.VersionHistoryMatcher;
@@ -98,8 +98,8 @@ public class VersionHistoryRestRepositoryIT extends AbstractControllerIntegratio
                           .build();
         context.restoreAuthSystemState();
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        formattedDate = formatter.format(new Date(System.currentTimeMillis()));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        formattedDate = LocalDate.now().format(formatter);
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -23,7 +23,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -319,6 +321,54 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
                                             hasJsonPath("$.type", is("version"))
                                             )))
                                  .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
+        } finally {
+            VersionBuilder.delete(idRef.get());
+        }
+    }
+
+    @Test
+    public void createFirstVersionItemNewTitleTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection test")
+                .build();
+
+        Item item = ItemBuilder.createItem(context, col)
+                .withTitle("Public test item")
+                .withIssueDate("2021-04-27")
+                .withAuthor("Doe, John")
+                .withSubject("ExtraEntry")
+                .build();
+
+        context.restoreAuthSystemState();
+
+        Date date = new Date();
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        String formattedDate = formatter.format(date);
+        // Set the item's title with the formatted date appended
+        String titleWithDate = item.getName() + " (" + formattedDate + ")";
+
+        AtomicReference<Integer> idRef = new AtomicReference<Integer>();
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        try {
+            getClient(adminToken).perform(post("/api/versioning/versions")
+                            .param("summary", "test summary!")
+                            .contentType(MediaType.parseMediaType(RestMediaTypes.TEXT_URI_LIST_VALUE))
+                            .content("/api/core/items/" + item.getID()))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$", Matchers.allOf(
+                            hasJsonPath("$.version", is(2)),
+                            hasJsonPath("$.summary", is("test summary!")),
+                            hasJsonPath("$.submitterName", is("first (admin) last (admin)")),
+                            hasJsonPath("$.type", is("version"))
+                    )))
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
+            assert (titleWithDate.equals(versioningService.getVersion(context, idRef.get()).getItem().getName()));
         } finally {
             VersionBuilder.delete(idRef.get());
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -328,7 +328,7 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
-    public void createFirstVersionItemNewTitleTest() throws Exception {
+    public void createVersionTitleWithDateTest() throws Exception {
         context.turnOffAuthorisationSystem();
         parentCommunity = CommunityBuilder.createCommunity(context)
                 .withName("Parent Community")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -368,7 +369,7 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
                             hasJsonPath("$.type", is("version"))
                     )))
                     .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
-            assert (titleWithDate.equals(versioningService.getVersion(context, idRef.get()).getItem().getName()));
+            assertEquals(titleWithDate, versioningService.getVersion(context, idRef.get()).getItem().getName());
         } finally {
             VersionBuilder.delete(idRef.get());
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -24,9 +24,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -347,8 +347,8 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         context.restoreAuthSystemState();
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        String formattedDate = formatter.format(new Date(System.currentTimeMillis()));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String formattedDate = LocalDate.now().format(formatter);
         // Set the item's title with the formatted date appended
         String titleWithDate = item.getName() + " (" + formattedDate + ")";
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -347,9 +347,8 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         context.restoreAuthSystemState();
 
-        Date date = new Date();
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        String formattedDate = formatter.format(date);
+        String formattedDate = formatter.format(new Date(System.currentTimeMillis()));
         // Set the item's title with the formatted date appended
         String titleWithDate = item.getName() + " (" + formattedDate + ")";
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When a new version of an item is created, the title should include the creation date in the format (YYYY-MM-DD).

![image](https://github.com/user-attachments/assets/47318c4d-1e69-4ffc-9502-dfa2c44c326c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - When creating a new version of an item, the current date is automatically appended to the item's title.
- **Tests**
  - Added an integration test to verify the new versioned item's title includes the current date.
  - Updated existing tests to expect the current date appended to related metadata values and titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->