### PR TITLE
UFAL/EU Sponsor openaire id should not be required

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -3228,7 +3228,7 @@
             <input name="code"  input-type="autocomplete" label="Grant no. or funding project code" placeholder="Start typing the name/number of the grant..." required="true"/>
             <input name="orgname" input-type="text" label="Funding organization" required="true"/>
             <input name="projname" input-type="autocomplete" label="Funding project name" required="true"/>
-            <input name="openaire_id" input-type="text" label="EU Project Identifier (OpenAIRE)" readonly="true" placeholder="Filled out automatically..." mapped-to-if-not-default="dc.relation" required="true"/>
+            <input name="openaire_id" input-type="text" label="EU Project Identifier (OpenAIRE)" readonly="true" placeholder="Filled out automatically..." mapped-to-if-not-default="dc.relation"/>
         </definition>
 
         <definition name="sizeInfo">

--- a/dspace/config/submission-forms_cs.xml
+++ b/dspace/config/submission-forms_cs.xml
@@ -3183,7 +3183,7 @@
             <input name="code"  input-type="autocomplete" label="Číslo grantu, nebo kód financujícího projektu" placeholder="Začněte psát jméno/číslo grantu..." required="true"/>
             <input name="orgname" input-type="text" label="Financující organizace" required="true"/>
             <input name="projname" input-type="autocomplete" label="Zdroj financí (jméno projektku)" required="true"/>
-            <input name="openaire_id" input-type="text" label="EU Project Identifier (OpenAIRE)" readonly="true" placeholder="Vyplněno automaticky..." mapped-to-if-not-default="dc.relation" required="true"/>
+            <input name="openaire_id" input-type="text" label="EU Project Identifier (OpenAIRE)" readonly="true" placeholder="Vyplněno automaticky..." mapped-to-if-not-default="dc.relation"/>
         </definition>
 
         <definition name="sizeInfo">


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Issue: https://github.com/dataquest-dev/dspace-angular/issues/896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The "EU Project Identifier (OpenAIRE)" field in the funding section is no longer required during submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->