### PR TITLE
UFAL/JSONificate License Summary health reports

### DIFF
--- a/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
@@ -135,10 +135,8 @@ public class LicenseCheck extends Check {
                 oneProblemItem.put("type", entry.getKey());
                 oneProblemItem.put("count", uuids.size());
                 for (UUID uuid : uuids) {
-                    JSONObject oneProblemId = new JSONObject();
                     sb.append(String.format("     %s\n", uuid));
-                    oneProblemId.put("id", uuid.toString());
-                    problemIdsArray.put(oneProblemId);
+                    problemIdsArray.put(uuid.toString());
                 }
                 oneProblemItem.put("problemIds", problemIdsArray);
                 problemItemsArray.put(oneProblemItem);

--- a/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
@@ -113,29 +113,28 @@ public class LicenseCheck extends Check {
             }
         }
 
+        JSONArray licensesArray = new JSONArray();
         for (Map.Entry<String, Integer> result : licensesCount.entrySet()) {
-            String key = result.getKey();
-            int value = result.getValue();
+            JSONObject oneLicense = new JSONObject();
 
-            sb.append(String.format("%-20s: %d\n", key, value));
-            key = caseFormat(key);
-            root.put(key, value);
+            sb.append(String.format("%-20s: %d\n", result.getKey(), result.getValue()));
+            oneLicense.put("type", result.getKey());
+            oneLicense.put("count", result.getValue());
+
+            licensesArray.put(oneLicense);
         }
+        root.put("licenses", licensesArray);
 
         if (!problemItems.isEmpty()) {
             JSONArray problemItemsArray = new JSONArray();
             for (Map.Entry<String, List<UUID>> entry: problemItems.entrySet()) {
                 List<UUID> uuids = entry.getValue();
                 JSONObject oneProblemItem = new JSONObject();
-
-                String key = entry.getKey();
-                int size = uuids.size();
-
-                sb.append(String.format("\n%s: %d\n", key, size));
-                key = caseFormat(key);
-                oneProblemItem.put(key, size);
-
                 JSONArray problemIdsArray = new JSONArray();
+
+                sb.append(String.format("\n%s: %d\n", entry.getKey(), uuids.size()));
+                oneProblemItem.put("type", entry.getKey());
+                oneProblemItem.put("count", uuids.size());
                 for (UUID uuid : uuids) {
                     JSONObject oneProblemId = new JSONObject();
                     sb.append(String.format("     %s\n", uuid));
@@ -151,11 +150,5 @@ public class LicenseCheck extends Check {
         context.close();
         this.setReportJson(root);
         return sb.toString();
-    }
-
-    String caseFormat(String str) {
-        str = str.toLowerCase().replaceAll("\\s+", "_");
-        str = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, str);
-        return str;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
@@ -17,7 +17,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 import com.amazonaws.util.CollectionUtils;
-import com.google.common.base.CaseFormat;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;

--- a/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
@@ -129,16 +129,16 @@ public class LicenseCheck extends Check {
             for (Map.Entry<String, List<UUID>> entry: problemItems.entrySet()) {
                 List<UUID> uuids = entry.getValue();
                 JSONObject oneProblemItem = new JSONObject();
-                JSONArray problemIdsArray = new JSONArray();
+                JSONArray problemUUIDsArray = new JSONArray();
 
                 sb.append(String.format("\n%s: %d\n", entry.getKey(), uuids.size()));
                 oneProblemItem.put("type", entry.getKey());
                 oneProblemItem.put("count", uuids.size());
                 for (UUID uuid : uuids) {
                     sb.append(String.format("     %s\n", uuid));
-                    problemIdsArray.put(uuid.toString());
+                    problemUUIDsArray.put(uuid.toString());
                 }
-                oneProblemItem.put("problemIds", problemIdsArray);
+                oneProblemItem.put("problemUUIDs", problemUUIDsArray);
                 problemItemsArray.put(oneProblemItem);
             }
             root.put("problemItems", problemItemsArray);

--- a/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/LicenseCheck.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import com.amazonaws.util.CollectionUtils;
+import com.google.common.base.CaseFormat;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
@@ -28,6 +29,8 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 /**
  * This check provides information about the number of items categorized by clarin license type (PUB/RES/ACA),
@@ -45,6 +48,7 @@ public class LicenseCheck extends Check {
     protected String run(ReportInfo ri) {
         Context context = new Context();
         StringBuilder sb = new StringBuilder();
+        JSONObject root = new JSONObject();
 
         Iterator<Item> items;
         ItemService itemService = ContentServiceFactory.getInstance().getItemService();
@@ -110,20 +114,48 @@ public class LicenseCheck extends Check {
         }
 
         for (Map.Entry<String, Integer> result : licensesCount.entrySet()) {
-            sb.append(String.format("%-20s: %d\n", result.getKey(), result.getValue()));
+            String key = result.getKey();
+            int value = result.getValue();
+
+            sb.append(String.format("%-20s: %d\n", key, value));
+            key = caseFormat(key);
+            root.put(key, value);
         }
 
         if (!problemItems.isEmpty()) {
-            for (Map.Entry<String, List<UUID>> problemItems : problemItems.entrySet()) {
-                List<UUID> uuids = problemItems.getValue();
-                sb.append(String.format("\n%s: %d\n", problemItems.getKey(), uuids.size()));
+            JSONArray problemItemsArray = new JSONArray();
+            for (Map.Entry<String, List<UUID>> entry: problemItems.entrySet()) {
+                List<UUID> uuids = entry.getValue();
+                JSONObject oneProblemItem = new JSONObject();
+
+                String key = entry.getKey();
+                int size = uuids.size();
+
+                sb.append(String.format("\n%s: %d\n", key, size));
+                key = caseFormat(key);
+                oneProblemItem.put(key, size);
+
+                JSONArray problemIdsArray = new JSONArray();
                 for (UUID uuid : uuids) {
+                    JSONObject oneProblemId = new JSONObject();
                     sb.append(String.format("     %s\n", uuid));
+                    oneProblemId.put("id", uuid.toString());
+                    problemIdsArray.put(oneProblemId);
                 }
+                oneProblemItem.put("problemIds", problemIdsArray);
+                problemItemsArray.put(oneProblemItem);
             }
+            root.put("problemItems", problemItemsArray);
         }
 
         context.close();
+        this.setReportJson(root);
         return sb.toString();
+    }
+
+    String caseFormat(String str) {
+        str = str.toLowerCase().replaceAll("\\s+", "_");
+        str = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, str);
+        return str;
     }
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
[#978](https://github.com/dataquest-dev/DSpace/issues/978) We need to JSONificate regular health reports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a structured JSON report for license checks, providing detailed license statistics and problem items in a machine-readable format alongside the existing text report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->