### PR TITLE
VSB-TUO/Changed dspace.server.url to localhost

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -25,7 +25,7 @@ dspace.dir = /dspace
 # NOTE: This URL must be accessible to all DSpace users (should not use 'localhost' in Production)
 # and is usually "synced" with the "rest" section in the DSpace User Interface's config.*.yml.
 # It corresponds to the URL that you would type into your browser to access the REST API.
-dspace.server.url = https://dspace.vsb.cz/
+dspace.server.url = http://localhost:8080/server
 # Additional URL of DSpace backend which could be used by DSpace frontend during SSR execution.
 # May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
`dspace.server.url` was set to `https://dspace.vsb.cz/` what made it unavailable on localhost