### PR TITLE
UFAL/Local file size is 0 for file with no zero size

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -182,7 +182,7 @@ public class ClarinBitstreamImportController {
             }
             log.info("Going to update bitstream with UUID: " + bitstream.getID());
             bitstreamService.update(context, bitstream);
-            
+
             // If bitstream is deleted make it deleted
             if (deleted) {
                 bitstreamService.delete(context, bitstream);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -200,15 +200,8 @@ public class ClarinBitstreamImportController {
                 }
                 if (item != null) {
                     // Update item file metadata after the bitstream size has changed
-                    try {
-                        clarinItemService.updateItemFilesMetadata(context,
-                                item, bundle);
-                    } catch (Exception e) {
-                        String message = "Failed to update item file metadata for bundle with UUID: "
-                                + (bundle != null ? bundle.getID() : "null");
-                        log.error(message, e);
-                        throw new RuntimeException(message, e);
-                    }
+                    clarinItemService.updateItemFilesMetadata(context,
+                            item, bundle);
                     itemService.update(context, item);
                 }
                 bundleService.update(context, bundle);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -33,6 +33,7 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinBitstreamService;
+import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,6 +73,8 @@ public class ClarinBitstreamImportController {
     private Utils utils;
     @Autowired
     private MostRecentChecksumService checksumService;
+    @Autowired
+    protected ClarinItemService clarinItemService;
 
     /**
      * Endpoint for import bitstream, whose file already exists in assetstore under internal_id
@@ -179,7 +182,9 @@ public class ClarinBitstreamImportController {
             }
             log.info("Going to update bitstream with UUID: " + bitstream.getID());
             bitstreamService.update(context, bitstream);
-
+            // Update item file metadata after the bitstream size has changed
+            clarinItemService.updateItemFilesMetadata(context,
+                    (Item) bundleService.getParentObject(context, bundle), bundle);
             // If bitstream is deleted make it deleted
             if (deleted) {
                 bitstreamService.delete(context, bitstream);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -180,6 +180,7 @@ public class ClarinBitstreamImportController {
                             primaryBundleUUID, e);
                 }
             }
+            
             log.info("Going to update bitstream with UUID: " + bitstream.getID());
             bitstreamService.update(context, bitstream);
             // If bitstream is deleted make it deleted

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -182,9 +182,6 @@ public class ClarinBitstreamImportController {
             }
             log.info("Going to update bitstream with UUID: " + bitstream.getID());
             bitstreamService.update(context, bitstream);
-            // Update item file metadata after the bitstream size has changed
-            clarinItemService.updateItemFilesMetadata(context,
-                    (Item) bundleService.getParentObject(context, bundle), bundle);
             // If bitstream is deleted make it deleted
             if (deleted) {
                 bitstreamService.delete(context, bitstream);
@@ -202,6 +199,16 @@ public class ClarinBitstreamImportController {
                     throw new AccessDeniedException("You do not have write rights to update the Bundle's item");
                 }
                 if (item != null) {
+                    // Update item file metadata after the bitstream size has changed
+                    try {
+                        clarinItemService.updateItemFilesMetadata(context,
+                                item, bundle);
+                    } catch (Exception e) {
+                        String message = "Failed to update item file metadata for bundle with UUID: "
+                                + (bundle != null ? bundle.getID() : "null");
+                        log.error(message, e);
+                        throw new RuntimeException(message, e);
+                    }
                     itemService.update(context, item);
                 }
                 bundleService.update(context, bundle);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ClarinBitstreamImportController.java
@@ -180,9 +180,9 @@ public class ClarinBitstreamImportController {
                             primaryBundleUUID, e);
                 }
             }
-            
             log.info("Going to update bitstream with UUID: " + bitstream.getID());
             bitstreamService.update(context, bitstream);
+            
             // If bitstream is deleted make it deleted
             if (deleted) {
                 bitstreamService.delete(context, bitstream);


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Local file size is 0, but the file exists and its size is not 0. The item's metadata was not updated when the bitstream size changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of item file metadata updates after changes to bitstream properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->