### PR TITLE
UFAL/Added back the clarin-license step

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -463,6 +463,7 @@
             <step id="clariahSubmissionsPageThree"/>
             <step id="upload"/>
             <step id="license"/>
+            <step id="clarin-license"/>
             <step id="specialFields"/>
         </submission-process>
 
@@ -474,6 +475,7 @@
             <step id="teachingSubmissionsPageThree"/>
             <step id="upload"/>
             <step id="license"/>
+            <step id="clarin-license"/>
             <step id="specialFields"/>
         </submission-process>
     </submission-definitions>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Somehow, we removed important clarin-license steps in 2 submissions.
### Reported issues
#1004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "clarin-license" step to the submission workflows for both "clariah" and "teaching" submissions. This step now appears after the existing license step and before the special fields step during item submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->