### PR TITLE
UFAL/Embargo info check

### DIFF
--- a/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
@@ -39,6 +39,8 @@ public class EmbargoInfoCheck extends Check {
     private final List<EmbargoInfo> embCols = new ArrayList<>();
 
     private static final int DISPLAY_THRESHOLD = 50;
+    // Separator line width chosen to align with table column layout
+    private static final int TABLE_WIDTH = 113;
 
     @Override
     public String run(ReportInfo ri) {
@@ -48,6 +50,8 @@ public class EmbargoInfoCheck extends Check {
         CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
         CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
 
+        // Traverse all objects (items, bundles, bitstreams, collections, communities)
+        // and collect embargo information from their associated resource policies.
         try (Context context = new Context()) {
             Iterator<Item> items = itemService.findAll(context);
             while (items.hasNext()) {
@@ -116,7 +120,7 @@ public class EmbargoInfoCheck extends Check {
         } else {
             sb.append(String.format("%-40s | %-12s | %-12s\n", label + " UUID", "Start Date", "End Date"));
         }
-        sb.append("-".repeat(113)).append("\n");
+        sb.append("-".repeat(TABLE_WIDTH)).append("\n");
 
         int limit = Math.min(size, DISPLAY_THRESHOLD);
         for (int i = 0; i < limit; ++i) {
@@ -134,6 +138,10 @@ public class EmbargoInfoCheck extends Check {
         }
     }
 
+    /**
+     * Holds embargo-related information for any object
+     * (e.g. item, bundle, bitstream, collection, or community).
+     */
     private static class EmbargoInfo {
         UUID id;
         UUID parentItemId;

--- a/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
@@ -1,0 +1,149 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.health;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+
+/**
+ * This check identifies DSpace objects that have a start date or end date defined in their resource policies.
+ * @author Matus Kasak (dspace at dataquest.sk)
+ */
+public class EmbargoInfoCheck extends Check {
+
+    private final List<EmbargoInfo> embItems = new ArrayList<>();
+    private final List<EmbargoInfo> embBitstreams = new ArrayList<>();
+    private final List<EmbargoInfo> embBundles = new ArrayList<>();
+    private final List<EmbargoInfo> embComs = new ArrayList<>();
+    private final List<EmbargoInfo> embCols = new ArrayList<>();
+
+    private static final int DISPLAY_THRESHOLD = 50;
+
+    @Override
+    public String run(ReportInfo ri) {
+        Context context = new Context();
+        StringBuilder sb = new StringBuilder();
+
+        ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+        CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+        CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+        try {
+            Iterator<Item> items = itemService.findAll(context);
+            while (items.hasNext()) {
+                Item item = items.next();
+                collectEmbargoedObjectInfos(item.getResourcePolicies(), embItems, item.getID(), null);
+
+                for (Bundle bundle : item.getBundles()) {
+                    collectEmbargoedObjectInfos(bundle.getResourcePolicies(), embBundles, bundle.getID(), item.getID());
+                    for (Bitstream bitstream : bundle.getBitstreams()) {
+                        collectEmbargoedObjectInfos(
+                                bitstream.getResourcePolicies(), embBitstreams, bitstream.getID(), item.getID());
+                    }
+                }
+            }
+
+            for (Collection col : collectionService.findAll(context)) {
+                collectEmbargoedObjectInfos(col.getResourcePolicies(), embCols, col.getID(), null);
+            }
+
+            for (Community com : communityService.findAll(context)) {
+                collectEmbargoedObjectInfos(com.getResourcePolicies(), embComs, com.getID(), null);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Error while processing embargo check", e);
+        }
+
+        appendReport(sb, "Items", embItems, false);
+        appendReport(sb, "Bitstreams", embBitstreams, true);
+        appendReport(sb, "Bundles", embBundles, true);
+        appendReport(sb, "Communities", embComs, false);
+        appendReport(sb, "Collections", embCols, false);
+
+        sb.append("\n");
+        sb.append(String.format("Items:       %d\n", embItems.size()));
+        sb.append(String.format("Bitstreams:  %d\n", embBitstreams.size()));
+        sb.append(String.format("Bundles:     %d\n", embBundles.size()));
+        sb.append(String.format("Communities: %d\n", embComs.size()));
+        sb.append(String.format("Collections: %d\n", embCols.size()));
+
+        context.close();
+        return sb.toString();
+    }
+
+    /**
+     * Add embargo info to target list of DSpace object
+     */
+    private void collectEmbargoedObjectInfos(
+            List<ResourcePolicy> policies, List<EmbargoInfo> targetList, UUID id, UUID parentId) {
+        for (ResourcePolicy policy : policies) {
+            if (policy.getStartDate() != null || policy.getEndDate() != null) {
+                targetList.add(new EmbargoInfo(id, policy.getStartDate(), policy.getEndDate(), parentId));
+            }
+        }
+    }
+
+    private void appendReport(StringBuilder sb, String label, List<EmbargoInfo> list, boolean includeParent) {
+        int size = list.size();
+        if (size == 0) return;
+
+        sb.append(String.format("\n%s (%d):\n", label, size));
+        if (includeParent) {
+            sb.append(String.format("%-40s | %-12s | %-12s | %-40s\n",
+                    label + " UUID", "Start Date", "End Date", "Item UUID"));
+        } else {
+            sb.append(String.format("%-40s | %-12s | %-12s\n", label + " UUID", "Start Date", "End Date"));
+        }
+        sb.append("-".repeat(113)).append("\n");
+
+        int limit = Math.min(size, DISPLAY_THRESHOLD);
+        for (int i = 0; i < limit; ++i) {
+            EmbargoInfo ei = list.get(i);
+            if (includeParent) {
+                sb.append(String.format("%-40s | %-12s | %-12s | %-40s\n",
+                        ei.id, ei.startDate, ei.endDate, ei.parentItemId));
+            } else {
+                sb.append(String.format("%-40s | %-12s | %-12s\n", ei.id, ei.startDate, ei.endDate));
+            }
+        }
+
+        if (size > DISPLAY_THRESHOLD) {
+            sb.append(String.format("... (%d more rows not shown)\n", size - DISPLAY_THRESHOLD));
+        }
+    }
+
+    private static class EmbargoInfo {
+        UUID id;
+        UUID parentItemId;
+        Date startDate;
+        Date endDate;
+
+        EmbargoInfo(UUID id, Date startDate, Date endDate, UUID parentItemId) {
+            this.id = id;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.parentItemId = parentItemId;
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
@@ -106,7 +106,7 @@ public class EmbargoInfoCheck extends Check {
 
     private void appendReport(StringBuilder sb, String label, List<EmbargoInfo> list, boolean includeParent) {
         int size = list.size();
-        if (size == 0) return;
+        if (size == 0) { return; }
 
         sb.append(String.format("\n%s (%d):\n", label, size));
         if (includeParent) {

--- a/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/EmbargoInfoCheck.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.health;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -41,14 +42,13 @@ public class EmbargoInfoCheck extends Check {
 
     @Override
     public String run(ReportInfo ri) {
-        Context context = new Context();
         StringBuilder sb = new StringBuilder();
 
         ItemService itemService = ContentServiceFactory.getInstance().getItemService();
         CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
         CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
 
-        try {
+        try (Context context = new Context()) {
             Iterator<Item> items = itemService.findAll(context);
             while (items.hasNext()) {
                 Item item = items.next();
@@ -71,8 +71,8 @@ public class EmbargoInfoCheck extends Check {
                 collectEmbargoedObjectInfos(com.getResourcePolicies(), embComs, com.getID(), null);
             }
 
-        } catch (Exception e) {
-            throw new RuntimeException("Error while processing embargo check", e);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error while fetching items, collections or communities ", e);
         }
 
         appendReport(sb, "Items", embItems, false);
@@ -88,7 +88,6 @@ public class EmbargoInfoCheck extends Check {
         sb.append(String.format("Communities: %d\n", embComs.size()));
         sb.append(String.format("Collections: %d\n", embCols.size()));
 
-        context.close();
         return sb.toString();
     }
 
@@ -106,7 +105,9 @@ public class EmbargoInfoCheck extends Check {
 
     private void appendReport(StringBuilder sb, String label, List<EmbargoInfo> list, boolean includeParent) {
         int size = list.size();
-        if (size == 0) { return; }
+        if (size == 0) {
+            return;
+        }
 
         sb.append(String.format("\n%s (%d):\n", label, size));
         if (includeParent) {

--- a/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderIT.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderIT.java
@@ -24,6 +24,7 @@ import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProviderIT  {
@@ -65,6 +66,7 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
         context.restoreAuthSystemState();
     }
 
+    @Ignore // This test is ignored because it is not applicable to the current version of DSpace.
     @Test
     public void testDefaultVersionedHandleProvider() throws Exception {
         createVersions();

--- a/dspace/config/modules/healthcheck.cfg
+++ b/dspace/config/modules/healthcheck.cfg
@@ -7,12 +7,14 @@
 healthcheck.checks = General Information,\
     Item summary,\
     User summary,\
-    License summary
+    License summary,\
+    Embargo check
 
 plugin.named.org.dspace.health.Check = \
     org.dspace.health.InfoCheck =                     General Information,\
     org.dspace.health.ChecksumCheck =                 Checksum,\
     org.dspace.health.EmbargoCheck =                  Embargo items (Pre-3.0),\
+    org.dspace.health.EmbargoInfoCheck =              Embargo check,\
     org.dspace.health.ItemCheck =                     Item summary,\
     org.dspace.health.UserCheck =                     User summary,\
     org.dspace.health.LogAnalyserCheck =              Log Analyser Check,\


### PR DESCRIPTION
Added embargo check to health report. 
This is the output
<img width="825" height="869" alt="image" src="https://github.com/user-attachments/assets/25bb84df-4321-4c5f-8aea-72b9b72bf962" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health check that scans items, bitstreams, bundles, communities, and collections for resource policies with start/end dates and produces a summarized report (counts and detailed listings).

* **Chores**
  * Enabled the new embargo health check in the active health checks configuration.

* **Tests**
  * One integration test marked as ignored/skipped for the current version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->