### PR TITLE
UFAL/Use the right checkbox input field - it must be defined as repeatable

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -155,9 +155,8 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Should this item be hidden from browse/search? (Admin only field)</label>
-                    <style>col-sm-4</style>
                     <input-type value-pairs-name="hidden_list">list</input-type>
                     <hint>Indicate whether you want to hide this item from browse and search. Combine with "Upload cmdi"
                         for weblicht submissions.
@@ -172,7 +171,7 @@
                 <field>
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Are you going to upload cmdi file? (Admin only field)</label>
                     <input-type value-pairs-name="hasCMDI_checkbox">list</input-type>
                     <hint>Indicate whether you will upload cmdi file in the next step. Combine with "hide" for weblicht
@@ -1600,7 +1599,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Should this item be hidden from browse/search? (Admin only field)</label>
                     <input-type value-pairs-name="hidden_list">list</input-type>
                     <hint>Indicate whether you want to hide this item from browse and search. Combine with "Upload cmdi"
@@ -1617,7 +1616,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Are you going to upload cmdi file? (Admin only field)</label>
                     <input-type value-pairs-name="metashare_languageDependent">list</input-type>
                     <!-- true/false value -->
@@ -1896,7 +1895,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Should this item be hidden from browse/search? (Admin only field)</label>
                     <input-type value-pairs-name="hidden_list">list</input-type>
                     <hint>Indicate whether you want to hide this item from browse and search. Combine with "Upload cmdi"
@@ -1913,7 +1912,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Are you going to upload cmdi file? (Admin only field)</label>
                     <input-type value-pairs-name="metashare_languageDependent">list</input-type>
                     <!-- true/false value -->

--- a/dspace/config/submission-forms_cs.xml
+++ b/dspace/config/submission-forms_cs.xml
@@ -150,9 +150,8 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Má být tento příspěvek skryt při procházení/vyhledávání? (Admin only field)</label>
-                    <style>col-sm-4</style>
                     <input-type value-pairs-name="hidden_list">list</input-type>
                     <hint>Uveďte, má-li být záznam skryt ve vyhledávání a procházení. Pro příspěvky pro weblicht kombinujte s "Nahrát cmdi".</hint>
                     <required/>
@@ -165,7 +164,7 @@
                 <field>
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Chystáte se nahrát cmdi soubor? (Admin only field)</label>
                     <input-type value-pairs-name="hasCMDI_checkbox">list</input-type>
                     <hint>Uveďte, jestli se chystáte v dalším kroku nahrát cmdi soubor. Kombinujte se schováváním záznamů pro weblicht příspěvky.</hint>
@@ -1572,7 +1571,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Má být tento příspěvek skryt při procházení/vyhledávání? (Admin only field)</label>
                     <input-type value-pairs-name="hidden_list">list</input-type>
                     <hint>Uveďte, má-li být záznam skryt ve vyhledávání a procházení. Pro příspěvky pro weblicht kombinujte s "Nahrát cmdi".</hint>
@@ -1587,7 +1586,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Chystáte se nahrát cmdi soubor? (Admin only field)</label>
                     <input-type value-pairs-name="metashare_languageDependent">list</input-type>
                     <!-- true/false value -->
@@ -1859,7 +1858,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hidden</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Má být tento příspěvek skryt při procházení/vyhledávání? (Admin only field)</label>
                     <input-type value-pairs-name="hidden_list">list</input-type>
                     <hint>Uveďte, má-li být záznam skryt ve vyhledávání a procházení. Pro příspěvky pro weblicht kombinujte s "Nahrát cmdi".</hint>
@@ -1874,7 +1873,7 @@
                     <dc-schema>local</dc-schema>
                     <dc-element>hasCMDI</dc-element>
                     <dc-qualifier/>
-                    <repeatable>false</repeatable>
+                    <repeatable>true</repeatable>
                     <label>Chystáte se nahrát cmdi soubor? (Admin only field)</label>
                     <input-type value-pairs-name="metashare_languageDependent">list</input-type>
                     <!-- true/false value -->


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When the input field type is `list` and the repeatable is set to `false` the wrong checbox input field is used.. you cannot unclick the checbox.
![Screenshot_2](https://github.com/user-attachments/assets/563ab0e9-413c-454b-b520-c4a796c3ae2c)

