### PR TITLE
UFAL/Zip download missing content length header

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -9,8 +9,10 @@ package org.dspace.app.rest;
 
 import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Objects;
@@ -119,7 +121,8 @@ public class MetadataBitstreamController {
         response.setContentType("application/zip");
         List<Bundle> bundles = item.getBundles("ORIGINAL");
 
-        ZipArchiveOutputStream zip = new ZipArchiveOutputStream(response.getOutputStream());
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ZipArchiveOutputStream zip = new ZipArchiveOutputStream(baos);
         zip.setCreateUnicodeExtraFields(ZipArchiveOutputStream.UnicodeExtraFieldPolicy.ALWAYS);
         zip.setLevel(Deflater.NO_COMPRESSION);
         for (Bundle original : bundles) {
@@ -140,7 +143,18 @@ public class MetadataBitstreamController {
             }
         }
         zip.close();
+
+        byte[] zipBytes = baos.toByteArray();
+
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s\"", name));
+        response.setContentType("application/zip");
+        response.setContentLength(zipBytes.length);
+
+        try (OutputStream out = response.getOutputStream()) {
+            out.write(zipBytes);
+            out.flush();
+        }
+
         matomoBitstreamTracker.trackBitstreamDownload(context, request, bitstreamForStatistics, true);
-        response.getOutputStream().flush();
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -146,8 +146,6 @@ public class MetadataBitstreamController {
 
         byte[] zipBytes = baos.toByteArray();
 
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s\"", name));
-        response.setContentType("application/zip");
         response.setContentLength(zipBytes.length);
 
         try (OutputStream out = response.getOutputStream()) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -7,17 +7,13 @@
  */
 package org.dspace.app.rest;
 
+import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.util.zip.Deflater;
 
 import org.apache.commons.codec.CharEncoding;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
@@ -31,7 +27,9 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.service.BitstreamService;
 import org.junit.Test;
+import org.purl.sword.base.HttpHeaders;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MvcResult;
 
 public class MetadataBitstreamControllerIT extends AbstractControllerIntegrationTest {
     private static final String METADATABITSTREAM_ENDPOINT = "/api/" + ItemRest.CATEGORY + "/" + ItemRest.PLURAL_NAME;
@@ -78,23 +76,27 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
 
     @Test
     public void downloadAllZip() throws Exception {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        ZipArchiveOutputStream zip = new ZipArchiveOutputStream(byteArrayOutputStream);
-        zip.setCreateUnicodeExtraFields(ZipArchiveOutputStream.UnicodeExtraFieldPolicy.ALWAYS);
-        zip.setLevel(Deflater.NO_COMPRESSION);
-        ZipArchiveEntry ze = new ZipArchiveEntry(bts.getName());
-        zip.putArchiveEntry(ze);
-        InputStream is = bitstreamService.retrieve(context, bts);
-        org.apache.commons.compress.utils.IOUtils.copy(is, zip);
-        zip.closeArchiveEntry();
-        is.close();
-        zip.close();
-
         String token = getAuthToken(admin.getEmail(), password);
-        getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + publicItem.getID() +
+
+        MvcResult result = getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + publicItem.getID() +
                         "/" + ALL_ZIP_PATH).param(HANDLE_PARAM, publicItem.getHandle()))
                 .andExpect(status().isOk())
-                .andExpect(content().bytes(byteArrayOutputStream.toByteArray()));
+                .andReturn();
 
+        byte[] responseBytes = result.getResponse().getContentAsByteArray();
+        long actualContentLength = responseBytes.length;
+
+        String contentLengthHeader = result.getResponse().getHeader(HttpHeaders.CONTENT_LENGTH);
+        String contentTypeHeader = result.getResponse().getHeader("Content-Type");
+        String contentDispositionHeader = result.getResponse().getHeader(HttpHeaders.CONTENT_DISPOSITION);
+
+        assertNotNull(contentLengthHeader);
+        assertEquals(String.valueOf(actualContentLength), contentLengthHeader);
+
+        assertNotNull(contentTypeHeader);
+        assertTrue(contentTypeHeader.startsWith("application/zip"));
+
+        assertNotNull(contentDispositionHeader);
+        assertTrue(contentDispositionHeader.startsWith("attachment"));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -7,7 +7,9 @@
  */
 package org.dspace.app.rest;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -13,7 +13,10 @@ import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
@@ -100,5 +103,10 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
 
         assertNotNull(contentDispositionHeader);
         assertTrue(contentDispositionHeader.startsWith("attachment"));
+        try (ZipInputStream zipIn = new ZipInputStream(new ByteArrayInputStream(responseBytes))) {
+            ZipEntry entry = zipIn.getNextEntry();
+            assertNotNull("ZIP should contain at least one entry.", entry);
+            assertEquals("Bitstream", entry.getName());
+        }
     }
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When downloading ZIP files, the missing Content-Length header prevents the browser from knowing the file size and download time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP file download reliability by correctly setting response headers and content length.

* **Tests**
  * Enhanced tests to validate HTTP headers and ZIP content structure for downloads, improving test accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->