### PR TITLE
Ufal dtq sync062025

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinAutoRegistrationController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinAutoRegistrationController.java
@@ -87,7 +87,7 @@ public class ClarinAutoRegistrationController {
         // Fetch DSpace main cfg info and send it in the email
         String uiUrl = configurationService.getProperty("dspace.ui.url");
         String helpDeskEmail = configurationService.getProperty("lr.help.mail", "");
-        String helpDeskPhoneNum = configurationService.getProperty("lr.help.phone", "");
+        String helpDeskPhoneNum = configurationService.getProperty("mail.message.helpdesk.telephone", "");
         String dspaceName = configurationService.getProperty("dspace.name", "");
         String dspaceNameShort = configurationService.getProperty("dspace.shortname", "");
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -36,7 +36,7 @@ public class RootConverter {
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
         rootRest.setDspaceUI(configurationService.getProperty("dspace.ui.url"));
         rootRest.setDspaceServer(configurationService.getProperty("dspace.server.url"));
-        rootRest.setDspaceVersion("DSpace " + getSourceVersion());
+        rootRest.setDspaceVersion("CLARIN-DSpace " + getSourceVersion());
         rootRest.setBuildVersion(getBuildVersion());
         return rootRest;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -287,7 +287,7 @@ public class ClarinUserMetadataRestController {
         // Fetch DSpace main cfg info and send it in the email
         String uiUrl = configurationService.getProperty("dspace.ui.url", "");
         String helpDeskEmail = configurationService.getProperty("lr.help.mail", "");
-        String helpDeskPhoneNum = configurationService.getProperty("lr.help.phone", "");
+        String helpDeskPhoneNum = configurationService.getProperty("mail.message.helpdesk.telephone", "");
         String dspaceName = configurationService.getProperty("dspace.name", "");
         String dspaceNameShort = configurationService.getProperty("dspace.shortname", "");
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -52,7 +52,7 @@ public class RootConverterTest {
         assertEquals("dspaceurl", rootRest.getDspaceUI());
         assertEquals("dspacename", rootRest.getDspaceName());
         assertEquals(restUrl, rootRest.getDspaceServer());
-        assertEquals("DSpace " + Util.getSourceVersion(), rootRest.getDspaceVersion());
+        assertEquals("CLARIN-DSpace " + Util.getSourceVersion(), rootRest.getDspaceVersion());
     }
 
     @Test

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -318,3 +318,6 @@ autocomplete.custom.allowed = solr-author_ac,solr-publisher_ac,solr-dataProvider
 #### FILE-PREVIEW ####
 # Create file preview when item page is loading
 create.file-preview.on-item-page-load = false
+
+#### OAI description.xml ####
+oai.sample.identifier = oai:${oai.identifier.prefix}:${handle.prefix}/1234

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -66,7 +66,6 @@ the email and the url is not blacklisted.
 # `lr.help.mail` is exposed to the FE - must be set as exposed
 
 lr.help.mail = test@test.sk
-lr.help.phone = 0000
 
 # Admin could upload the file bigger than maximum upload size.
 # Should be this big file deleted from where it was uploaded?

--- a/dspace/config/crosswalks/oai/description.xml
+++ b/dspace/config/crosswalks/oai/description.xml
@@ -2,5 +2,5 @@
 <scheme>oai</scheme>
 <repositoryIdentifier>${oai.identifier.prefix}</repositoryIdentifier>
 <delimiter>:</delimiter>
-<sampleIdentifier>oai:${oai.identifier.prefix}:${handle.prefix}/1234</sampleIdentifier>
+<sampleIdentifier>${oai.sample.identifier}</sampleIdentifier>
 </oai-identifier>

--- a/dspace/config/default.license
+++ b/dspace/config/default.license
@@ -1,18 +1,61 @@
-NOTE: PLACE YOUR OWN LICENSE HERE
-This sample license is provided for informational purposes only.
+Deposit Licence Agreement
 
-NON-EXCLUSIVE DISTRIBUTION LICENSE
 
-By signing and submitting this license, you (the author(s) or copyright owner) grants to DSpace University (DSU) the non-exclusive right to reproduce, translate (as defined below), and/or distribute your submission (including the abstract) worldwide in print and electronic format and in any medium, including but not limited to audio or video.
 
-You agree that DSU may, without changing the content, translate the submission to any medium or format for the purpose of preservation.
+Preamble
 
-You also agree that DSU may keep more than one copy of this submission for purposes of security, back-up and preservation.
+Charles University, ID 00216208, with its registered seat at Ovocný trh 560/5, 116 36 Praha 1 (hereinafter referred to as the “Administrator”) is an administrator of the LINDAT/CLARIAH-CZ repository (hereinafter referred to as the “Repository”).
 
-You represent that the submission is your original work, and that you have the right to grant the rights contained in this license. You also represent that your submission does not, to the best of your knowledge, infringe upon anyone's copyright.
+This Agreement constitutes a licence arrangement between you as the licensor and the Administrator as the licensee. By entering into this Agreement, you authorise the Administrator to store the dataset which you have uploaded and to make it available through the Repository on a long-term basis.
 
-If the submission contains material for which you do not hold copyright, you represent that you have obtained the unrestricted permission of the copyright owner to grant DSU the rights required by this license, and that such third-party owned material is clearly identified and acknowledged within the text or content of the submission.
+For this purpose, the Administrator may, for example, make copies of the dataset, communicate the dataset to the public, or modify its format to ensure compatibility and functionality. The Administrator will not make changes to the content of the dataset itself.
 
-IF THE SUBMISSION IS BASED UPON WORK THAT HAS BEEN SPONSORED OR SUPPORTED BY AN AGENCY OR ORGANIZATION OTHER THAN DSU, YOU REPRESENT THAT YOU HAVE FULFILLED ANY RIGHT OF REVIEW OR OTHER OBLIGATIONS REQUIRED BY SUCH CONTRACT OR AGREEMENT.
+The licence granted for the dataset under this Agreement is non-exclusive, which means that you, as the author of the dataset, retain all rights to exercise copyright and these rights are not limited by this Agreement in any way (i.e., you may, for example, licence the dataset to other persons, store the dataset in other repositories, or otherwise distribute it).
 
-DSU will clearly identify your name(s) as the author(s) or owner(s) of the submission, and will not make any alteration, other than as allowed by this license, to your submission.
+For the purposes of this Licence Agreement, the content of the dataset may consist of, for example:
+
+Spreadsheets, documents
+
+Audio and video recordings
+
+Images, photographs
+
+Questionnaires, test responses, interview transcripts
+
+Code, software
+
+Laboratory notebooks, field notebooks, diaries
+
+This Agreement applies to the unique outcomes of creative intellectual activities of a natural person (works of authorship) or possibly to databases which the dataset uploaded by you contains and which are protected by a special right of the database maker.
+
+
+
+Subject Matter of the Agreement
+
+By means of this Licence Agreement, you grant the Administrator a non-exclusive, worldwide, and royalty-free licence to use the dataset and its content for the duration of the copyright and/or for the duration of the special right of the database maker. The licence grants the right to use the dataset, its content, or part thereof in any way (in particular the right to reproduce the dataset and its content, to communicate it to the public, or to store it), but only for the purpose of permanent storage and making the dataset available in the Repository.
+
+The availability of a dataset in the Repository is subject to the conditions you specify during the process of uploading the dataset to the Repository. Public access to the dataset is governed by the licence terms you choose to attach to the dataset, as permitted by the Repository, and may be limited by publication delay (embargo) or by choosing to restrict access to the dataset.
+
+
+
+Declarations of the Licensor
+
+You declare that:
+
+You have full authority to grant this licence and, if applicable, you have the consent of all co-authors of the dataset and its content or you are authorised to grant this licence by your employer if the content of the dataset is a work for hire,
+
+Storing and making the dataset available will not infringe the rights of any third parties, in particular their intellectual property rights, rights to protection of classified information, trade secret rights, and/or rights to protection of personal data,
+
+If your dataset contains works of authorship by third parties, these works are properly identified, cited, and you have all necessary permissions to store and potentially make these works available through the Repository,
+
+Storing and making the dataset available through the Repository does not breach any contractual obligations with any third party (e.g., an obligation under a publishing contract or a contract with a funder), and
+
+You are not aware of any other legal obstacle that may prevent the Administrator from exercising the rights granted by this Licence Agreement.
+
+
+
+Choice of Law and Jurisdiction
+
+All disputes arising from this Agreement, as well as disputes arising from any relationships associated with this Agreement, will be settled before the general court in whose district the Administrator has its registered office.
+
+The Agreement, as well as any relationships associated with the Agreement, including issues related to its drafting, amendment, or termination, will be governed by Czech law.

--- a/dspace/config/default_cs.license
+++ b/dspace/config/default_cs.license
@@ -1,31 +1,62 @@
-POZNÁMKA: VLOŽTE ZDE SVOU VLASTNÍ LICENCI
-Tento vzorový licenční text je poskytován pouze pro informační účely.
+Depoziční licenční smlouva
 
-NEVÝHRADNÍ LICENCE NA DISTRIBUCI
 
-Podpisem a odesláním této licence vy (autor/autoři nebo vlastník/vlastníci autorských práv) udělujete
-Univerzitě Karlově (UK) nevýhradní právo celosvětově reprodukovat,
-překládat (jak je definováno níže) a/nebo distribuovat vaše příspěvky (včetně abstraktů)
-v tištěné i elektronické podobě a za pomoci jakéhokoli média (včetně audia nebo videa, ale i jakýchkoliv jiných médií).
 
-Souhlasíte s tím, že UK může, pokud nezmění obsah,  převést váš příspěvek do jakéhokoli formátu
-nebo na jakékoli médium za účelem jeho uchování.
+Preambule
 
-Rovněž souhlasíte, že UK  si může ponechat více než jednu kopii tohoto příspěvku pro
-účely jeho bezpečnosti, zálohování a dlouhodobého uchovávání.
+Univerzita Karlova, IČO 00216208, se sídlem Ovocný trh 560/5, 116 36 Praha 1 (dále jen „Provozovatel”) je provozovatelem repozitáře LINDAT/CLARIAH-CZ (dále jen jako „Repozitář”).
 
-Prohlašujete, že váš příspěvek k dílu je původní a že máte právo udělovat práva uvedená v této licenci k celému dílu.
-Prohlašujete také, že podle vašeho nejlepšího vědomí a svědomí, neporušujete tímto ničí autorská práva.
+Tato smlouva představuje licenční ujednání mezi Vámi jakožto poskytovatelem licence a Provozovatelem jakožto nabyvatelem licence. Prostřednictvím této smlouvy poskytujete Provozovateli oprávnění k tomu, aby Vámi nahrávaná datová sada mohla být dlouhodobě uložena a zpřístupněna prostřednictvím Repozitáře.
 
-V případě, že příspěvek obsahuje materiál, pro který nevlastníte autorská práva,
-prohlašujete, že jste obdržel(i) neomezené povolení
-vlastníka autorských práv udělit UK práva požadovaná touto licencí a že
-takový materiál ve vlastnictví třetí strany je zřetelně označen a citován
-v textu nebo obsahu vašeho příspěvku.
+Za tímto účelem může Provozovatel např. vytvářet kopie datové sady, datovou sadu sdělovat veřejnosti nebo upravovat její formát pro zajištění kompatibility a funkcionality. Do samotného obsahu datové sady nebude ze strany Provozovatele zasahováno.
 
-POKUD JE PŘÍSPĚVEK ZALOŽEN NA PRÁCI, KTERÁ BYLA SPONZOROVÁNA NEBO PODPOROVÁNA JAKOUKOLI JINOU AGENTUROU NEBO ORGANIZACÍ,
-NEŽ JE UK, PROHLAŠUJETE, ŽE JSTE SPLNIL(I) VŠECHNA PRÁVA NA PŘEZKOUMÁNÍ A TAKÉ JINÉ ZÁVAZKY
-VYŽADOVANÉ TAKOVOUTO SMLOUVOU NEBO UJEDNÁNÍM.
+Poskytovaná licence k datové sadě dle této smlouvy je nevýhradní, což znamená, že Vám jakožto autorovi datové sady jsou nadále zachována veškerá oprávnění k výkonu autorských práv a tato oprávnění nejsou nijak touto smlouvou omezena (tj. můžete např. poskytovat licence k datové sadě dalším osobám, ukládat datovou sadu do jiných repozitářů nebo ji jinak distribuovat).
 
-UK bude jasně identifikovat vaše jméno (jména) jako autora (autorů) nebo vlastníka (vlastníků)
-poskytnutého díla a nebude provádět žádné jiné změny tohoto díla než ty, které povoluje tato licence.
+Obsah datové sady mohou pro účely této licenční smlouvy představovat například:
+
+Tabulky, dokumenty
+
+Audio a video nahrávky
+
+Obrázky, fotografie
+
+Dotazníky, odpovědi na testové otázky, přepisy rozhovorů
+
+Software, skript
+
+Laboratorní deníky, terénní poznámky, diáře.
+
+Tato smlouva se vztahuje na jedinečné výsledky tvůrčí duševní činnosti fyzické osoby (autorská díla), případně na databáze chráněné zvláštním právem pořizovatele databáze, které Vámi nahrávaná datová sada obsahuje.
+
+
+
+Předmět smlouvy
+
+Prostřednictvím této licenční smlouvy poskytujete Provozovateli nevýhradní, celosvětovou a bezúplatnou licenci k užití datové sady a jejího obsahu, a to na dobu trvání autorských majetkových práv a/nebo na dobu trvání zvláštního práva pořizovatele databáze. Licenční oprávnění představuje právo užít všemi způsoby datovou sadu, její obsah nebo jeho část (zejména právo datovou sadu a její obsah rozmnožovat, sdělovat veřejnosti nebo archivovat), avšak výhradně pro účely trvalého uložení a zpřístupnění datové sady v Repozitáři.
+
+Zpřístupnění datové sady v Repozitáři probíhá výhradně na základě podmínek, které specifikujete při procesu vkládání datové sady do Repozitáře. Zpřístupnění datové sady veřejnosti se řídí Vámi zvolenými licenčními podmínkami, které Repozitář umožňuje k datové sadě přiřadit, a může být omezeno odkladem zpřístupnění (embargem) nebo volbou omezeného přístupu k datové sadě.
+
+
+
+Prohlášení poskytovatele licence
+
+Prohlašujete, že:
+
+Máte veškerá oprávnění k poskytnutí této licence, a pokud je to relevantní, máte souhlas všech spoluautorů datové sady a jejího obsahu nebo jste oprávněn k udělení této licence ze strany zaměstnavatele u obsahu datové sady, který je zaměstnaneckým dílem,
+
+Uložením a případným zpřístupněním datové sady nebude zasaženo do práv třetích osob, zejm. do práv duševního vlastnictví, práv na ochranu utajovaných informací, do práva na ochranu obchodního tajemství a/nebo do práv na ochranu osobních údajů,
+
+Pokud Vaše datová sada obsahuje autorská díla třetích osob, jsou řádně označena, citována a máte veškerá potřebná oprávnění pro uložení a případné zpřístupnění těchto děl prostřednictvím Repozitáře,
+
+Uložením a případným zpřístupněním datové sady v Repozitáři nedochází k porušení smluvních závazků s třetí stranou (např. závazku z vydavatelské / nakladatelské smlouvy nebo ze smlouvy uzavřené s poskytovatelem financí),
+
+Nemáte povědomí o existenci žádné další právní překážky, která by mohla Provozovateli bránit ve výkonu oprávnění poskytnutého touto licenční smlouvou.
+
+
+
+Volba práva a jurisdikce
+
+Veškeré spory vyplývající z této smlouvy, jakož i spory ze vztahů se smlouvou souvisejících, budou řešeny před obecným soudem, v jehož obvodu má sídlo Provozovatel.
+
+Smlouva, jakož i vztahy se smlouvou související včetně otázek týkajících se jejího vzniku, změny či zániku, se řídí českým právem.
+

--- a/dspace/config/emails/change_password
+++ b/dspace/config/emails/change_password
@@ -4,9 +4,9 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Change Password Request")
+#set($subject = "${config.get('dspace.shortname')}: Change Password Request")
 #set($phone = ${config.get('mail.message.helpdesk.telephone')})
-To change the password for your ${config.get('dspace.name')} account, please click the link below:
+To change the password for your ${config.get('dspace.shortname')} account, please click the link below:
 
   ${params[0]}
 
@@ -18,4 +18,4 @@ If you need assistance with your account, please email
 or call us at ${phone}.
 #end
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/clarin_autoregistration
+++ b/dspace/config/emails/clarin_autoregistration
@@ -9,7 +9,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'Account Registration')
+#set($subject = "${config.get('dspace.shortname')}: Account Registration")
 To complete registration for a ${params[3]} repository account at ${params[5]}, please click the link below:
 
   ${params[0]}

--- a/dspace/config/emails/clarin_autoregistration
+++ b/dspace/config/emails/clarin_autoregistration
@@ -10,12 +10,15 @@
 ## See org.dspace.core.Email for information on the format of this file.
 ##
 #set($subject = "${config.get('dspace.shortname')}: Account Registration")
+#set($phone = ${config.get('mail.message.helpdesk.telephone')})
 To complete registration for a ${params[3]} repository account at ${params[5]}, please click the link below:
 
   ${params[0]}
 
-If you need assistance with your account, please email
-${params[1]} or call us at ${params[2]}
+If you need assistance with your account, please email ${params[1]}
+#if( $phone )
+or call us at ${phone}.
+#end
 
 
 ${params[3]} Team
@@ -24,4 +27,6 @@ _____________________________________
 ${params[4]},
 WWW: ${params[5]}
 Email: ${params[1]}
-Tel.: ${params[2]}
+#if( $phone )
+Tel.: ${phone}
+#end

--- a/dspace/config/emails/clarin_download_link
+++ b/dspace/config/emails/clarin_download_link
@@ -11,7 +11,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'Download instructions')
+#set($subject = "${config.get('dspace.shortname')}: Download instructions")
 To download the file you have requested, please click the link below:
  ${params[1]}
   

--- a/dspace/config/emails/clarin_download_link
+++ b/dspace/config/emails/clarin_download_link
@@ -12,6 +12,7 @@
 ## See org.dspace.core.Email for information on the format of this file.
 ##
 #set($subject = "${config.get('dspace.shortname')}: Download instructions")
+#set($phone = ${config.get('mail.message.helpdesk.telephone')})
 To download the file you have requested, please click the link below:
  ${params[1]}
   
@@ -19,7 +20,10 @@ Remember, the file is distributed under specific license:
  ${params[2]}
 
 If you have trouble downloading the file or if you did not request this download please contact
-${params[3]} or call us at ${params[4]}
+${params[3]}
+#if( $phone )
+or call us at ${phone}.
+#end
 
 
 ${params[5]} Team
@@ -28,4 +32,6 @@ _____________________________________
 ${params[6]},
 WWW: ${params[7]}
 Email: ${params[3]}
-Tel.: ${params[4]}
+#if( $phone )
+Tel.: ${phone}
+#end

--- a/dspace/config/emails/clarin_download_link_admin
+++ b/dspace/config/emails/clarin_download_link_admin
@@ -29,7 +29,7 @@ Extra information filled by the user:
 ${config.get('dspace.shortname')} Team
 
 _____________________________________
-${config.get('dspace.name')},
+${config.get('dspace.shortname')},
 WWW: ${config.get('dspace.ui.url')}
 Email: ${config.get('lr.help.mail')}
 Tel.: ${config.get('lr.help.phone')}

--- a/dspace/config/emails/clarin_download_link_admin
+++ b/dspace/config/emails/clarin_download_link_admin
@@ -10,6 +10,7 @@
 ## See org.dspace.core.Email for information on the format of this file.
 ##
 #set($subject = "${config.get('dspace.shortname')}: New File Download Request (CC)")
+#set($phone = ${config.get('mail.message.helpdesk.telephone')})
 
 This is an information for administrators and other configured people about a new download request.
 
@@ -32,4 +33,6 @@ _____________________________________
 ${config.get('dspace.shortname')},
 WWW: ${config.get('dspace.ui.url')}
 Email: ${config.get('lr.help.mail')}
-Tel.: ${config.get('lr.help.phone')}
+#if( $phone )
+Tel.: ${phone}
+#end

--- a/dspace/config/emails/doi_maintenance_error
+++ b/dspace/config/emails/doi_maintenance_error
@@ -10,11 +10,11 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Error ${params[0]} DOI ${params[3]}")
+#set($subject = "${config.get('dspace.shortname')}: Error ${params[0]} DOI ${params[3]}")
 
 Date:    ${params[1]}
 
 ${params[0]} DOI ${params[4]} for ${params[2]} with ID ${params[3]} failed:
 ${params[5]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/export_error
+++ b/dspace/config/emails/export_error
@@ -6,11 +6,11 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: The item export you requested was not completed.")
+#set($subject = "${config.get('dspace.shortname')}: The item export you requested was not completed.")
 The item export you requested was not completed, due to the following reason:
  ${params[0]}
 
 For more information you may contact your system administrator:
  ${params[1]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/export_success
+++ b/dspace/config/emails/export_success
@@ -5,7 +5,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Item export requested is ready for download")
+#set($subject = "${config.get('dspace.shortname')}: Item export requested is ready for download")
 The item export you requested from the repository is now ready for download.
 
 You may download the compressed file using the following link:
@@ -13,4 +13,4 @@ ${params[0]}
 
 This file will remain available for at least ${params[1]} hours.
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/feedback
+++ b/dspace/config/emails/feedback
@@ -10,7 +10,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Feedback Form Information")
+#set($subject = "${config.get('dspace.shortname')}: Feedback Form Information")
 
 Comments:
 
@@ -24,4 +24,4 @@ Referring Page: ${params[3]}
 User Agent: ${params[4]}
 Session: ${params[5]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/flowtask_notify
+++ b/dspace/config/emails/flowtask_notify
@@ -7,7 +7,7 @@
 ## {4}  Task result
 ## {5}  Workflow action taken
 ##
-#set($subject = "${config.get('dspace.name')}: Curation Task Report")
+#set($subject = "${config.get('dspace.shortname')}: Curation Task Report")
 
 Title:         ${params[0]}
 Collection:    ${params[1]}
@@ -20,4 +20,4 @@ ${params[4]}
 
 Action taken on the submission: ${params[5]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/harvesting_error
+++ b/dspace/config/emails/harvesting_error
@@ -8,7 +8,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Harvesting Error")
+#set($subject = "${config.get('dspace.shortname')}: Harvesting Error")
 Collection ${params[0]} failed on harvest:
 
 Date:       	${params[1]}
@@ -19,4 +19,4 @@ ${params[3]}
 Exception:
 ${params[4]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/healthcheck
+++ b/dspace/config/emails/healthcheck
@@ -3,7 +3,7 @@
 ## Parameters: {0} is the output of healthcheck command
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Repository healthcheck")
+#set($subject = "${config.get('dspace.shortname')}: Repository healthcheck")
 The healthcheck finished with the following output:
 
 ${params[0]}

--- a/dspace/config/emails/internal_error
+++ b/dspace/config/emails/internal_error
@@ -10,7 +10,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Internal Server Error")
+#set($subject = "${config.get('dspace.shortname')}: Internal Server Error")
 An internal server error occurred on ${params[0]}:
 
 Date:       ${params[1]}

--- a/dspace/config/emails/register
+++ b/dspace/config/emails/register
@@ -4,9 +4,9 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')} Account Registration")
+#set($subject = "${config.get('dspace.shortname')} Account Registration")
 #set($phone = ${config.get('mail.message.helpdesk.telephone')})
-To complete registration for a ${config.get('dspace.name')} account, please click the link below:
+To complete registration for a ${config.get('dspace.shortname')} account, please click the link below:
 
   ${params[0]}
 
@@ -15,4 +15,4 @@ If you need assistance with your account, please email ${config.get("mail.helpde
 or call us at ${phone}.
 #end
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/registration_notify
+++ b/dspace/config/emails/registration_notify
@@ -8,7 +8,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Registration Notification")
+#set($subject = "${config.get('dspace.shortname')}: Registration Notification")
 
 A new user has registered on ${params[0]} at ${params[1]}:
 
@@ -16,4 +16,4 @@ Name:                   ${params[2]}
 Email:                  ${params[3]}
 Date:                   ${params[4]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/request_item.admin
+++ b/dspace/config/emails/request_item.admin
@@ -8,7 +8,7 @@
 ##             {4} the approver's email address
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "${config.get('dspace.name')}: Request for Open Access")
+#set($subject = "${config.get('dspace.shortname')}: Request for Open Access")
 
 ${params[3]}, with address ${params[4]},
 requested the following document/file to be in Open Access:
@@ -17,4 +17,4 @@ Document Handle: ${params[1]}
 File ID: ${params[0]}
 Token: ${params[2]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/request_item.author
+++ b/dspace/config/emails/request_item.author
@@ -11,11 +11,11 @@
 ##             8 corresponding author email
 ##             9 configuration property "dspace.name"
 ##             10 configuration property "mail.helpdesk"
-#set($subject = "${config.get('dspace.name')}: Request copy of document")
+#set($subject = "${config.get('dspace.shortname')}: Request copy of document")
 
 Dear ${params[7]},
 
-A user of ${params[9]}, named ${params[0]} and using the email ${params[1]}, requested a copy of the file(s) associated with the document: "${params[4]}" (${params[3]}) submitted by you.
+A user of ${config.get('dspace.shortname')}, named ${params[0]} and using the email ${params[1]}, requested a copy of the file(s) associated with the document: "${params[4]}" (${params[3]}) submitted by you.
 
 This request came along with the following message:
 
@@ -29,4 +29,4 @@ IF YOU ARE AN AUTHOR OF THE REQUESTED DOCUMENT, thank you for your cooperation!
 
 If you have any questions concerning this request, please contact ${params[10]}.
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/request_item.granted
+++ b/dspace/config/emails/request_item.granted
@@ -8,7 +8,7 @@
 ##  {3} name of the grantor
 ##  {4} email address of the grantor (unused)
 ##  {5} custom message sent by the grantor.
-#set($subject = 'Request for Copy of Restricted Document is Granted')
+#set($subject = "${config.get('dspace.shortname')}: Request for Copy of Restricted Document is Granted")
 Dear ${params[0]}:
 
 Your request for a copy of the file(s) from the below document has been approved by ${params[3]}.  You may find the requested file(s) attached.
@@ -23,4 +23,4 @@ ${params[5]}
 #end
 
 Best regards,
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/request_item.rejected
+++ b/dspace/config/emails/request_item.rejected
@@ -8,7 +8,7 @@
 ##  {3} name of the grantor
 ##  {4} email address of the grantor (unused)
 ##  {5} custom message sent by the grantor.
-#set($subject = 'Request for Copy of Restricted Document is Denied')
+#set($subject = "${config.get('dspace.shortname')}: Request for Copy of Restricted Document is Denied")
 Dear ${params[0]}:
 
 Your request for a copy of the file(s) from the below document has been denied by ${params[3]}.
@@ -23,4 +23,4 @@ ${params[5]}
 #end
 
 Best regards,
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/share_submission
+++ b/dspace/config/emails/share_submission
@@ -5,6 +5,7 @@
 ## See org.dspace.core.Email for information on the format of this file.
 ##
 #set($subject = 'Submission share link')
+#set($subject = "${config.get('dspace.shortname')}: Submission share link")
 To pass your submission to another user give them the following link:
  ${params[0]}
 
@@ -15,7 +16,7 @@ ${config.get('lr.help.mail')} or call us at ${config.get('lr.help.phone')}
 ${config.get('dspace.shortname')} Team
 
 _____________________________________
-${config.get('dspace.name')},
+${config.get('dspace.shortname')},
 WWW: ${config.get('dspace.ui.url')}
 Email: ${config.get('lr.help.mail')}
 Tel.: ${config.get('lr.help.phone')}

--- a/dspace/config/emails/share_submission
+++ b/dspace/config/emails/share_submission
@@ -4,13 +4,15 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'Submission share link')
 #set($subject = "${config.get('dspace.shortname')}: Submission share link")
+#set($phone = ${config.get('mail.message.helpdesk.telephone')})
 To pass your submission to another user give them the following link:
  ${params[0]}
 
-If you have trouble please contact
-${config.get('lr.help.mail')} or call us at ${config.get('lr.help.phone')}
+If you have trouble please contact ${config.get('lr.help.mail')}
+#if( $phone )
+or call us at ${phone}.
+#end
 
 
 ${config.get('dspace.shortname')} Team
@@ -19,4 +21,6 @@ _____________________________________
 ${config.get('dspace.shortname')},
 WWW: ${config.get('dspace.ui.url')}
 Email: ${config.get('lr.help.mail')}
-Tel.: ${config.get('lr.help.phone')}
+#if( $phone )
+Tel.: ${phone}
+#end

--- a/dspace/config/emails/submit_archive
+++ b/dspace/config/emails/submit_archive
@@ -4,13 +4,13 @@
 ## {1}  Name of collection
 ## {2}  handle
 ##
-#set($subject = "${config.get('dspace.name')}: Submission Approved and Archived")
+#set($subject = "${config.get('dspace.shortname')}: Submission Approved and Archived")
 
 You submitted: ${params[0]}
 
 To collection: ${params[1]}
 
-Your submission has been accepted and archived in ${config.get('dspace.name')},
+Your submission has been accepted and archived in ${config.get('dspace.shortname')},
 and it has been assigned the following identifier:
 ${params[2]}
 
@@ -18,4 +18,4 @@ Please use this identifier when citing your submission.
 
 Many thanks!
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/submit_reject
+++ b/dspace/config/emails/submit_reject
@@ -6,7 +6,7 @@
 ## {3}  Reason for the rejection
 ## {4}  Link to 'My DSpace' page
 ##
-#set($subject = "${config.get('dspace.name')}: Submission Rejected")
+#set($subject = "${config.get('dspace.shortname')}: Submission Rejected")
 
 You submitted: ${params[0]}
 
@@ -19,4 +19,4 @@ ${params[3]}
 
 Your submission has not been deleted. You can access it from your "My${config.get('dspace.shortname')}" page: ${params[4]}
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/submit_task
+++ b/dspace/config/emails/submit_task
@@ -6,7 +6,7 @@
 ## {3}  Description of task
 ## {4}  link to 'my DSpace' page
 ##
-#set($subject = "${config.get('dspace.name')}: You have a new task")
+#set($subject = "${config.get('dspace.shortname')}: You have a new task")
 
 A new item has been submitted:
 
@@ -16,9 +16,9 @@ Submitted by: ${params[2]}
 
 ${params[3]}
 
-To claim this task, please visit your "My${config.get('dspace.shortname')}"
+To claim this task, please visit your "My DSpace"
 page:  ${params[4]}
 
 Many thanks!
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/emails/subscriptions_content
+++ b/dspace/config/emails/subscriptions_content
@@ -2,8 +2,8 @@
 ##
 ## Parameters: {0} Collections updates
 ##             {1} Communities updates
-#set($subject = "${config.get('dspace.name')} Subscriptions")
-This email is sent from ${config.get('dspace.name')} based on the chosen subscription preferences.
+#set($subject = "${config.get('dspace.shortname')} Subscriptions")
+This email is sent from ${config.get('dspace.shortname')} based on the chosen subscription preferences.
 
 #if( not( "$params[0]" == "" ))
 Community Subscriptions:

--- a/dspace/config/emails/welcome
+++ b/dspace/config/emails/welcome
@@ -2,7 +2,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "Welcome new registered ${config.get('dspace.name')} user!")
+#set($subject = "Welcome new registered ${config.get('dspace.shortname')} user!")
 Thank you for registering an account. Your new account can be used immediately
 to subscribe to notices of new content arriving in collections of your choice.
 
@@ -11,4 +11,4 @@ edit and/or approve submissions.
 
 If you need assistance with your account, please email ${config.get("mail.helpdesk")}.
 
-The ${config.get('dspace.name')} Team
+The ${config.get('dspace.shortname')} Team

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -155,7 +155,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>true</repeatable>
+                    <repeatable>false</repeatable>
                     <label>Should this item be hidden from browse/search? (Admin only field)</label>
                     <style>col-sm-4</style>
                     <input-type value-pairs-name="hidden_list">list</input-type>
@@ -172,7 +172,7 @@
                 <field>
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
-                    <repeatable>true</repeatable>
+                    <repeatable>false</repeatable>
                     <label>Are you going to upload cmdi file? (Admin only field)</label>
                     <input-type value-pairs-name="hasCMDI_checkbox">list</input-type>
                     <hint>Indicate whether you will upload cmdi file in the next step. Combine with "hide" for weblicht
@@ -227,7 +227,6 @@
                     <style>col-sm-5</style>
                     <input-type complex-definition-ref="funding">complex</input-type>
                     <hint>Acknowledge sponsors and funding that supported work described by this submission.</hint>
-                    <required></required>
                 </field>
             </row>
         </form>
@@ -250,7 +249,7 @@
                     <dc-schema>dc</dc-schema>
                     <dc-element>language</dc-element>
                     <dc-qualifier>iso</dc-qualifier>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Language</label>
                     <type-bind>corpus,lexicalConceptualResource,languageDescription</type-bind>
                     <input-type autocomplete-custom="json_static-iso_langs.json">autocomplete</input-type>

--- a/dspace/config/submission-forms_cs.xml
+++ b/dspace/config/submission-forms_cs.xml
@@ -150,7 +150,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>true</repeatable>
+                    <repeatable>false</repeatable>
                     <label>Má být tento příspěvek skryt při procházení/vyhledávání? (Admin only field)</label>
                     <style>col-sm-4</style>
                     <input-type value-pairs-name="hidden_list">list</input-type>
@@ -165,7 +165,7 @@
                 <field>
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
-                    <repeatable>true</repeatable>
+                    <repeatable>false</repeatable>
                     <label>Chystáte se nahrát cmdi soubor? (Admin only field)</label>
                     <input-type value-pairs-name="hasCMDI_checkbox">list</input-type>
                     <hint>Uveďte, jestli se chystáte v dalším kroku nahrát cmdi soubor. Kombinujte se schováváním záznamů pro weblicht příspěvky.</hint>
@@ -238,7 +238,7 @@
                     <dc-schema>dc</dc-schema>
                     <dc-element>language</dc-element>
                     <dc-qualifier>iso</dc-qualifier>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Jazyk</label>
                     <type-bind>corpus,lexicalConceptualResource,languageDescription</type-bind>
                     <input-type autocomplete-custom="json_static-iso_langs.json">autocomplete</input-type>


### PR DESCRIPTION
port of ufal/DSpace#1215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Email notifications now consistently use the repository's short name and dynamically display the helpdesk phone number from configuration where available.
	- Sample OAI identifier values are now configurable for greater flexibility.

- **Bug Fixes**
	- Submission forms updated to correctly allow or restrict multiple entries for specific metadata fields.

- **Documentation**
	- Deposit license agreements replaced with detailed, legally-structured versions in both English and Czech.

- **Chores**
	- Improved branding consistency across all user-facing email templates.
	- Updated DSpace version display to clarify CLARIN-DSpace branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->