### PR TITLE
UFAL/Item handle info in email after download request

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -47,6 +47,7 @@ import org.dspace.content.clarin.ClarinUserMetadata;
 import org.dspace.content.clarin.ClarinUserRegistration;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
 import org.dspace.content.service.clarin.ClarinLicenseResourceUserAllowanceService;
 import org.dspace.content.service.clarin.ClarinUserMetadataService;
@@ -86,6 +87,8 @@ public class ClarinUserMetadataRestController {
 
     @Autowired
     ItemService itemService;
+    @Autowired
+    ClarinItemService clarinItemService;
 
     @Autowired
     ConfigurationService configurationService;
@@ -172,7 +175,7 @@ public class ClarinUserMetadataRestController {
             try {
                 String email = getEmailFromUserMetadata(clarinUserMetadataRestList);
                 this.sendEmailWithDownloadLink(context, item, clarinLicense,
-                        email, downloadToken, MailType.ALLZIP, clarinUserMetadataRestList);
+                        email, downloadToken, MailType.ALLZIP, clarinUserMetadataRestList, item.getHandle());
             } catch (MessagingException e) {
                 log.error("Cannot send the download email because: " + e.getMessage());
                 throw new RuntimeException("Cannot send the download email because: " + e.getMessage());
@@ -252,8 +255,9 @@ public class ClarinUserMetadataRestController {
             // If yes - send token to e-mail
             try {
                 String email = getEmailFromUserMetadata(clarinUserMetadataRestList);
+                List<Item> items = clarinItemService.findByBitstreamUUID(context, bitstreamUUID);
                 this.sendEmailWithDownloadLink(context, bitstream, clarinLicense,
-                        email, downloadToken, MailType.BITSTREAM, clarinUserMetadataRestList);
+                        email, downloadToken, MailType.BITSTREAM, clarinUserMetadataRestList, items.get(0).getHandle());
             } catch (MessagingException e) {
                 log.error("Cannot send the download email because: " + e.getMessage());
                 throw new RuntimeException("Cannot send the download email because: " + e.getMessage());
@@ -271,7 +275,8 @@ public class ClarinUserMetadataRestController {
                                            String email,
                                            String downloadToken,
                                            MailType mailType,
-                                           List<ClarinUserMetadataRest> clarinUserMetadataRestList)
+                                           List<ClarinUserMetadataRest> clarinUserMetadataRestList,
+                                           String itemHandle)
             throws IOException, SQLException, MessagingException {
         if (StringUtils.isBlank(email)) {
             log.error("Cannot send email with download link because the email is empty.");
@@ -320,7 +325,8 @@ public class ClarinUserMetadataRestController {
         }
         // If previous mail fails with exception, this block never executes = admin is NOT
         // notified, if the mail is not really sent (if it fails HERE, not later, e.g. due to mail server issue).
-        sendAdminNotificationEmail(context, downloadLink, dso, clarinLicense, mailType, clarinUserMetadataRestList);
+        sendAdminNotificationEmail(context, downloadLink, dso, clarinLicense,
+                                    mailType, clarinUserMetadataRestList, itemHandle);
 
     }
 
@@ -347,7 +353,8 @@ public class ClarinUserMetadataRestController {
 
     private void addAdminEmailArguments(Email mail, MailType mailType, DSpaceObject dso, String downloadLink,
                                         ClarinLicense clarinLicense, Context context,
-                                        List<ClarinUserMetadataRest> extraMetadata) {
+                                        List<ClarinUserMetadataRest> extraMetadata,
+                                        String handle) {
         if (mailType == MailType.ALLZIP) {
             mail.addArgument("all files requested");
         } else if (mailType == MailType.BITSTREAM) {
@@ -372,6 +379,7 @@ public class ClarinUserMetadataRestController {
             exdata.append(data.getMetadataKey()).append(": ").append(data.getMetadataValue()).append(", ");
         }
         mail.addArgument(exdata.toString());
+        mail.addArgument(handle);
     }
 
     private void sendAdminNotificationEmail(Context context,
@@ -379,7 +387,8 @@ public class ClarinUserMetadataRestController {
                                             DSpaceObject dso,
                                             ClarinLicense clarinLicense,
                                             MailType mailType,
-                                            List<ClarinUserMetadataRest> extraMetadata)
+                                            List<ClarinUserMetadataRest> extraMetadata,
+                                            String itemHandle)
             throws MessagingException, IOException {
         try {
             Locale locale = context.getCurrentLocale();
@@ -391,7 +400,8 @@ public class ClarinUserMetadataRestController {
                 for (String cc : ccEmails) {
                     email2Admin.addRecipient(cc);
                 }
-                addAdminEmailArguments(email2Admin, mailType, dso, downloadLink, clarinLicense, context, extraMetadata);
+                addAdminEmailArguments(email2Admin, mailType, dso, downloadLink,
+                                            clarinLicense, context, extraMetadata, itemHandle);
 
             }
             email2Admin.send();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -361,7 +361,7 @@ public class ClarinUserMetadataRestController {
     private void addAdminEmailArguments(Email mail, MailType mailType, DSpaceObject dso, String downloadLink,
                                         ClarinLicense clarinLicense, Context context,
                                         List<ClarinUserMetadataRest> extraMetadata,
-                                        String handle) {
+                                        String itemHandle) {
         if (mailType == MailType.ALLZIP) {
             mail.addArgument("all files requested");
         } else if (mailType == MailType.BITSTREAM) {
@@ -386,7 +386,7 @@ public class ClarinUserMetadataRestController {
             exdata.append(data.getMetadataKey()).append(": ").append(data.getMetadataValue()).append(", ");
         }
         mail.addArgument(exdata.toString());
-        mail.addArgument(handle);
+        mail.addArgument(itemHandle);
     }
 
     private void sendAdminNotificationEmail(Context context,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -256,6 +256,9 @@ public class ClarinUserMetadataRestController {
             try {
                 String email = getEmailFromUserMetadata(clarinUserMetadataRestList);
                 List<Item> items = clarinItemService.findByBitstreamUUID(context, bitstreamUUID);
+                if (CollectionUtils.isEmpty(items)) {
+                    throw new NotFoundException("No items found for the given bitstream UUID: " + bitstreamUUID);
+                }
                 this.sendEmailWithDownloadLink(context, bitstream, clarinLicense,
                         email, downloadToken, MailType.BITSTREAM, clarinUserMetadataRestList, items.get(0).getHandle());
             } catch (MessagingException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -258,6 +258,10 @@ public class ClarinUserMetadataRestController {
                 List<Item> items = clarinItemService.findByBitstreamUUID(context, bitstreamUUID);
                 if (CollectionUtils.isEmpty(items)) {
                     throw new NotFoundException("No items found for the given bitstream UUID: " + bitstreamUUID);
+                } else if (items.size() > 1) {
+                    // This situation is not expected. A bitstream should be linked to only one item.
+                    log.error("Multiple items ({}) found for bitstream UUID: {}. Expected only one.",
+                            items.size(), bitstreamUUID);
                 }
                 this.sendEmailWithDownloadLink(context, bitstream, clarinLicense,
                         email, downloadToken, MailType.BITSTREAM, clarinUserMetadataRestList, items.get(0).getHandle());

--- a/dspace/config/emails/clarin_download_link_admin
+++ b/dspace/config/emails/clarin_download_link_admin
@@ -25,7 +25,7 @@ Link of the requested file (does not contain the download token):
 The file is distributed under specific license:
 	${params[2]}
 
-Item handle:
+Item's handle:
     ${params[6]}
 
 Extra information filled by the user:

--- a/dspace/config/emails/clarin_download_link_admin
+++ b/dspace/config/emails/clarin_download_link_admin
@@ -6,7 +6,7 @@
 ##             {3} user name
 ##             {4} user email
 ##             {5} extra metadata provided
-##             {6} item uuid
+##             {6} item handle
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##

--- a/dspace/config/emails/clarin_download_link_admin
+++ b/dspace/config/emails/clarin_download_link_admin
@@ -6,7 +6,7 @@
 ##             {3} user name
 ##             {4} user email
 ##             {5} extra metadata provided
-##             {6} item handle
+##             {6} item PID
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
@@ -25,7 +25,7 @@ Link of the requested file (does not contain the download token):
 The file is distributed under specific license:
 	${params[2]}
 
-Item's handle:
+Item's PID:
     ${params[6]}
 
 Extra information filled by the user:

--- a/dspace/config/emails/clarin_download_link_admin
+++ b/dspace/config/emails/clarin_download_link_admin
@@ -6,6 +6,7 @@
 ##             {3} user name
 ##             {4} user email
 ##             {5} extra metadata provided
+##             {6} item uuid
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
@@ -23,6 +24,9 @@ Link of the requested file (does not contain the download token):
   
 The file is distributed under specific license:
 	${params[2]}
+
+Item handle:
+    ${params[6]}
 
 Extra information filled by the user:
 	${params[5]}


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
### Reported issues
### Not-reported issues
## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin notification emails for file download requests now include the item handle for improved context.

* **Documentation**
  * Updated admin email template to display the item handle in notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->