### PR TITLE
Incorrect password hash funct used during migration

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinEPersonImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinEPersonImportController.java
@@ -21,6 +21,7 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
@@ -32,6 +33,7 @@ import org.dspace.content.clarin.ClarinUserRegistration;
 import org.dspace.content.service.clarin.ClarinUserRegistrationService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.PasswordHash;
 import org.dspace.eperson.service.EPersonService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -74,7 +76,7 @@ public class ClarinEPersonImportController {
     @PreAuthorize("hasAuthority('ADMIN')")
     @RequestMapping(method = RequestMethod.POST, value = "/eperson")
     public EPersonRest importEPerson(HttpServletRequest request)
-            throws AuthorizeException, SQLException {
+            throws AuthorizeException, SQLException, DecoderException {
         Context context = obtainContext(request);
         if (Objects.isNull(context)) {
             throw new RuntimeException("Context is null!");
@@ -84,6 +86,9 @@ public class ClarinEPersonImportController {
         String selfRegisteredString = request.getParameter("selfRegistered");
         boolean selfRegistered = getBooleanFromString(selfRegisteredString);
         String lastActiveString = request.getParameter("lastActive");
+        String password = request.getParameter("password");
+        String algorithm = request.getParameter("digestAlgorithm");
+        String salt = request.getParameter("salt");
         Date lastActive;
         try {
             lastActive = getDateFromString(lastActiveString);
@@ -95,6 +100,9 @@ public class ClarinEPersonImportController {
         EPerson eperson = ePersonService.find(context, UUID.fromString(epersonRest.getUuid()));
         eperson.setSelfRegistered(selfRegistered);
         eperson.setLastActive(lastActive);
+        //the password is already hashed in the request
+        PasswordHash passwordHash = new PasswordHash(algorithm, salt, password);
+        ePersonService.setPasswordHash(eperson, passwordHash);
         ePersonService.update(context, eperson);
 
         epersonRest = converter.toRest(eperson, utils.obtainProjection());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinEPersonImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinEPersonImportController.java
@@ -86,7 +86,7 @@ public class ClarinEPersonImportController {
         String selfRegisteredString = request.getParameter("selfRegistered");
         boolean selfRegistered = getBooleanFromString(selfRegisteredString);
         String lastActiveString = request.getParameter("lastActive");
-        String password = request.getParameter("password");
+        String passwordHashStr = request.getParameter("passwordHashStr");
         String algorithm = request.getParameter("digestAlgorithm");
         String salt = request.getParameter("salt");
         Date lastActive;
@@ -101,7 +101,7 @@ public class ClarinEPersonImportController {
         eperson.setSelfRegistered(selfRegistered);
         eperson.setLastActive(lastActive);
         //the password is already hashed in the request
-        PasswordHash passwordHash = new PasswordHash(algorithm, salt, password);
+        PasswordHash passwordHash = new PasswordHash(algorithm, salt, passwordHashStr);
         ePersonService.setPasswordHash(eperson, passwordHash);
         ePersonService.update(context, eperson);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinEPersonImportControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinEPersonImportControllerIT.java
@@ -75,7 +75,7 @@ public class ClarinEPersonImportControllerIT  extends AbstractControllerIntegrat
                             .param("projection", "full")
                             .param("selfRegistered", "true")
                             .param("lastActive", "2018-02-10T13:21:29.733")
-                            .param("password",
+                            .param("passwordHashStr",
                                     "5b62ec4a3492ec34f1e659e93a6c204c8a72b2f53d1a60e83f48bdb2e5718ebf")
                             .param("salt", "7f9d4e63bde7a0d546d8e6f4e32870f3")
                             .param("digestAlgorithm", "SHA-512"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinEPersonImportControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinEPersonImportControllerIT.java
@@ -74,7 +74,11 @@ public class ClarinEPersonImportControllerIT  extends AbstractControllerIntegrat
                             .contentType(contentType)
                             .param("projection", "full")
                             .param("selfRegistered", "true")
-                            .param("lastActive", "2018-02-10T13:21:29.733"))
+                            .param("lastActive", "2018-02-10T13:21:29.733")
+                            .param("password",
+                                    "5b62ec4a3492ec34f1e659e93a6c204c8a72b2f53d1a60e83f48bdb2e5718ebf")
+                            .param("salt", "7f9d4e63bde7a0d546d8e6f4e32870f3")
+                            .param("digestAlgorithm", "SHA-512"))
                     .andExpect(status().isOk())
                     .andDo(result -> idRef
                             .set(UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))));
@@ -88,7 +92,7 @@ public class ClarinEPersonImportControllerIT  extends AbstractControllerIntegrat
             assertFalse(createdEperson.getRequireCertificate());
             assertEquals(createdEperson.getFirstName(), "John");
             assertEquals(createdEperson.getLastName(), "Doe");
-
+            assertTrue(createdEperson.hasPasswordSet());
         } finally {
             EPersonBuilder.deleteEPerson(idRef.get());
         }


### PR DESCRIPTION
…unct

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
During migration, the password is already hashed; we do not want to hash it again.

## Solutioin
Use a different hash function during migration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced user import functionality to allow setting a pre-hashed password with its hashing algorithm and salt during import.

* **Tests**
  * Updated tests to cover the new password, salt, and digest algorithm parameters and to verify that imported users have a password set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->