### PR TITLE
VSB-TUO/Oai-phm nusl does not work

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -330,3 +330,6 @@ webui.supported.locales = cs
 ##### S3 #####
 # S3 direct download is not used in the test environment
 s3.download.direct.enabled = false
+
+# Default language for metadata values
+default.language = en

--- a/dspace/config/crosswalks/oai/metadataFormats/mets_nusl.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets_nusl.xsl
@@ -15,7 +15,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:doc="http://www.lyncode.com/xoai"
                 xmlns:date="http://exslt.org/dates-and-times"
-                extension-element-prefixes="date" version="1.0">
+                extension-element-prefixes="date" version="2.0">
 
     <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
@@ -32,7 +32,7 @@
             </xsl:attribute>
             <metsHdr>
                 <xsl:attribute name="CREATEDATE">
-                    <xsl:value-of select="concat(date:format-date(date:date(), 'yyyy-MM-dd'), 'T' , date:format-date(date:time(), 'HH:mm:ss'), 'Z')"/>
+                    <xsl:value-of select="format-dateTime(current-dateTime(), '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]Z')"/>
                 </xsl:attribute>
                 <agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
                     <name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -474,6 +474,11 @@ filter.plugins = Text Extractor
 
 #Assign 'human-understandable' names to each filter
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = Text Extractor
+plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = PDF Text Extractor
+plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = HTML Text Extractor
+plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = Word Text Extractor
+plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = Excel Text Extractor
+plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = PowerPoint Text Extractor
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.JPEGFilter = JPEG Thumbnail
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.BrandedPreviewJPEGFilter = Branded Preview JPEG
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.PDFBoxThumbnail = PDFBox JPEG Thumbnail
@@ -1622,7 +1627,7 @@ google.recaptcha.site-verify = https://www.google.com/recaptcha/api/siteverify
 # for v2 we can choice between invisible and checkbox
 # invisible - The invisible reCAPTCHA badge does not require the user to click on a checkbox,
 #             instead it is invoked directly when the user clicks on an existing button on your site
-# checkbox - The "I'm not a robot" Checkbox requires the user to click a checkbox indicating the user is not a robot.
+# checkbox - The "I'm not a robot" Checkbox requires the user to click on a checkbox indicating the user is not a robot.
 #google.recaptcha.mode =
 
 #------------------------------------------------------------------#

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd" default-lazy-init="true">
 
-    <bean name="org.dspace.storage.bitstore.BitstreamStorageService" class="org.dspace.storage.bitstore.SyncBitstreamStorageServiceImpl">
+    <bean name="org.dspace.storage.bitstore.BitstreamStorageService" class="org.dspace.storage.bitstore.BitstreamStorageServiceImpl">
         <property name="incoming" value="${assetstore.index.primary}"/>
         <property name="stores">
             <map>

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd" default-lazy-init="true">
 
-    <bean name="org.dspace.storage.bitstore.BitstreamStorageService" class="org.dspace.storage.bitstore.SyncBitstreamStorageServiceImpl">
+    <bean id="bitstreamStorageService" name="org.dspace.storage.bitstore.BitstreamStorageService" class="org.dspace.storage.bitstore.SyncBitstreamStorageServiceImpl">
         <property name="incoming" value="${assetstore.index.primary}"/>
         <property name="stores">
             <map>

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd" default-lazy-init="true">
 
-    <bean id="bitstreamStorageService" name="org.dspace.storage.bitstore.BitstreamStorageService" class="org.dspace.storage.bitstore.SyncBitstreamStorageServiceImpl">
+    <bean name="org.dspace.storage.bitstore.BitstreamStorageService" class="org.dspace.storage.bitstore.SyncBitstreamStorageServiceImpl">
         <property name="incoming" value="${assetstore.index.primary}"/>
         <property name="stores">
             <map>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  1  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  4  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
<img width="1600" height="306" alt="image" src="https://github.com/user-attachments/assets/5b018b76-f393-47d2-8153-bae129b3e235" />
## Problem solution
Fix EXSLT date formatting function compatibility issue in mets_nusl.xsl by replacing format-dateTime() with XSLT 2.0 standard date formatting to resolve Saxon processor errors.