### PR TITLE
UFAL/Update the resource policy rights when changing submitter

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
@@ -60,6 +60,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/" + RestAddressableModel.SUBMISSION)
 public class SubmissionController {
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(SubmissionController.class);
+    private static final int RESOURCE_POLICIES = 5 ; // Number of resource policies to create for the submitter
 
     @Autowired
     WorkspaceItemService workspaceItemService;
@@ -179,7 +180,7 @@ public class SubmissionController {
         // Remove resource policy for submitter
         resourcePolicyService.removePolicies(context, wsi.getItem(), ResourcePolicy.TYPE_SUBMISSION);
         // Create new ResourcePolicy for current user
-        for (int action = 0; action < 5; action++) {
+        for (int action = 0; action < RESOURCE_POLICIES; action++) {
             ResourcePolicy policy = resourcePolicyService.create(context, currentUser, null);
             policy.setdSpaceObject(wsi.getItem());
             policy.setRpType(ResourcePolicy.TYPE_SUBMISSION);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
@@ -60,7 +60,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/" + RestAddressableModel.SUBMISSION)
 public class SubmissionController {
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(SubmissionController.class);
-    private static final int RESOURCE_POLICIES = 5 ; // Number of resource policies to create for the submitter
 
     @Autowired
     WorkspaceItemService workspaceItemService;
@@ -177,15 +176,11 @@ public class SubmissionController {
             throw new AccessDeniedException(errorMessage);
         }
 
-        // Remove resource policy for submitter
-        resourcePolicyService.removePolicies(context, wsi.getItem(), ResourcePolicy.TYPE_SUBMISSION);
-        // Create new ResourcePolicy for current user
-        for (int action = 0; action < RESOURCE_POLICIES; action++) {
-            ResourcePolicy policy = resourcePolicyService.create(context, currentUser, null);
-            policy.setdSpaceObject(wsi.getItem());
-            policy.setRpType(ResourcePolicy.TYPE_SUBMISSION);
-            policy.setAction(action);
-            resourcePolicyService.update(context, policy);
+        List<ResourcePolicy> resourcePolicies = resourcePolicyService.find(context, wsi.getItem(), ResourcePolicy.TYPE_SUBMISSION);
+        // Set submitter
+        for (ResourcePolicy resourcePolicy: resourcePolicies) {
+            resourcePolicy.setEPerson(currentUser);
+            resourcePolicyService.update(context, resourcePolicy);
         }
 
         wsi.getItem().setSubmitter(currentUser);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
@@ -24,7 +24,10 @@ import org.dspace.app.rest.model.ShareSubmissionLinkDTO;
 import org.dspace.app.rest.model.WorkspaceItemRest;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.Collection;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
@@ -32,6 +35,8 @@ import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.web.ContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,6 +72,12 @@ public class SubmissionController {
 
     @Autowired
     AuthorizeService authorizeService;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    ResourcePolicyService resourcePolicyService;
 
     @Lazy
     @Autowired
@@ -145,12 +156,6 @@ public class SubmissionController {
         // Check the wsi does exist
         validateWorkspaceItem(wsi, null, shareToken);
 
-        if (!authorizeService.authorizeActionBoolean(context, wsi.getItem(), Constants.READ)) {
-            String errorMessage = "The current user does not have rights to view the WorkflowItem";
-            log.error(errorMessage);
-            throw new AccessDeniedException(errorMessage);
-        }
-
         // Set the owner of the workspace item to the current user
         EPerson currentUser = context.getCurrentUser();
         // If the current user is null, throw an exception
@@ -158,6 +163,28 @@ public class SubmissionController {
             String errorMessage = "The current user is not valid, it cannot be null.";
             log.error(errorMessage);
             throw new DSpaceBadRequestException(errorMessage);
+        }
+
+        Collection collection = wsi.getCollection();
+        Group submittersGroup = collection.getSubmitters();
+        boolean isSubmitterGroupMember = submittersGroup != null &&
+                groupService.isMember(context, currentUser, submittersGroup);
+        boolean canRead = authorizeService.authorizeActionBoolean(context, wsi.getItem(), Constants.READ);
+        if (!canRead && !isSubmitterGroupMember) {
+            String errorMessage = "The current user does not have rights to view or claim the WorkspaceItem";
+            log.error(errorMessage);
+            throw new AccessDeniedException(errorMessage);
+        }
+
+        // Remove resource policy for submitter
+        resourcePolicyService.removePolicies(context, wsi.getItem(), ResourcePolicy.TYPE_SUBMISSION);
+        // Create new ResourcePolicy for current user
+        for (int action = 0; action < 5; action++) {
+            ResourcePolicy policy = resourcePolicyService.create(context, currentUser, null);
+            policy.setdSpaceObject(wsi.getItem());
+            policy.setRpType(ResourcePolicy.TYPE_SUBMISSION);
+            policy.setAction(action);
+            resourcePolicyService.update(context, policy);
         }
 
         wsi.getItem().setSubmitter(currentUser);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionController.java
@@ -176,7 +176,8 @@ public class SubmissionController {
             throw new AccessDeniedException(errorMessage);
         }
 
-        List<ResourcePolicy> resourcePolicies = resourcePolicyService.find(context, wsi.getItem(), ResourcePolicy.TYPE_SUBMISSION);
+        List<ResourcePolicy> resourcePolicies = resourcePolicyService.find(context,
+                wsi.getItem(), ResourcePolicy.TYPE_SUBMISSION);
         // Set submitter
         for (ResourcePolicy resourcePolicy: resourcePolicies) {
             resourcePolicy.setEPerson(currentUser);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionControllerIT.java
@@ -23,12 +23,15 @@ import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.GroupBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +48,8 @@ public class SubmissionControllerIT extends AbstractControllerIntegrationTest {
     private WorkspaceItemService workspaceItemService;
     @Autowired
     private EPersonService ePersonService;
+    @Autowired
+    private GroupService groupService;
 
     WorkspaceItem wsi;
 
@@ -112,5 +117,75 @@ public class SubmissionControllerIT extends AbstractControllerIntegrationTest {
         updatedWsi = workspaceItemService.find(context, wsi.getID());
         assertThat(updatedWsi.getSubmitter().getEmail(), is(adminUser.getEmail()));
         assertThat(updatedWsi.getSubmitter().getEmail(), not(SUBMITTER_EMAIL));
+    }
+
+    @Test
+    public void generateShareTokenAndSetOwnerTo3rdPersonTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        EPerson submitter2 = EPersonBuilder.createEPerson(context)
+                .withEmail("user@test.edu")
+                .withPassword(password)
+                .build();
+        Group group = GroupBuilder.createCollectionSubmitterGroup(context, wsi.getCollection())
+                .withName("Test Submitters Group").build();
+        groupService.addMember(context, group, submitter2);
+        context.restoreAuthSystemState();
+
+
+        AtomicReference<String> shareLink = new AtomicReference<>();
+        EPerson currentUser = context.getCurrentUser();
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/submission/share")
+                        .param("workspaceitemid", wsi.getID().toString())
+                        .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.shareLink", is(notNullValue())))
+                .andDo(result -> shareLink.set(read(result.getResponse().getContentAsString(), "$.shareLink")));
+
+        // Check that the share token was set on the WorkspaceItem and persisted into the database
+        WorkspaceItem updatedWsi = workspaceItemService.find(context, wsi.getID());
+        assertThat(wsi.getID(), is(updatedWsi.getID()));
+        assertThat(updatedWsi.getSubmitter().getEmail(), is(SUBMITTER_EMAIL));
+        assertThat(updatedWsi.getSubmitter().getEmail(), not(currentUser.getEmail()));
+
+        EPerson adminUser = ePersonService.findByEmail(context, admin.getEmail());
+        context.setCurrentUser(adminUser);
+        // Set workspace item owner to the current user
+        getClient(adminToken).perform(get("/api/submission/setOwner")
+                        .param("shareToken", updatedWsi.getShareToken())
+                        .param("workspaceitemid", updatedWsi.getID().toString())
+                        .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        // Check that the owner of the WorkspaceItem was set to the current user
+        // Check the wsi was persisted into the database
+        updatedWsi = workspaceItemService.find(context, wsi.getID());
+        assertThat(updatedWsi.getSubmitter().getEmail(), is(adminUser.getEmail()));
+        assertThat(updatedWsi.getSubmitter().getEmail(), not(SUBMITTER_EMAIL));
+
+        getClient(adminToken).perform(get("/api/submission/share")
+                        .param("workspaceitemid", wsi.getID().toString())
+                        .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.shareLink", is(notNullValue())))
+                .andDo(result -> shareLink.set(read(result.getResponse().getContentAsString(), "$.shareLink")));
+
+        updatedWsi = workspaceItemService.find(context, wsi.getID());
+
+        context.setCurrentUser(submitter2);
+        String userToken = getAuthToken(submitter2.getEmail(), password);
+        // Set workspace item owner to the 3rd person
+        getClient(userToken).perform(get("/api/submission/setOwner")
+                        .param("shareToken", updatedWsi.getShareToken())
+                        .param("workspaceitemid", updatedWsi.getID().toString())
+                        .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        // Check that the owner of the WorkspaceItem was set to the current user
+        // Check the wsi was persisted into the database
+        updatedWsi = workspaceItemService.find(context, wsi.getID());
+        assertThat(updatedWsi.getSubmitter().getEmail(), is(submitter2.getEmail()));
+        assertThat(updatedWsi.getSubmitter().getEmail(), not(adminUser.getEmail()));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionControllerIT.java
@@ -131,7 +131,6 @@ public class SubmissionControllerIT extends AbstractControllerIntegrationTest {
         groupService.addMember(context, group, submitter2);
         context.restoreAuthSystemState();
 
-        AtomicReference<String> shareLink = new AtomicReference<>();
         EPerson currentUser = context.getCurrentUser();
 
         String adminToken = getAuthToken(admin.getEmail(), password);
@@ -139,8 +138,7 @@ public class SubmissionControllerIT extends AbstractControllerIntegrationTest {
                         .param("workspaceitemid", wsi.getID().toString())
                         .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.shareLink", is(notNullValue())))
-                .andDo(result -> shareLink.set(read(result.getResponse().getContentAsString(), "$.shareLink")));
+                .andExpect(jsonPath("$.shareLink", is(notNullValue())));
 
         // Check that the share token was set on the WorkspaceItem and persisted into the database
         WorkspaceItem updatedWsi = workspaceItemService.find(context, wsi.getID());
@@ -167,8 +165,7 @@ public class SubmissionControllerIT extends AbstractControllerIntegrationTest {
                         .param("workspaceitemid", wsi.getID().toString())
                         .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.shareLink", is(notNullValue())))
-                .andDo(result -> shareLink.set(read(result.getResponse().getContentAsString(), "$.shareLink")));
+                .andExpect(jsonPath("$.shareLink", is(notNullValue())));
 
         updatedWsi = workspaceItemService.find(context, wsi.getID());
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionControllerIT.java
@@ -131,7 +131,6 @@ public class SubmissionControllerIT extends AbstractControllerIntegrationTest {
         groupService.addMember(context, group, submitter2);
         context.restoreAuthSystemState();
 
-
         AtomicReference<String> shareLink = new AtomicReference<>();
         EPerson currentUser = context.getCurrentUser();
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  6  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

## Problem description
Changing the submitter did not update the resource policy rights.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded access control to allow users in the submitters group of a collection to access and claim ownership of workspace items, even without explicit READ permission.
  * Ownership of workspace items can now be transferred to users in the submitters group, updating submission rights accordingly.

* **Tests**
  * Added an integration test to verify share token generation and ownership transfer to a third user in the submitters group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->