### PR TITLE
UFAL/New version keeps the old identifier

### DIFF
--- a/dspace/config/spring/api/versioning-service.xml
+++ b/dspace/config/spring/api/versioning-service.xml
@@ -22,6 +22,7 @@
                    <set>
                        <value>dc.date.accessioned</value>
                        <value>dc.description.provenance</value>
+                       <value>dc.identifier.uri</value>
                    </set>
                </property>
                


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
New version of item keeps the old identifier.

The old identifier is copied to the workflow, after converting the workflow to archive item, the old identifier is standardly removed. By this update the old identifier is NOT copied to the workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated versioning service configuration to exclude "dc.identifier.uri" from metadata replication or versioning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->