### PR TITLE
UFAL/JSONificate User Summary health reports

### DIFF
--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -35,6 +35,8 @@ public class UserCheck extends Check {
     private static final GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
     private static final CollectionService collectionService = ContentServiceFactory.getInstance()
                                                                                     .getCollectionService();
+    private static final String HAVE_EMAIL = "Have email";
+    private static final String COUNT = "Count";
 
     @Override
     public String run(ReportInfo ri) {
@@ -44,9 +46,9 @@ public class UserCheck extends Check {
         Map<String, Integer> info = new HashMap<String, Integer>();
         try {
             List<EPerson> epersons = ePersonService.findAll(context, EPerson.LASTNAME);
-            info.put("Count", epersons.size());
+            info.put(COUNT, epersons.size());
             info.put("Can log in (password)", 0);
-            info.put("Have email", 0);
+            info.put(HAVE_EMAIL, 0);
             info.put("Have 1st name", 0);
             info.put("Have 2nd name", 0);
             info.put("Have lang", 0);
@@ -55,7 +57,7 @@ public class UserCheck extends Check {
 
             for (EPerson e : epersons) {
                 if (e.getEmail() != null && e.getEmail().length() > 0) {
-                    info.put("Have email", info.get("Have email") + 1);
+                    info.put(HAVE_EMAIL, info.get(HAVE_EMAIL) + 1);
                 }
                 if (e.canLogIn()) {
                     info.put("Can log in (password)",
@@ -83,13 +85,13 @@ public class UserCheck extends Check {
         }
 
         ret += String.format(
-            "%-20s: %d\n", "Users", info.get("Count"));
-        root.put("users", info.get("Count"));
+            "%-20s: %d\n", "Users", info.get(COUNT));
+        root.put("users", info.get(COUNT));
         ret += String.format(
-            "%-20s: %d\n", "Have email", info.get("Have email"));
-        root.put("haveEmail", info.get("Have email"));
+            "%-20s: %d\n", HAVE_EMAIL, info.get(HAVE_EMAIL));
+        root.put("haveEmail", info.get(HAVE_EMAIL));
         for (Map.Entry<String, Integer> e : info.entrySet()) {
-            if (!e.getKey().equals("Count") && !e.getKey().equals("Have email")) {
+            if (!e.getKey().equals(COUNT) && !e.getKey().equals(HAVE_EMAIL)) {
                 String key = e.getKey();
                 int value = e.getValue();
                 ret += String.format("%-21s: %s\n", key,

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -95,8 +95,7 @@ public class UserCheck extends Check {
                 ret += String.format("%-21s: %s\n", key,
                                      String.valueOf(value));
 
-                key = key.toLowerCase().replaceAll("\\s+", "_");
-                key = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key);
+                key = caseFormat(key);
                 root.put(key, value);
             }
         }
@@ -152,5 +151,11 @@ public class UserCheck extends Check {
             jsonArr.put(oneId);
         }
         return ids.toString();
+    }
+
+    String caseFormat(String str) {
+        str = str.toLowerCase().replaceAll("\\s+", "_");
+        str = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, str);
+        return str;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -95,7 +95,7 @@ public class UserCheck extends Check {
                 ret += String.format("%-21s: %s\n", key,
                                      String.valueOf(value));
 
-                key = caseFormat(key);
+                key = toCamelCase(key);
                 root.put(key, value);
             }
         }
@@ -150,11 +150,17 @@ public class UserCheck extends Check {
             oneId.put("id", o.getID());
             jsonArr.put(oneId);
         }
+
+        // deleting last delimeter character
+        if (ids.length() > 0){
+            ids.deleteCharAt(ids.length() - 1);
+        }
+
         return ids.toString();
     }
 
-    String caseFormat(String str) {
-        str = str.toLowerCase().replaceAll("\\s+", "_");
+    private String toCamelCase(String str) {
+        str = str.toLowerCase().replace(" ", "_");
         str = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, str);
         return str;
     }

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -41,7 +41,7 @@ public class UserCheck extends Check {
     @Override
     public String run(ReportInfo ri) {
         Context context = new Context();
-        String ret = "";
+        StringBuilder sb = new StringBuilder();
         JSONObject root = new JSONObject();
         Map<String, Integer> info = new HashMap<String, Integer>();
         try {
@@ -84,54 +84,53 @@ public class UserCheck extends Check {
             error(e);
         }
 
-        ret += String.format(
-            "%-20s: %d\n", "Users", info.get(COUNT));
+        sb.append(String.format("%-22s: %d\n", "Users", info.get(COUNT)));
         root.put("users", info.get(COUNT));
-        ret += String.format(
-            "%-20s: %d\n", HAVE_EMAIL, info.get(HAVE_EMAIL));
+        sb.append(String.format("%-22s: %d\n", HAVE_EMAIL, info.get(HAVE_EMAIL)));
         root.put("haveEmail", info.get(HAVE_EMAIL));
         for (Map.Entry<String, Integer> e : info.entrySet()) {
             if (!e.getKey().equals(COUNT) && !e.getKey().equals(HAVE_EMAIL)) {
                 String key = e.getKey();
                 int value = e.getValue();
-                ret += String.format("%-21s: %s\n", key,
-                                     String.valueOf(value));
+                sb.append(String.format("%-22s: %s\n", key, value));
 
                 key = toCamelCase(key);
                 root.put(key, value);
             }
         }
 
-        ret += "\n";
+        sb.append("\n");
 
         try {
             // empty group
             List<Group> emptyGroups = groupService.getEmptyGroups(context);
-            ret += String.format("Empty groups: #%d\n    ", emptyGroups.size());
+            sb.append(String.format("Empty groups: #%d\n    ", emptyGroups.size()));
             JSONArray emptyGroupsArray = new JSONArray();
             for (Group group : emptyGroups) {
                 JSONObject oneEmptyGroup = new JSONObject();
-                ret += String.format("id=%s;name=%s,\n    ", group.getID(), group.getName());
+                sb.append(String.format("id=%s;name=%s,\n    ", group.getID(), group.getName()));
                 oneEmptyGroup.put("id", group.getID());
                 oneEmptyGroup.put("name", group.getName());
                 emptyGroupsArray.put(oneEmptyGroup);
             }
             root.put("emptyGroups", emptyGroupsArray);
 
+            sb.append("\n");
+
             //subscribers
             List<EPerson> subscribers = ePersonService.findEPeopleWithSubscription(context);
             JSONArray subsIdsArray = new JSONArray();
-            ret += String.format("Subscribers: #%d [", subscribers.size());
-            formatIds(subscribers, subsIdsArray, ret);
-            ret += "]\n";
+            sb.append(String.format("Subscribers: #%d ", subscribers.size()));
+            formatIds(subscribers, subsIdsArray, sb);
+            sb.append("\n");
             root.put("subscribers", subsIdsArray);
 
             //subscribed collections
             List<Collection> subscribedCols = collectionService.findCollectionsWithSubscribers(context);
             JSONArray subsColsArray = new JSONArray();
-            ret += String.format("Subscribed cols.: #%d [", subscribedCols.size());
-            formatIds(subscribedCols, subsColsArray, ret);
-            ret += "]\n";
+            sb.append(String.format("Subscribed cols.: #%d ", subscribedCols.size()));
+            formatIds(subscribedCols, subsColsArray, sb);
+            sb.append("\n");
             root.put("subscribedCollections", subsColsArray);
 
             context.complete();
@@ -141,24 +140,22 @@ public class UserCheck extends Check {
         }
 
         this.setReportJson(root);
-        return ret;
+        return sb.toString();
     }
 
-    private void formatIds(List<? extends DSpaceObject> objects, JSONArray jsonOut, String strOut) {
-        StringBuilder ids = new StringBuilder();
+    private void formatIds(List<? extends DSpaceObject> objects, JSONArray jsonOut, StringBuilder strOut) {
+        strOut.append("[");
         for (DSpaceObject o : objects) {
-            JSONObject oneId = new JSONObject();
-            ids.append(o.getID()).append(", ");
-            oneId.put("id", o.getID());
-            jsonOut.put(oneId);
+            strOut.append(o.getID()).append(", ");
+            jsonOut.put(o.getID());
         }
 
         // deleting last delimeter character
-        if (ids.length() > 0) {
-            ids.deleteCharAt(ids.length() - 1);
+        if (strOut.length() > 0) {
+            strOut.deleteCharAt(strOut.length() - 2);
         }
 
-        strOut += ids.toString();
+        strOut.append("]");
     }
 
     private String toCamelCase(String str) {

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -152,7 +152,7 @@ public class UserCheck extends Check {
         }
 
         // deleting last delimeter character
-        if (ids.length() > 0){
+        if (ids.length() > 0) {
             ids.deleteCharAt(ids.length() - 1);
         }
 

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -143,6 +143,20 @@ public class UserCheck extends Check {
         return sb.toString();
     }
 
+    /**
+     * Formats a list of DSpace objects' IDs into both a JSON array and a human-readable string representation.
+     * <p>
+     * This method takes a list of DSpace objects and extracts their IDs, adding them to:
+     * <ul>
+     *   <li>A JSON array for programmatic access</li>
+     *   <li>A StringBuilder in the format "[id1, id2, id3]" for logging or display purposes</li>
+     * </ul>
+     *
+     * @param objects The list of DSpace objects whose IDs should be formatted
+     * @param jsonOut The JSON array to which the object IDs will be added
+     * @param strOut The StringBuilder that will be populated with the formatted string representation of IDs
+     *              in the format "[id1, id2, id3]"
+     */
     private void formatIds(List<? extends DSpaceObject> objects, JSONArray jsonOut, StringBuilder strOut) {
         strOut.append("[");
         for (DSpaceObject o : objects) {

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -151,7 +151,7 @@ public class UserCheck extends Check {
         }
 
         // deleting last delimeter character
-        if (strOut.length() > 0) {
+        if (!objects.isEmpty() && strOut.length() > 1) {
             strOut.deleteCharAt(strOut.length() - 2);
         }
 

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.CaseFormat;
 import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -22,6 +23,8 @@ import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
+import org.json.JSONObject;
+import org.json.JSONArray;
 
 /**
  * @author LINDAT/CLARIN dev team
@@ -37,6 +40,7 @@ public class UserCheck extends Check {
     public String run(ReportInfo ri) {
         Context context = new Context();
         String ret = "";
+        JSONObject root = new JSONObject();
         Map<String, Integer> info = new HashMap<String, Integer>();
         try {
             List<EPerson> epersons = ePersonService.findAll(context, EPerson.LASTNAME);
@@ -80,12 +84,20 @@ public class UserCheck extends Check {
 
         ret += String.format(
             "%-20s: %d\n", "Users", info.get("Count"));
+        root.put("users", info.get("Count"));
         ret += String.format(
             "%-20s: %d\n", "Have email", info.get("Have email"));
+        root.put("haveEmail", info.get("Have email"));
         for (Map.Entry<String, Integer> e : info.entrySet()) {
             if (!e.getKey().equals("Count") && !e.getKey().equals("Have email")) {
-                ret += String.format("%-21s: %s\n", e.getKey(),
-                                     String.valueOf(e.getValue()));
+                String key = e.getKey();
+                int value = e.getValue();
+                ret += String.format("%-21s: %s\n", key,
+                                     String.valueOf(value));
+
+                key = key.toLowerCase().replaceAll("\\s+", "_");
+                key = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key);
+                root.put(key, value);
             }
         }
 
@@ -95,21 +107,31 @@ public class UserCheck extends Check {
             // empty group
             List<Group> emptyGroups = groupService.getEmptyGroups(context);
             ret += String.format("Empty groups: #%d\n    ", emptyGroups.size());
+            JSONArray emptyGroupsArray = new JSONArray();
             for (Group group : emptyGroups) {
+                JSONObject oneEmptyGroup = new JSONObject();
                 ret += String.format("id=%s;name=%s,\n    ", group.getID(), group.getName());
+                oneEmptyGroup.put("id", group.getID());
+                oneEmptyGroup.put("name", group.getName());
+                emptyGroupsArray.put(oneEmptyGroup);
             }
+            root.put("emptyGroups", emptyGroupsArray);
 
             //subscribers
             List<EPerson> subscribers = ePersonService.findEPeopleWithSubscription(context);
+            JSONArray subsIdsArray = new JSONArray();
             ret += String.format(
                 "Subscribers: #%d [%s]\n",
-                subscribers.size(), formatIds(subscribers));
+                subscribers.size(), formatIds(subscribers, subsIdsArray));
+            root.put("subscribers", subsIdsArray);
 
             //subscribed collections
             List<Collection> subscribedCols = collectionService.findCollectionsWithSubscribers(context);
+            JSONArray subsColsArray = new JSONArray();
             ret += String.format(
                 "Subscribed cols.: #%d [%s]\n",
-                subscribedCols.size(), formatIds(subscribedCols));
+                subscribedCols.size(), formatIds(subscribedCols, subsColsArray));
+            root.put("subscribedCollections", subsColsArray);
 
             context.complete();
 
@@ -120,10 +142,14 @@ public class UserCheck extends Check {
         return ret;
     }
 
-    private String formatIds(List<? extends DSpaceObject> objects) {
+    private String formatIds(List<? extends DSpaceObject> objects, JSONArray ja) {
+
         StringBuilder ids = new StringBuilder();
         for (DSpaceObject o : objects) {
+            JSONObject oneId = new JSONObject();
             ids.append(o.getID()).append(", ");
+            oneId.put("id", o.getID());
+            ja.put(oneId);
         }
         return ids.toString();
     }

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -23,8 +23,8 @@ import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
-import org.json.JSONObject;
 import org.json.JSONArray;
+import org.json.JSONObject;
 
 /**
  * @author LINDAT/CLARIN dev team

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -121,17 +121,17 @@ public class UserCheck extends Check {
             //subscribers
             List<EPerson> subscribers = ePersonService.findEPeopleWithSubscription(context);
             JSONArray subsIdsArray = new JSONArray();
-            ret += String.format(
-                "Subscribers: #%d [%s]\n",
-                subscribers.size(), formatIds(subscribers, subsIdsArray));
+            ret += String.format("Subscribers: #%d [", subscribers.size());
+            formatIds(subscribers, subsIdsArray, ret);
+            ret += "]\n";
             root.put("subscribers", subsIdsArray);
 
             //subscribed collections
             List<Collection> subscribedCols = collectionService.findCollectionsWithSubscribers(context);
             JSONArray subsColsArray = new JSONArray();
-            ret += String.format(
-                "Subscribed cols.: #%d [%s]\n",
-                subscribedCols.size(), formatIds(subscribedCols, subsColsArray));
+            ret += String.format("Subscribed cols.: #%d [", subscribedCols.size());
+            formatIds(subscribedCols, subsColsArray, ret);
+            ret += "]\n";
             root.put("subscribedCollections", subsColsArray);
 
             context.complete();
@@ -144,13 +144,13 @@ public class UserCheck extends Check {
         return ret;
     }
 
-    private String formatIds(List<? extends DSpaceObject> objects, JSONArray jsonArr) {
+    private void formatIds(List<? extends DSpaceObject> objects, JSONArray jsonOut, String strOut) {
         StringBuilder ids = new StringBuilder();
         for (DSpaceObject o : objects) {
             JSONObject oneId = new JSONObject();
             ids.append(o.getID()).append(", ");
             oneId.put("id", o.getID());
-            jsonArr.put(oneId);
+            jsonOut.put(oneId);
         }
 
         // deleting last delimeter character
@@ -158,7 +158,7 @@ public class UserCheck extends Check {
             ids.deleteCharAt(ids.length() - 1);
         }
 
-        return ids.toString();
+        strOut += ids.toString();
     }
 
     private String toCamelCase(String str) {

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -139,17 +139,17 @@ public class UserCheck extends Check {
             error(e);
         }
 
+        this.setReportJson(root);
         return ret;
     }
 
-    private String formatIds(List<? extends DSpaceObject> objects, JSONArray ja) {
-
+    private String formatIds(List<? extends DSpaceObject> objects, JSONArray jsonArr) {
         StringBuilder ids = new StringBuilder();
         for (DSpaceObject o : objects) {
             JSONObject oneId = new JSONObject();
             ids.append(o.getID()).append(", ");
             oneId.put("id", o.getID());
-            ja.put(oneId);
+            jsonArr.put(oneId);
         }
         return ids.toString();
     }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
[#978](https://github.com/dataquest-dev/DSpace/issues/978) We need to JSONificate regular health reports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user and group statistics report to include a structured JSON output alongside the existing text format. This provides a more detailed and accessible summary of user counts, group information, and subscription details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->