### PR TITLE
UFAL/Fetching preview item data only when necessary

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
@@ -201,7 +201,7 @@ public class PreviewContentServiceImpl implements PreviewContentService {
     @Override
     public FileInfo createFileInfo(PreviewContent pc) {
         Hashtable<String, FileInfo> sub = createSubMap(pc.sub, this::createFileInfo);
-        return new FileInfo(pc.name, pc.content, pc.size, pc.isDirectory, sub);
+        return new FileInfo(pc.name, pc.content, pc.size, pc.isDirectory);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/util/FileInfo.java
+++ b/dspace-api/src/main/java/org/dspace/util/FileInfo.java
@@ -22,12 +22,11 @@ public class FileInfo {
 
     public Hashtable<String, FileInfo> sub = null;
 
-    public FileInfo(String name, String content, String size, boolean isDirectory, Hashtable<String, FileInfo> sub) {
+    public FileInfo(String name, String content, String size, boolean isDirectory) {
         this.name = name;
         this.content = content;
         this.size = size;
         this.isDirectory = isDirectory;
-        this.sub = sub;
     }
 
     public FileInfo(String name) {
@@ -44,5 +43,9 @@ public class FileInfo {
         this.name = name;
         this.size = size;
         isDirectory = false;
+    }
+
+    public void setSub(Hashtable<String, FileInfo> sub) {
+        this.sub = sub;
     }
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Items are prefetching their previews even without "preview" button clicked, it is unnecessary.
### Reported issues
[ufal#1212](https://github.com/ufal/clarin-dspace/issues/1212)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way file information is constructed and managed, allowing for more flexible assignment of file structure details. No changes to visible features or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->