### PR TITLE
UFAL/Turn off direct download

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -167,6 +167,9 @@ public class BitstreamRestController {
                     currentUser != null ? currentUser.getID() : null,
                     context.getSpecialGroupUuids(), citationEnabledForBitstream);
 
+            // Track the download statistics - only if the downloading has started (the condition is inside the method)
+            matomoBitstreamTracker.trackBitstreamDownload(context, request, bit, false);
+
             HttpHeadersInitializer httpHeadersInitializer = new HttpHeadersInitializer()
                 .withBufferSize(BUFFER_SIZE)
                 .withFileName(name)
@@ -188,9 +191,6 @@ public class BitstreamRestController {
                     || checkFormatForContentDisposition(format)) {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
             }
-
-            // Track the download statistics - only if the downloading has started (the condition is inside the method)
-            matomoBitstreamTracker.trackBitstreamDownload(context, request, bit, false);
 
             //We have all the data we need, close the connection to the database so that it doesn't stay open during
             //download/streaming

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -149,8 +149,9 @@ public class BitstreamRestController {
 
         try {
             boolean s3DirectDownload = configurationService.getBooleanProperty("s3.download.direct.enabled");
+            boolean s3AssetstoreEnabled = configurationService.getBooleanProperty("assetstore.s3.enabled");
             boolean hasOriginalBundle = false;
-            if (s3DirectDownload) {
+            if (s3DirectDownload && s3AssetstoreEnabled) {
                 // Download only files which are stored in the `ORIGINAL` bundle, because some specific files are
                 // not correctly downloaded and displayed in the UI when using presigned URLs. E.g., the
                 // process output.

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -101,7 +101,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.IfProfileValue;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
@@ -111,7 +110,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
  * @author Tom Desair (tom dot desair at atmire dot com)
  * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
  */
-@TestPropertySource(locations = "classpath:dspace.cfg")
 public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest {
 
     protected SolrLoggerService solrLoggerService = StatisticsServiceFactory.getInstance().getSolrLoggerService();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -100,7 +100,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.EnabledIf;
+import org.springframework.test.annotation.IfProfileValue;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
@@ -110,6 +111,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
  * @author Tom Desair (tom dot desair at atmire dot com)
  * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
  */
+@TestPropertySource(locations = "classpath:dspace.cfg")
 public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest {
 
     protected SolrLoggerService solrLoggerService = StatisticsServiceFactory.getInstance().getSolrLoggerService();
@@ -1562,9 +1564,8 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
     }
 
-    @EnabledIf(expression = "#{environment['s3.download.direct.enabled'] == 'true'}",
-            reason = "Requires direct S3 download enabled")
     @Test
+    @IfProfileValue(name = "s3.download.direct.enabled", value = "true")
     public void testS3DirectDownloadRedirect() throws Exception {
         // Enable S3 direct download for test
         configurationService.setProperty("s3.download.direct.enabled", true);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -100,9 +100,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 /**
  * Integration test to test the /api/core/bitstreams/[id]/* endpoints

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -102,6 +102,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 /**
  * Integration test to test the /api/core/bitstreams/[id]/* endpoints
@@ -1561,6 +1562,8 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
     }
 
+    @EnabledIf(expression = "#{environment['s3.download.direct.enabled'] == 'true'}",
+            reason = "Requires direct S3 download enabled")
     @Test
     public void testS3DirectDownloadRedirect() throws Exception {
         // Enable S3 direct download for test

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -259,9 +259,9 @@ file.preview.zip.limit.length = 1000
 # Synchronization is NOT enabled by default
 sync.storage.service.enabled = true
 # Upload large file by parts - check the checksum of every part
-s3.upload.by.parts.enabled = true
+s3.upload.by.parts.enabled = false
 # Enable direct downloading from the S3
-s3.download.direct.enabled = true
+s3.download.direct.enabled = false
 # The expiration time of the signed URL for direct download
 s3.download.direct.expiration = 3600
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to disable S3 multipart upload and direct download features by default.
  * Modified S3 direct download behavior to require both direct download and asset store enablement flags.
  * Adjusted test execution to run S3 direct download tests only when the feature is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->