### PR TITLE
ZCU-PUB/New endpoint for embargo info (start_date & end_date)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -67,6 +67,16 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
         return resourcePolicyDAO.findByID(context, ResourcePolicy.class, id);
     }
 
+    @Override
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException {
+        return resourcePolicyDAO.findAll(context, offset, limit);
+    }
+
+    @Override
+    public int countAll(Context context) throws SQLException {
+        return resourcePolicyDAO.countAll(context);
+    }
+
     /**
      * Create a new ResourcePolicy
      *
@@ -408,6 +418,17 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     @Override
     public int countByGroupAndResourceUuid(Context context, Group group, UUID resourceUuid) throws SQLException {
         return resourcePolicyDAO.countByGroupAndResourceUuid(context, group, resourceUuid);
+    }
+
+    @Override
+    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException {
+        return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, offset, limit);
+    }
+
+    @Override
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
+        return resourcePolicyDAO.countByDatePresence(context, hasStartDate, hasEndDate);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -421,7 +421,8 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     }
 
     @Override
-    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate, int offset, int limit) throws SQLException {
+    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate, 
+                                                   int offset, int limit) throws SQLException {
         return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, offset, limit);
     }
 

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -421,15 +421,13 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     }
 
     @Override
-    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   boolean useAndLogic, int offset, int limit) throws SQLException {
-        return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, useAndLogic, offset, limit);
+    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate, int offset, int limit) throws SQLException {
+        return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, offset, limit);
     }
 
     @Override
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                   boolean useAndLogic) throws SQLException {
-        return resourcePolicyDAO.countByDatePresence(context, hasStartDate, hasEndDate, useAndLogic);
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
+        return resourcePolicyDAO.countByDatePresence(context, hasStartDate, hasEndDate);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -421,7 +421,7 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     }
 
     @Override
-    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate, 
+    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException {
         return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, offset, limit);
     }

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -422,13 +422,14 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
 
     @Override
     public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   int offset, int limit) throws SQLException {
-        return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, offset, limit);
+                                                   boolean useAndLogic, int offset, int limit) throws SQLException {
+        return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, useAndLogic, offset, limit);
     }
 
     @Override
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
-        return resourcePolicyDAO.countByDatePresence(context, hasStartDate, hasEndDate);
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                   boolean useAndLogic) throws SQLException {
+        return resourcePolicyDAO.countByDatePresence(context, hasStartDate, hasEndDate, useAndLogic);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -421,14 +421,14 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     }
 
     @Override
-    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException {
-        return resourcePolicyDAO.findByDatePresence(context, hasStartDate, hasEndDate, offset, limit);
+        return resourcePolicyDAO.findByDate(context, hasStartDate, hasEndDate, offset, limit);
     }
 
     @Override
-    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
-        return resourcePolicyDAO.countByDatePresence(context, hasStartDate, hasEndDate);
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
+        return resourcePolicyDAO.countByDate(context, hasStartDate, hasEndDate);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -427,7 +427,7 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     }
 
     @Override
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
+    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
         return resourcePolicyDAO.countByDatePresence(context, hasStartDate, hasEndDate);
     }
 

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -289,14 +289,14 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
      * @return               list of resource policies matching the criteria
      * @throws SQLException  if database error occurs
      */
-    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException;
 
     /**
      * Count resource policies based on embargo date presence criteria.
      * 
      * This method provides the total count for the same filtering logic as
-     * {@link #findByDatePresence(Context, Boolean, Boolean, int, int)} but without
+     * {@link #findByDate(Context, Boolean, Boolean, int, int)} but without
      * pagination parameters. Used for calculating total pages in REST API responses.
      *
      * @param context        DSpace context object
@@ -305,5 +305,5 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
      * @return               total count of resource policies matching the criteria
      * @throws SQLException  if database error occurs
      */
-    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -263,47 +263,27 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     public int countAll(Context context) throws SQLException;
 
     /**
-     * Find resource policies based on embargo date presence criteria.
-     * <p>
-     * This method enables flexible querying of ResourcePolicies based on the presence
-     * or absence of start and end dates. It supports various filtering combinations:
+     * Return a paginated list of policies based on embargo date presence criteria
      * 
-     * <ul>
-     * <li><b>Default (both null):</b> Returns policies with any dates (startDate OR endDate)</li>
-     * <li><b>Both true:</b> Returns policies with both startDate AND endDate</li>
-     * <li><b>Both false:</b> Returns policies without any dates (permanent policies)</li>
-     * <li><b>hasStartDate=true, hasEndDate=null:</b> Returns policies with startDate present</li>
-     * <li><b>hasStartDate=null, hasEndDate=true:</b> Returns policies with endDate present</li>
-     * <li><b>hasStartDate=true, hasEndDate=false:</b> Returns policies with startDate only</li>
-     * <li><b>hasStartDate=false, hasEndDate=true:</b> Returns policies with endDate only</li>
-     * </ul>
-     * 
-     * This method is primarily used by the embargo REST endpoint to filter policies
-     * based on embargo status and date configurations.
-     *
      * @param context        DSpace context object
-     * @param hasStartDate   null=any, true=required, false=must be absent
-     * @param hasEndDate     null=any, true=required, false=must be absent
-     * @param offset         the position of the first result to return (pagination)
-     * @param limit          maximum number of results to return (pagination)
-     * @return               list of resource policies matching the criteria
-     * @throws SQLException  if database error occurs
+     * @param hasStartDate   filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate     filter for end date presence, null=any, true=required, false=must be absent
+     * @param offset         the position of the first result to return
+     * @param limit          paging limit
+     * @return               list of resource policies
+     * @throws SQLException  if database error
      */
     public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException;
 
     /**
-     * Count resource policies based on embargo date presence criteria.
+     * Count all the resource policies based on embargo date presence criteria
      * 
-     * This method provides the total count for the same filtering logic as
-     * {@link #findByDate(Context, Boolean, Boolean, int, int)} but without
-     * pagination parameters. Used for calculating total pages in REST API responses.
-     *
      * @param context        DSpace context object
-     * @param hasStartDate   null=any, true=required, false=must be absent
-     * @param hasEndDate     null=any, true=required, false=must be absent
-     * @return               total count of resource policies matching the criteria
-     * @throws SQLException  if database error occurs
+     * @param hasStartDate   filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate     filter for end date presence, null=any, true=required, false=must be absent
+     * @return               total policies
+     * @throws SQLException  if database error
      */
     public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -271,9 +271,11 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
      * <ul>
      * <li><b>Default (both null):</b> Returns policies with any dates (startDate OR endDate)</li>
      * <li><b>Both true:</b> Returns policies with both startDate AND endDate</li>
-     * <li><b>hasStartDate=true, hasEndDate=null:</b> Returns policies with startDate only</li>
-     * <li><b>hasStartDate=null, hasEndDate=true:</b> Returns policies with endDate only</li>
      * <li><b>Both false:</b> Returns policies without any dates (permanent policies)</li>
+     * <li><b>hasStartDate=true, hasEndDate=null:</b> Returns policies with startDate present</li>
+     * <li><b>hasStartDate=null, hasEndDate=true:</b> Returns policies with endDate present</li>
+     * <li><b>hasStartDate=true, hasEndDate=false:</b> Returns policies with startDate only</li>
+     * <li><b>hasStartDate=false, hasEndDate=true:</b> Returns policies with endDate only</li>
      * </ul>
      * 
      * This method is primarily used by the embargo REST endpoint to filter policies
@@ -298,8 +300,8 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
      * pagination parameters. Used for calculating total pages in REST API responses.
      *
      * @param context        DSpace context object
-     * @param hasStartDate   true=required, false=must be absent
-     * @param hasEndDate     true=required, false=must be absent
+     * @param hasStartDate   null=any, true=required, false=must be absent
+     * @param hasEndDate     null=any, true=required, false=must be absent
      * @return               total count of resource policies matching the criteria
      * @throws SQLException  if database error occurs
      */

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -303,5 +303,5 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
      * @return               total count of resource policies matching the criteria
      * @throws SQLException  if database error occurs
      */
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
+    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -268,24 +268,21 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
      * @param context        DSpace context object
      * @param hasStartDate   true if looking for policies with a start date, false otherwise
      * @param hasEndDate     true if looking for policies with an end date, false otherwise
-     * @param useAndLogic    true for AND logic (both conditions must be met), false for OR logic (either condition). Only used when both hasStartDate and hasEndDate are true.
      * @param offset         the position of the first result to return
      * @param limit          paging limit
      * @return               list of resource policies matching the criteria
      * @throws SQLException  if database error
      */
-    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   boolean useAndLogic, int offset, int limit) throws SQLException;
+    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException;
 
     /**
      * Count all resource policies that have a start date or end date set.
      * @param context        DSpace context object
      * @param hasStartDate   true if looking for policies with a start date, false otherwise
      * @param hasEndDate     true if looking for policies with an end date, false otherwise
-     * @param useAndLogic    true for AND logic (both conditions must be met), false for OR logic (either condition). Only used when both hasStartDate and hasEndDate are true.
      * @return               total resource policies matching the criteria
      * @throws SQLException  if database error
      */
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                   boolean useAndLogic) throws SQLException;
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -263,26 +263,45 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     public int countAll(Context context) throws SQLException;
 
     /**
-     * Find all resource policies that have a start date or end date set.
+     * Find resource policies based on embargo date presence criteria.
+     * <p>
+     * This method enables flexible querying of ResourcePolicies based on the presence
+     * or absence of start and end dates. It supports various filtering combinations:
+     * 
+     * <ul>
+     * <li><b>Default (both null):</b> Returns policies with any dates (startDate OR endDate)</li>
+     * <li><b>Both true:</b> Returns policies with both startDate AND endDate</li>
+     * <li><b>hasStartDate=true, hasEndDate=null:</b> Returns policies with startDate only</li>
+     * <li><b>hasStartDate=null, hasEndDate=true:</b> Returns policies with endDate only</li>
+     * <li><b>Both false:</b> Returns policies without any dates (permanent policies)</li>
+     * </ul>
+     * 
+     * This method is primarily used by the embargo REST endpoint to filter policies
+     * based on embargo status and date configurations.
      *
      * @param context        DSpace context object
-     * @param hasStartDate   true if looking for policies with a start date, false otherwise
-     * @param hasEndDate     true if looking for policies with an end date, false otherwise
-     * @param offset         the position of the first result to return
-     * @param limit          paging limit
+     * @param hasStartDate   null=any, true=required, false=must be absent
+     * @param hasEndDate     null=any, true=required, false=must be absent
+     * @param offset         the position of the first result to return (pagination)
+     * @param limit          maximum number of results to return (pagination)
      * @return               list of resource policies matching the criteria
-     * @throws SQLException  if database error
+     * @throws SQLException  if database error occurs
      */
     public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException;
 
     /**
-     * Count all resource policies that have a start date or end date set.
+     * Count resource policies based on embargo date presence criteria.
+     * 
+     * This method provides the total count for the same filtering logic as 
+     * {@link #findByDatePresence(Context, Boolean, Boolean, int, int)} but without
+     * pagination parameters. Used for calculating total pages in REST API responses.
+     *
      * @param context        DSpace context object
-     * @param hasStartDate   true if looking for policies with a start date, false otherwise
-     * @param hasEndDate     true if looking for policies with an end date, false otherwise
-     * @return               total resource policies matching the criteria
-     * @throws SQLException  if database error
+     * @param hasStartDate   true=required, false=must be absent
+     * @param hasEndDate     true=required, false=must be absent
+     * @return               total count of resource policies matching the criteria
+     * @throws SQLException  if database error occurs
      */
     public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -293,7 +293,7 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     /**
      * Count resource policies based on embargo date presence criteria.
      * 
-     * This method provides the total count for the same filtering logic as 
+     * This method provides the total count for the same filtering logic as
      * {@link #findByDatePresence(Context, Boolean, Boolean, int, int)} but without
      * pagination parameters. Used for calculating total pages in REST API responses.
      *

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -268,21 +268,24 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
      * @param context        DSpace context object
      * @param hasStartDate   true if looking for policies with a start date, false otherwise
      * @param hasEndDate     true if looking for policies with an end date, false otherwise
+     * @param useAndLogic    true for AND logic (both conditions must be met), false for OR logic (either condition). Only used when both hasStartDate and hasEndDate are true.
      * @param offset         the position of the first result to return
      * @param limit          paging limit
      * @return               list of resource policies matching the criteria
      * @throws SQLException  if database error
      */
     public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   int offset, int limit) throws SQLException;
+                                                   boolean useAndLogic, int offset, int limit) throws SQLException;
 
     /**
      * Count all resource policies that have a start date or end date set.
      * @param context        DSpace context object
      * @param hasStartDate   true if looking for policies with a start date, false otherwise
      * @param hasEndDate     true if looking for policies with an end date, false otherwise
+     * @param useAndLogic    true for AND logic (both conditions must be met), false for OR logic (either condition). Only used when both hasStartDate and hasEndDate are true.
      * @return               total resource policies matching the criteria
      * @throws SQLException  if database error
      */
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                   boolean useAndLogic) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -242,5 +242,47 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
 
     public ResourcePolicy findOneById(Context context, Integer id) throws SQLException;
 
+    /**
+     * Return a paginated list of all resource policies
+     *
+     * @param context        DSpace context object
+     * @param offset         the position of the first result to return
+     * @param limit          paging limit
+     * @return               list of resource policies
+     * @throws SQLException  if database error
+     */
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException;
 
+    /**
+     * Count all the resource policies
+     *
+     * @param context        DSpace context object
+     * @return               total resource policies
+     * @throws SQLException  if database error
+     */
+    public int countAll(Context context) throws SQLException;
+
+    /**
+     * Find all resource policies that have a start date or end date set.
+     *
+     * @param context        DSpace context object
+     * @param hasStartDate   true if looking for policies with a start date, false otherwise
+     * @param hasEndDate     true if looking for policies with an end date, false otherwise
+     * @param offset         the position of the first result to return
+     * @param limit          paging limit
+     * @return               list of resource policies matching the criteria
+     * @throws SQLException  if database error
+     */
+    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException;
+
+    /**
+     * Count all resource policies that have a start date or end date set.
+     * @param context        DSpace context object
+     * @param hasStartDate   true if looking for policies with a start date, false otherwise
+     * @param hasEndDate     true if looking for policies with an end date, false otherwise
+     * @return               total resource policies matching the criteria
+     * @throws SQLException  if database error
+     */
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -418,6 +418,24 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         return count(query);
     }
 
+    /**
+     * Find resource policies based on the presence of start and end dates.
+     * <p>
+     * This method supports various combinations of date presence filtering:
+     * - Both null: finds policies with either start OR end date (OR logic)
+     * - Both true: finds policies with both start AND end dates (AND logic) 
+     * - hasStartDate=true, hasEndDate=null: finds policies with start date only
+     * - hasStartDate=null, hasEndDate=true: finds policies with end date only
+     * - Both false: finds policies without any dates (neither start nor end)
+     *
+     * @param context      DSpace context
+     * @param hasStartDate null for any, true for presence required, false for absence required
+     * @param hasEndDate   null for any, true for presence required, false for absence required
+     * @param offset       pagination offset
+     * @param limit        pagination limit
+     * @return             list of matching ResourcePolicies
+     * @throws SQLException if database error occurs
+     */
     @Override
     public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException {
@@ -425,14 +443,17 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
 
         if (hasStartDate == null && hasEndDate == null) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
-        } else if (hasStartDate && hasEndDate) {
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
-        } else if (hasStartDate) {
+        } else if (Boolean.TRUE.equals(hasStartDate) && hasEndDate == null) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
-        } else if (hasEndDate) {
+        } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
-        } else {
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
+        } else {
+            throw new IllegalArgumentException("Invalid combination of date presence parameters: " +
+                    "hasStartDate=" + hasStartDate + ", hasEndDate=" + hasEndDate);
         }
 
         queryBuilder.append(" ORDER BY rp.id");
@@ -444,16 +465,29 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         return list(query);
     }
 
+    /**
+     * Count resource policies based on the presence of start and end dates.
+     * <p>
+     * This method uses the same logic as findByDatePresence but only counts results.
+     *
+     * @param context      DSpace context
+     * @param hasStartDate true for start date presence required, false for absence required
+     * @param hasEndDate   true for end date presence required, false for absence required
+     * @return             count of matching ResourcePolicies
+     * @throws SQLException if database error occurs
+     */
     @Override
     public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
 
         if (hasStartDate && hasEndDate) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
-        } else if (hasStartDate) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
-        } else if (hasEndDate) {
-            queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
+        } else if (hasStartDate && !hasEndDate) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL");
+        } else if (!hasStartDate && hasEndDate) {
+            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
+        } else {
+            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
         }
 
         Query query = createQuery(context, queryBuilder.toString());

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -477,17 +477,22 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
      * @throws SQLException if database error occurs
      */
     @Override
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
+    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
 
-        if (hasStartDate && hasEndDate) {
+        if (hasStartDate == null && hasEndDate == null) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
-        } else if (hasStartDate && !hasEndDate) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL");
-        } else if (!hasStartDate && hasEndDate) {
-            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
-        } else {
+        } else if (Boolean.TRUE.equals(hasStartDate) && hasEndDate == null) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
+        } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
+            queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
+        } else {
+            throw new IllegalArgumentException("Invalid combination of date presence parameters: " +
+                    "hasStartDate=" + hasStartDate + ", hasEndDate=" + hasEndDate);
         }
 
         Query query = createQuery(context, queryBuilder.toString());

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -423,7 +423,7 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
      * <p>
      * This method supports various combinations of date presence filtering:
      * - Both null: finds policies with either start OR end date (OR logic)
-     * - Both true: finds policies with both start AND end dates (AND logic) 
+     * - Both true: finds policies with both start AND end dates (AND logic)
      * - hasStartDate=true, hasEndDate=null: finds policies with start date only
      * - hasStartDate=null, hasEndDate=true: finds policies with end date only
      * - Both false: finds policies without any dates (neither start nor end)

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -419,6 +419,28 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     }
 
     /**
+     * Helper to build the WHERE clause for date presence queries.
+     */
+    private String buildDatePresenceWhere(Boolean hasStartDate, Boolean hasEndDate) {
+        if (hasStartDate == null && hasEndDate == null) {
+            return " WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL";
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL";
+        } else if (Boolean.TRUE.equals(hasStartDate) && hasEndDate == null) {
+            return " WHERE rp.startDate IS NOT NULL";
+        } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
+            return " WHERE rp.endDate IS NOT NULL";
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL";
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL";
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NULL AND rp.endDate IS NULL";
+        }
+        return "";
+    }
+
+    /**
      * Find resource policies based on the presence of start and end dates.
      * <p>
      * This method supports various combinations of date presence filtering:
@@ -440,23 +462,7 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT rp FROM ResourcePolicy rp");
-
-        if (hasStartDate == null && hasEndDate == null) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
-        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
-        } else if (Boolean.TRUE.equals(hasStartDate) && hasEndDate == null) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
-        } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
-        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL");
-        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
-        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
-        }
-
+        queryBuilder.append(buildDatePresenceWhere(hasStartDate, hasEndDate));
         queryBuilder.append(" ORDER BY rp.id");
 
         Query query = createQuery(context, queryBuilder.toString());
@@ -480,23 +486,7 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     @Override
     public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
-
-        if (hasStartDate == null && hasEndDate == null) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
-        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
-        } else if (Boolean.TRUE.equals(hasStartDate) && hasEndDate == null) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
-        } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
-        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL");
-        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
-        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
-            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
-        }
-
+        queryBuilder.append(buildDatePresenceWhere(hasStartDate, hasEndDate));
         Query query = createQuery(context, queryBuilder.toString());
         return count(query);
     }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -419,22 +419,19 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     }
 
     @Override
-    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   boolean useAndLogic, int offset, int limit) throws SQLException {
+    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT rp FROM ResourcePolicy rp");
 
-        if (hasStartDate && hasEndDate) {
-            if (useAndLogic) {
-                queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
-            } else {
-                queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
-            }
+        if (hasStartDate == null && hasEndDate == null) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+        } else if (hasStartDate && hasEndDate) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
         } else if (hasStartDate) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
         } else if (hasEndDate) {
             queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
         } else {
-            // Both false - find policies WITHOUT any dates
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
         }
 
@@ -448,23 +445,15 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     }
 
     @Override
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                   boolean useAndLogic) throws SQLException {
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
 
         if (hasStartDate && hasEndDate) {
-            if (useAndLogic) {
-                queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
-            } else {
-                queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
-            }
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
         } else if (hasStartDate) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
         } else if (hasEndDate) {
             queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
-        } else {
-            // Both false - count policies WITHOUT any dates
-            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
         }
 
         Query query = createQuery(context, queryBuilder.toString());

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -449,6 +449,10 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
         } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL");
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
+            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
         } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
         } else {
@@ -488,6 +492,10 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
         } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL");
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
+            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
         } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
         } else {

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -403,4 +403,56 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         criteriaQuery.where(criteriaBuilder.equal(resourcePolicyRoot.get(ResourcePolicy_.id), id));
         return singleResult(context, criteriaQuery);
     }
+
+    @Override
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException {
+        Query query = createQuery(context, "SELECT rp FROM ResourcePolicy rp ORDER BY rp.id");
+        query.setFirstResult(offset);
+        query.setMaxResults(limit);
+        return list(query);
+    }
+
+    @Override
+    public int countAll(Context context) throws SQLException {
+        Query query = createQuery(context, "SELECT count(rp.id) FROM ResourcePolicy rp");
+        return count(query);
+    }
+
+    @Override
+    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException {
+        StringBuilder queryBuilder = new StringBuilder("SELECT rp FROM ResourcePolicy rp");
+
+        if (hasStartDate && hasEndDate) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+        } else if (hasStartDate) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
+        } else if (hasEndDate) {
+            queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+        }
+
+        queryBuilder.append(" ORDER BY rp.id");
+
+        Query query = createQuery(context, queryBuilder.toString());
+        query.setFirstResult(offset);
+        query.setMaxResults(limit);
+
+        return list(query);
+    }
+
+    @Override
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
+        StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
+
+        if (hasStartDate && hasEndDate) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+        } else if (hasStartDate) {
+            queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
+        } else if (hasEndDate) {
+            queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+        }
+
+        Query query = createQuery(context, queryBuilder.toString());
+        return count(query);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -455,9 +455,6 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
         } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
-        } else {
-            throw new IllegalArgumentException("Invalid combination of date presence parameters: " +
-                    "hasStartDate=" + hasStartDate + ", hasEndDate=" + hasEndDate);
         }
 
         queryBuilder.append(" ORDER BY rp.id");
@@ -498,9 +495,6 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL");
         } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
             queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
-        } else {
-            throw new IllegalArgumentException("Invalid combination of date presence parameters: " +
-                    "hasStartDate=" + hasStartDate + ", hasEndDate=" + hasEndDate);
         }
 
         Query query = createQuery(context, queryBuilder.toString());

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -459,7 +459,7 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
      * @throws SQLException if database error occurs
      */
     @Override
-    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT rp FROM ResourcePolicy rp");
         queryBuilder.append(buildDatePresenceWhere(hasStartDate, hasEndDate));
@@ -475,7 +475,7 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     /**
      * Count resource policies based on the presence of start and end dates.
      * <p>
-     * This method uses the same logic as findByDatePresence but only counts results.
+     * This method uses the same logic as findByDate but only counts results.
      *
      * @param context      DSpace context
      * @param hasStartDate true for start date presence required, false for absence required
@@ -484,7 +484,7 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
      * @throws SQLException if database error occurs
      */
     @Override
-    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
         queryBuilder.append(buildDatePresenceWhere(hasStartDate, hasEndDate));
         Query query = createQuery(context, queryBuilder.toString());

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -420,15 +420,22 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
 
     @Override
     public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   int offset, int limit) throws SQLException {
+                                                   boolean useAndLogic, int offset, int limit) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT rp FROM ResourcePolicy rp");
 
         if (hasStartDate && hasEndDate) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+            if (useAndLogic) {
+                queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
+            } else {
+                queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+            }
         } else if (hasStartDate) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
         } else if (hasEndDate) {
             queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+        } else {
+            // Both false - find policies WITHOUT any dates
+            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
         }
 
         queryBuilder.append(" ORDER BY rp.id");
@@ -441,15 +448,23 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     }
 
     @Override
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException {
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                   boolean useAndLogic) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
 
         if (hasStartDate && hasEndDate) {
-            queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+            if (useAndLogic) {
+                queryBuilder.append(" WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL");
+            } else {
+                queryBuilder.append(" WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL");
+            }
         } else if (hasStartDate) {
             queryBuilder.append(" WHERE rp.startDate IS NOT NULL");
         } else if (hasEndDate) {
             queryBuilder.append(" WHERE rp.endDate IS NOT NULL");
+        } else {
+            // Both false - count policies WITHOUT any dates
+            queryBuilder.append(" WHERE rp.startDate IS NULL AND rp.endDate IS NULL");
         }
 
         Query query = createQuery(context, queryBuilder.toString());

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -440,24 +440,6 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         return "";
     }
 
-    /**
-     * Find resource policies based on the presence of start and end dates.
-     * <p>
-     * This method supports various combinations of date presence filtering:
-     * - Both null: finds policies with either start OR end date (OR logic)
-     * - Both true: finds policies with both start AND end dates (AND logic)
-     * - hasStartDate=true, hasEndDate=null: finds policies with start date only
-     * - hasStartDate=null, hasEndDate=true: finds policies with end date only
-     * - Both false: finds policies without any dates (neither start nor end)
-     *
-     * @param context      DSpace context
-     * @param hasStartDate null for any, true for presence required, false for absence required
-     * @param hasEndDate   null for any, true for presence required, false for absence required
-     * @param offset       pagination offset
-     * @param limit        pagination limit
-     * @return             list of matching ResourcePolicies
-     * @throws SQLException if database error occurs
-     */
     @Override
     public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException {
@@ -472,17 +454,6 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         return list(query);
     }
 
-    /**
-     * Count resource policies based on the presence of start and end dates.
-     * <p>
-     * This method uses the same logic as findByDate but only counts results.
-     *
-     * @param context      DSpace context
-     * @param hasStartDate true for start date presence required, false for absence required
-     * @param hasEndDate   true for end date presence required, false for absence required
-     * @return             count of matching ResourcePolicies
-     * @throws SQLException if database error occurs
-     */
     @Override
     public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -321,43 +321,27 @@ public interface ResourcePolicyService {
     public int countByGroupAndResourceUuid(Context context, Group group, UUID resourceUuid) throws SQLException;
 
     /**
-     * Find resource policies based on embargo date presence criteria.
-     * <p>
-     * This service method delegates to the DAO layer to find ResourcePolicies
-     * based on the presence or absence of embargo dates. It supports flexible
-     * filtering for various embargo management scenarios.
+     * Return a paginated list of policies based on embargo date presence criteria
      * 
-     * <p><b>Common Use Cases:</b></p>
-     * <ul>
-     * <li>Find all embargoed items (any date present)</li>
-     * <li>Find items with time-limited embargoes (both dates present)</li>
-     * <li>Find items with start-only embargoes (publication date restrictions)</li>
-     * <li>Find items with end-only embargoes (expiration date restrictions)</li>
-     * <li>Find permanent policies (no embargo dates)</li>
-     * </ul>
-     *
-     * @param context      The relevant DSpace Context.
-     * @param hasStartDate null=any, true=required, false=must be absent
-     * @param hasEndDate   null=any, true=required, false=must be absent
-     * @param offset       The number of records to skip (for pagination).
-     * @param limit        The number of records to retrieve (for pagination).
-     * @return A list of matching ResourcePolicy objects.
-     * @throws SQLException If a database error occurs.
+     * @param context      DSpace context object
+     * @param hasStartDate filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate   filter for end date presence, null=any, true=required, false=must be absent
+     * @param offset       the position of the first result to return
+     * @param limit        paging limit
+     * @return             list of resource policies
+     * @throws SQLException if database error
      */
     public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException;
 
     /**
-     * Count resource policies based on embargo date presence criteria.
-     * <p>
-     * This method provides the count equivalent of findByDate() for
-     * pagination support in REST API responses.
-     *
-     * @param context      The relevant DSpace Context.
-     * @param hasStartDate null=any, true=required, false=must be absent
-     * @param hasEndDate   null=any, true=required, false=must be absent
-     * @return The total number of matching policies.
-     * @throws SQLException If a database error occurs.
+     * Count all the resource policies based on embargo date presence criteria
+     * 
+     * @param context      DSpace context object
+     * @param hasStartDate filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate   filter for end date presence, null=any, true=required, false=must be absent
+     * @return             total policies
+     * @throws SQLException if database error
      */
     public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -359,7 +359,7 @@ public interface ResourcePolicyService {
      * @return The total number of matching policies.
      * @throws SQLException If a database error occurs.
      */
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
+    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 
     /**
      * Check if the resource policy identified with (id) belong to ePerson

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -354,8 +354,8 @@ public interface ResourcePolicyService {
      * pagination support in REST API responses.
      *
      * @param context      The relevant DSpace Context.
-     * @param hasStartDate true=required, false=must be absent
-     * @param hasEndDate   true=required, false=must be absent
+     * @param hasStartDate null=any, true=required, false=must be absent
+     * @param hasEndDate   null=any, true=required, false=must be absent
      * @return The total number of matching policies.
      * @throws SQLException If a database error occurs.
      */

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -321,11 +321,24 @@ public interface ResourcePolicyService {
     public int countByGroupAndResourceUuid(Context context, Group group, UUID resourceUuid) throws SQLException;
 
     /**
-     * Finds resource policies based on the presence of a start or end date.
+     * Find resource policies based on embargo date presence criteria.
+     * <p>
+     * This service method delegates to the DAO layer to find ResourcePolicies
+     * based on the presence or absence of embargo dates. It supports flexible
+     * filtering for various embargo management scenarios.
+     * 
+     * <p><b>Common Use Cases:</b></p>
+     * <ul>
+     * <li>Find all embargoed items (any date present)</li>
+     * <li>Find items with time-limited embargoes (both dates present)</li> 
+     * <li>Find items with start-only embargoes (publication date restrictions)</li>
+     * <li>Find items with end-only embargoes (expiration date restrictions)</li>
+     * <li>Find permanent policies (no embargo dates)</li>
+     * </ul>
      *
      * @param context      The relevant DSpace Context.
-     * @param hasStartDate If true, the query will filter for policies where startDate is not null.
-     * @param hasEndDate   If true, the query will filter for policies where endDate is not null.
+     * @param hasStartDate null=any, true=required, false=must be absent
+     * @param hasEndDate   null=any, true=required, false=must be absent  
      * @param offset       The number of records to skip (for pagination).
      * @param limit        The number of records to retrieve (for pagination).
      * @return A list of matching ResourcePolicy objects.
@@ -335,11 +348,14 @@ public interface ResourcePolicyService {
                                                    int offset, int limit) throws SQLException;
 
     /**
-     * Counts resource policies based on the presence of a start or end date.
+     * Count resource policies based on embargo date presence criteria.
+     * <p>
+     * This method provides the count equivalent of findByDatePresence() for
+     * pagination support in REST API responses.
      *
      * @param context      The relevant DSpace Context.
-     * @param hasStartDate If true, the query will count policies where startDate is not null.
-     * @param hasEndDate   If true, the query will count policies where endDate is not null.
+     * @param hasStartDate true=required, false=must be absent
+     * @param hasEndDate   true=required, false=must be absent
      * @return The total number of matching policies.
      * @throws SQLException If a database error occurs.
      */

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -330,7 +330,7 @@ public interface ResourcePolicyService {
      * <p><b>Common Use Cases:</b></p>
      * <ul>
      * <li>Find all embargoed items (any date present)</li>
-     * <li>Find items with time-limited embargoes (both dates present)</li> 
+     * <li>Find items with time-limited embargoes (both dates present)</li>
      * <li>Find items with start-only embargoes (publication date restrictions)</li>
      * <li>Find items with end-only embargoes (expiration date restrictions)</li>
      * <li>Find permanent policies (no embargo dates)</li>
@@ -338,7 +338,7 @@ public interface ResourcePolicyService {
      *
      * @param context      The relevant DSpace Context.
      * @param hasStartDate null=any, true=required, false=must be absent
-     * @param hasEndDate   null=any, true=required, false=must be absent  
+     * @param hasEndDate   null=any, true=required, false=must be absent
      * @param offset       The number of records to skip (for pagination).
      * @param limit        The number of records to retrieve (for pagination).
      * @return A list of matching ResourcePolicy objects.

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -326,14 +326,13 @@ public interface ResourcePolicyService {
      * @param context      The relevant DSpace Context.
      * @param hasStartDate If true, the query will filter for policies where startDate is not null.
      * @param hasEndDate   If true, the query will filter for policies where endDate is not null.
-     * @param useAndLogic  If true, both conditions must be met (AND). If false, either condition (OR). Only used when both hasStartDate and hasEndDate are true.
      * @param offset       The number of records to skip (for pagination).
      * @param limit        The number of records to retrieve (for pagination).
      * @return A list of matching ResourcePolicy objects.
      * @throws SQLException If a database error occurs.
      */
-    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   boolean useAndLogic, int offset, int limit) throws SQLException;
+    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException;
 
     /**
      * Counts resource policies based on the presence of a start or end date.
@@ -341,12 +340,10 @@ public interface ResourcePolicyService {
      * @param context      The relevant DSpace Context.
      * @param hasStartDate If true, the query will count policies where startDate is not null.
      * @param hasEndDate   If true, the query will count policies where endDate is not null.
-     * @param useAndLogic  If true, both conditions must be met (AND). If false, either condition (OR). Only used when both hasStartDate and hasEndDate are true.
      * @return The total number of matching policies.
      * @throws SQLException If a database error occurs.
      */
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                   boolean useAndLogic) throws SQLException;
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
 
     /**
      * Check if the resource policy identified with (id) belong to ePerson

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -326,13 +326,14 @@ public interface ResourcePolicyService {
      * @param context      The relevant DSpace Context.
      * @param hasStartDate If true, the query will filter for policies where startDate is not null.
      * @param hasEndDate   If true, the query will filter for policies where endDate is not null.
+     * @param useAndLogic  If true, both conditions must be met (AND). If false, either condition (OR). Only used when both hasStartDate and hasEndDate are true.
      * @param offset       The number of records to skip (for pagination).
      * @param limit        The number of records to retrieve (for pagination).
      * @return A list of matching ResourcePolicy objects.
      * @throws SQLException If a database error occurs.
      */
     public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
-                                                   int offset, int limit) throws SQLException;
+                                                   boolean useAndLogic, int offset, int limit) throws SQLException;
 
     /**
      * Counts resource policies based on the presence of a start or end date.
@@ -340,10 +341,12 @@ public interface ResourcePolicyService {
      * @param context      The relevant DSpace Context.
      * @param hasStartDate If true, the query will count policies where startDate is not null.
      * @param hasEndDate   If true, the query will count policies where endDate is not null.
+     * @param useAndLogic  If true, both conditions must be met (AND). If false, either condition (OR). Only used when both hasStartDate and hasEndDate are true.
      * @return The total number of matching policies.
      * @throws SQLException If a database error occurs.
      */
-    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                   boolean useAndLogic) throws SQLException;
 
     /**
      * Check if the resource policy identified with (id) belong to ePerson

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -32,6 +32,26 @@ public interface ResourcePolicyService {
     public ResourcePolicy find(Context context, int id) throws SQLException;
 
     /**
+     * Finds all ResourcePolicies in the database with pagination.
+     *
+     * @param context The relevant DSpace Context.
+     * @param offset  The number of records to skip.
+     * @param limit   The number of records to retrieve.
+     * @return A list of ResourcePolicy objects.
+     * @throws SQLException If a database error occurs.
+     */
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException;
+
+    /**
+     * Counts the total number of ResourcePolicies in the database.
+     *
+     * @param context The relevant DSpace Context.
+     * @return The total number of policies.
+     * @throws SQLException If a database error occurs.
+     */
+    public int countAll(Context context) throws SQLException;
+
+    /**
      * Persist a model object.
      *
      * @param context
@@ -299,6 +319,31 @@ public interface ResourcePolicyService {
      * @throws SQLException  if database error
      */
     public int countByGroupAndResourceUuid(Context context, Group group, UUID resourceUuid) throws SQLException;
+
+    /**
+     * Finds resource policies based on the presence of a start or end date.
+     *
+     * @param context      The relevant DSpace Context.
+     * @param hasStartDate If true, the query will filter for policies where startDate is not null.
+     * @param hasEndDate   If true, the query will filter for policies where endDate is not null.
+     * @param offset       The number of records to skip (for pagination).
+     * @param limit        The number of records to retrieve (for pagination).
+     * @return A list of matching ResourcePolicy objects.
+     * @throws SQLException If a database error occurs.
+     */
+    public List<ResourcePolicy> findByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException;
+
+    /**
+     * Counts resource policies based on the presence of a start or end date.
+     *
+     * @param context      The relevant DSpace Context.
+     * @param hasStartDate If true, the query will count policies where startDate is not null.
+     * @param hasEndDate   If true, the query will count policies where endDate is not null.
+     * @return The total number of matching policies.
+     * @throws SQLException If a database error occurs.
+     */
+    public int countByDatePresence(Context context, boolean hasStartDate, boolean hasEndDate) throws SQLException;
 
     /**
      * Check if the resource policy identified with (id) belong to ePerson

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -344,13 +344,13 @@ public interface ResourcePolicyService {
      * @return A list of matching ResourcePolicy objects.
      * @throws SQLException If a database error occurs.
      */
-    public List<ResourcePolicy> findByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate,
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
                                                    int offset, int limit) throws SQLException;
 
     /**
      * Count resource policies based on embargo date presence criteria.
      * <p>
-     * This method provides the count equivalent of findByDatePresence() for
+     * This method provides the count equivalent of findByDate() for
      * pagination support in REST API responses.
      *
      * @param context      The relevant DSpace Context.
@@ -359,7 +359,7 @@ public interface ResourcePolicyService {
      * @return The total number of matching policies.
      * @throws SQLException If a database error occurs.
      */
-    public int countByDatePresence(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 
     /**
      * Check if the resource policy identified with (id) belong to ePerson

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -227,7 +227,7 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
 
     /**
      * Find resource policies based on the presence of a start or end date.
-     * If no parameters are provided, it returns all resource policies that have ANY embargo date set (start OR end).
+     * If no parameters are provided, it returns all resource policies from the database.
      *
      * @param hasStartDate if true, returns policies that have a start date set.
      * @param hasEndDate   if true, returns policies that have an end date set.
@@ -249,27 +249,18 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
 
         try {
             Context context = obtainContext();
-            
-            if (hasStartDate != null && hasStartDate == false && hasEndDate != null && hasEndDate == false) {
-                // Special case: both parameters explicitly false - find policies WITHOUT any embargo dates
-                policies = resourcePolicyService.findByDatePresence(context, false, false, false,
+
+            // Ak žiadne parametre nie sú zadané, vráť policies s akýmikoľvek dátumami (embargo endpoint)
+            if (hasStartDate == null && hasEndDate == null) {
+                // Default: vráť policies ktoré majú aspoň jeden dátum nastavený
+                policies = resourcePolicyService.findByDatePresence(context, null, null,
                         Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, false, false, false);
-            } else if (!bHasStartDate && !bHasEndDate) {
-                // If no parameters provided, find all policies that have ANY embargo date (start OR end)
-                policies = resourcePolicyService.findByDatePresence(context, true, true, false,
-                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, true, true, false);
-            } else if (bHasStartDate && bHasEndDate) {
-                // Both parameters true - find policies that have BOTH dates (AND logic)
-                policies = resourcePolicyService.findByDatePresence(context, true, true, true,
-                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, true, true, true);
+                total = resourcePolicyService.countByDatePresence(context, true, true);
             } else {
-                // Only one parameter is true - use OR logic (doesn't matter since only one is true)
-                policies = resourcePolicyService.findByDatePresence(context, bHasStartDate, bHasEndDate, false,
+                // Konkrétne filtre podľa parametrov
+                policies = resourcePolicyService.findByDatePresence(context, bHasStartDate, bHasEndDate,
                         Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, bHasStartDate, bHasEndDate, false);
+                total = resourcePolicyService.countByDatePresence(context, bHasStartDate, bHasEndDate);
             }
 
         } catch (SQLException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -9,12 +9,10 @@ package org.dspace.app.rest.repository;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.DiscoverableEndpointsService;
@@ -35,8 +33,6 @@ import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.discovery.DiscoverQuery;
-import org.dspace.discovery.indexobject.IndexableDSpaceObject;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.EPersonService;
@@ -261,20 +257,16 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
 
             if (hasStartDate == null && hasEndDate == null) {
                 policies = resourcePolicyService.findByDatePresence(context, null, null,
-                        Math.toIntExact(pageable.getOffset()), 
+                        Math.toIntExact(pageable.getOffset()),
                         Math.toIntExact(pageable.getPageSize()));
-                
                 total = resourcePolicyService.countByDatePresence(context, null, null);
             } else {
                 policies = resourcePolicyService.findByDatePresence(context, hasStartDate, hasEndDate,
-                        Math.toIntExact(pageable.getOffset()), 
+                        Math.toIntExact(pageable.getOffset()),
                         Math.toIntExact(pageable.getPageSize()));
-                
                 total = resourcePolicyService.countByDatePresence(context, hasStartDate, hasEndDate);
             }
-
             return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
-            
         } catch (SQLException e) {
             throw new RuntimeException("Database error while searching embargo policies: " + e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -246,7 +246,7 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
      */
     @PreAuthorize("hasAuthority('ADMIN')")
     @SearchRestMethod(name = "embargo")
-    public Page<ResourcePolicyRest> findByDatePresence(
+    public Page<ResourcePolicyRest> findByDate(
             @Parameter(value = "hasStartDate", required = false) Boolean hasStartDate,
             @Parameter(value = "hasEndDate", required = false) Boolean hasEndDate,
             Pageable pageable) {
@@ -257,10 +257,10 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
             List<ResourcePolicy> policies;
             int total;
 
-            policies = resourcePolicyService.findByDatePresence(context, hasStartDate, hasEndDate,
+            policies = resourcePolicyService.findByDate(context, hasStartDate, hasEndDate,
                         Math.toIntExact(pageable.getOffset()),
                         Math.toIntExact(pageable.getPageSize()));
-            total = resourcePolicyService.countByDatePresence(context, hasStartDate, hasEndDate);
+            total = resourcePolicyService.countByDate(context, hasStartDate, hasEndDate);
             return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
         } catch (SQLException e) {
             throw new RuntimeException("Database error while searching embargo policies: " + e.getMessage(), e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -226,11 +226,13 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
      * 
      * <p><b>Supported Parameter Combinations:</b></p>
      * <ul>
-     * <li><b>No parameters:</b> Returns all policies with any embargo dates (OR logic)</li>
-     * <li><b>hasStartDate=true:</b> Returns policies with start dates only</li>
-     * <li><b>hasEndDate=true:</b> Returns policies with end dates only</li>
-     * <li><b>Both true:</b> Returns policies with both start AND end dates</li>
+     * <li><b>Both true:</b> Returns policies with both startDate AND endDate present</li>
      * <li><b>Both false:</b> Returns policies without any embargo dates</li>
+     * <li><b>hasStartDate=true:</b> Returns policies with startDate present</li>
+     * <li><b>hasEndDate=true:</b> Returns policies with endDate present</li>
+     * <li><b>hasStartDate=true, hasEndDate=false:</b> Returns policies with startDate only</li>
+     * <li><b>hasStartDate=false, hasEndDate=true:</b> Returns policies with endDate only</li>
+     * <li><b>No parameters:</b> Returns all policies with any embargo dates (OR logic)</li>
      * </ul>
      * 
      * <p><b>Access Control:</b> Requires ADMIN authority</p>
@@ -253,19 +255,12 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
             Context context = obtainContext();
 
             List<ResourcePolicy> policies;
-            long total;
+            int total;
 
-            if (hasStartDate == null && hasEndDate == null) {
-                policies = resourcePolicyService.findByDatePresence(context, null, null,
+            policies = resourcePolicyService.findByDatePresence(context, hasStartDate, hasEndDate,
                         Math.toIntExact(pageable.getOffset()),
                         Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, null, null);
-            } else {
-                policies = resourcePolicyService.findByDatePresence(context, hasStartDate, hasEndDate,
-                        Math.toIntExact(pageable.getOffset()),
-                        Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, hasStartDate, hasEndDate);
-            }
+            total = resourcePolicyService.countByDatePresence(context, hasStartDate, hasEndDate);
             return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
         } catch (SQLException e) {
             throw new RuntimeException("Database error while searching embargo policies: " + e.getMessage(), e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -225,7 +225,7 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
      * Find the resource policies matching embargo date presence criteria
      *
      * @param hasStartDate optional, filter for start date presence
-     * @param hasEndDate   optional, filter for end date presence  
+     * @param hasEndDate   optional, filter for end date presence
      * @param pageable     contains the pagination information
      * @return a Page of ResourcePolicyRest instances matching the embargo criteria
      */

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -226,13 +226,25 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
     }
 
     /**
-     * Find resource policies based on the presence of a start or end date.
-     * If no parameters are provided, it returns all resource policies from the database.
+     * Find resource policies based on embargo date presence criteria.
+     * 
+     * <p><b>Supported Parameter Combinations:</b></p>
+     * <ul>
+     * <li><b>No parameters:</b> Returns all policies with any embargo dates (OR logic)</li>
+     * <li><b>hasStartDate=true:</b> Returns policies with start dates only</li>
+     * <li><b>hasEndDate=true:</b> Returns policies with end dates only</li>
+     * <li><b>Both true:</b> Returns policies with both start AND end dates</li>
+     * <li><b>Both false:</b> Returns policies without any embargo dates</li>
+     * </ul>
+     * 
+     * <p><b>Access Control:</b> Requires ADMIN authority</p>
+     * <p><b>REST Endpoint:</b> {@code GET /api/authz/resourcepolicies/search/embargo}</p>
      *
-     * @param hasStartDate if true, returns policies that have a start date set.
-     * @param hasEndDate   if true, returns policies that have an end date set.
-     * @param pageable     contains the pagination information.
-     * @return a Page of ResourcePolicyRest instances matching the criteria.
+     * @param hasStartDate Optional filter for start date presence (true/false/null)
+     * @param hasEndDate   Optional filter for end date presence (true/false/null)
+     * @param pageable     Pagination and sorting information
+     * @return Page of ResourcePolicyRest instances matching the criteria
+     * @throws RuntimeException if database error occurs (wrapped SQLException)
      */
     @PreAuthorize("hasAuthority('ADMIN')")
     @SearchRestMethod(name = "embargo")
@@ -241,33 +253,50 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
             @Parameter(value = "hasEndDate", required = false) Boolean hasEndDate,
             Pageable pageable) {
 
-        List<ResourcePolicy> policies;
-        long total;
-
-        boolean bHasStartDate = hasStartDate != null && hasStartDate;
-        boolean bHasEndDate = hasEndDate != null && hasEndDate;
-
         try {
             Context context = obtainContext();
 
-            // Ak žiadne parametre nie sú zadané, vráť policies s akýmikoľvek dátumami (embargo endpoint)
+            List<ResourcePolicy> policies;
+            long total;
+
             if (hasStartDate == null && hasEndDate == null) {
-                // Default: vráť policies ktoré majú aspoň jeden dátum nastavený
                 policies = resourcePolicyService.findByDatePresence(context, null, null,
-                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, true, true);
+                        Math.toIntExact(pageable.getOffset()), 
+                        Math.toIntExact(pageable.getPageSize()));
+                
+                total = getTotalEmbargoedPolicies(context);
             } else {
-                // Konkrétne filtre podľa parametrov
-                policies = resourcePolicyService.findByDatePresence(context, bHasStartDate, bHasEndDate,
-                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
+                boolean bHasStartDate = Boolean.TRUE.equals(hasStartDate);
+                boolean bHasEndDate = Boolean.TRUE.equals(hasEndDate);
+                
+                policies = resourcePolicyService.findByDatePresence(context, hasStartDate, hasEndDate,
+                        Math.toIntExact(pageable.getOffset()), 
+                        Math.toIntExact(pageable.getPageSize()));
+                
                 total = resourcePolicyService.countByDatePresence(context, bHasStartDate, bHasEndDate);
             }
 
+            return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
+            
         } catch (SQLException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new RuntimeException("Database error while searching embargo policies: " + e.getMessage(), e);
         }
+    }
 
-        return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
+    /**
+     * Helper method to count all policies with any embargo dates (OR logic).
+     * This is used for the default embargo endpoint behavior when no parameters are provided.
+     * 
+     * @param context DSpace context
+     * @return count of policies with either start date OR end date
+     * @throws SQLException if database error occurs
+     */
+    private long getTotalEmbargoedPolicies(Context context) throws SQLException {
+        int withStartDate = resourcePolicyService.countByDatePresence(context, true, false);
+        int withEndDate = resourcePolicyService.countByDatePresence(context, false, true);  
+        int withBothDates = resourcePolicyService.countByDatePresence(context, true, true);
+        
+        return withStartDate + withEndDate + withBothDates;
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -264,16 +264,13 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
                         Math.toIntExact(pageable.getOffset()), 
                         Math.toIntExact(pageable.getPageSize()));
                 
-                total = getTotalEmbargoedPolicies(context);
+                total = resourcePolicyService.countByDatePresence(context, null, null);
             } else {
-                boolean bHasStartDate = Boolean.TRUE.equals(hasStartDate);
-                boolean bHasEndDate = Boolean.TRUE.equals(hasEndDate);
-                
                 policies = resourcePolicyService.findByDatePresence(context, hasStartDate, hasEndDate,
                         Math.toIntExact(pageable.getOffset()), 
                         Math.toIntExact(pageable.getPageSize()));
                 
-                total = resourcePolicyService.countByDatePresence(context, bHasStartDate, bHasEndDate);
+                total = resourcePolicyService.countByDatePresence(context, hasStartDate, hasEndDate);
             }
 
             return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
@@ -281,22 +278,6 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
         } catch (SQLException e) {
             throw new RuntimeException("Database error while searching embargo policies: " + e.getMessage(), e);
         }
-    }
-
-    /**
-     * Helper method to count all policies with any embargo dates (OR logic).
-     * This is used for the default embargo endpoint behavior when no parameters are provided.
-     * 
-     * @param context DSpace context
-     * @return count of policies with either start date OR end date
-     * @throws SQLException if database error occurs
-     */
-    private long getTotalEmbargoedPolicies(Context context) throws SQLException {
-        int withStartDate = resourcePolicyService.countByDatePresence(context, true, false);
-        int withEndDate = resourcePolicyService.countByDatePresence(context, false, true);  
-        int withBothDates = resourcePolicyService.countByDatePresence(context, true, true);
-        
-        return withStartDate + withEndDate + withBothDates;
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -222,27 +222,12 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
     }
 
     /**
-     * Find resource policies based on embargo date presence criteria.
-     * 
-     * <p><b>Supported Parameter Combinations:</b></p>
-     * <ul>
-     * <li><b>Both true:</b> Returns policies with both startDate AND endDate present</li>
-     * <li><b>Both false:</b> Returns policies without any embargo dates</li>
-     * <li><b>hasStartDate=true:</b> Returns policies with startDate present</li>
-     * <li><b>hasEndDate=true:</b> Returns policies with endDate present</li>
-     * <li><b>hasStartDate=true, hasEndDate=false:</b> Returns policies with startDate only</li>
-     * <li><b>hasStartDate=false, hasEndDate=true:</b> Returns policies with endDate only</li>
-     * <li><b>No parameters:</b> Returns all policies with any embargo dates (OR logic)</li>
-     * </ul>
-     * 
-     * <p><b>Access Control:</b> Requires ADMIN authority</p>
-     * <p><b>REST Endpoint:</b> {@code GET /api/authz/resourcepolicies/search/embargo}</p>
+     * Find the resource policies matching embargo date presence criteria
      *
-     * @param hasStartDate Optional filter for start date presence (true/false/null)
-     * @param hasEndDate   Optional filter for end date presence (true/false/null)
-     * @param pageable     Pagination and sorting information
-     * @return Page of ResourcePolicyRest instances matching the criteria
-     * @throws RuntimeException if database error occurs (wrapped SQLException)
+     * @param hasStartDate optional, filter for start date presence
+     * @param hasEndDate   optional, filter for end date presence  
+     * @param pageable     contains the pagination information
+     * @return a Page of ResourcePolicyRest instances matching the embargo criteria
      */
     @PreAuthorize("hasAuthority('ADMIN')")
     @SearchRestMethod(name = "embargo")

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -227,7 +227,7 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
 
     /**
      * Find resource policies based on the presence of a start or end date.
-     * If no parameters are provided, it returns all resource policies from the database.
+     * If no parameters are provided, it returns all resource policies that have ANY embargo date set (start OR end).
      *
      * @param hasStartDate if true, returns policies that have a start date set.
      * @param hasEndDate   if true, returns policies that have an end date set.
@@ -249,14 +249,27 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
 
         try {
             Context context = obtainContext();
-            if (!bHasStartDate && !bHasEndDate) {
-                policies = resourcePolicyService.findAll(context,
+            
+            if (hasStartDate != null && hasStartDate == false && hasEndDate != null && hasEndDate == false) {
+                // Special case: both parameters explicitly false - find policies WITHOUT any embargo dates
+                policies = resourcePolicyService.findByDatePresence(context, false, false, false,
                         Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countAll(context);
+                total = resourcePolicyService.countByDatePresence(context, false, false, false);
+            } else if (!bHasStartDate && !bHasEndDate) {
+                // If no parameters provided, find all policies that have ANY embargo date (start OR end)
+                policies = resourcePolicyService.findByDatePresence(context, true, true, false,
+                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
+                total = resourcePolicyService.countByDatePresence(context, true, true, false);
+            } else if (bHasStartDate && bHasEndDate) {
+                // Both parameters true - find policies that have BOTH dates (AND logic)
+                policies = resourcePolicyService.findByDatePresence(context, true, true, true,
+                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
+                total = resourcePolicyService.countByDatePresence(context, true, true, true);
             } else {
-                policies = resourcePolicyService.findByDatePresence(context, bHasStartDate, bHasEndDate,
+                // Only one parameter is true - use OR logic (doesn't matter since only one is true)
+                policies = resourcePolicyService.findByDatePresence(context, bHasStartDate, bHasEndDate, false,
                         Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
-                total = resourcePolicyService.countByDatePresence(context, bHasStartDate, bHasEndDate);
+                total = resourcePolicyService.countByDatePresence(context, bHasStartDate, bHasEndDate, false);
             }
 
         } catch (SQLException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -9,10 +9,12 @@ package org.dspace.app.rest.repository;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.DiscoverableEndpointsService;
@@ -33,6 +35,8 @@ import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.discovery.DiscoverQuery;
+import org.dspace.discovery.indexobject.IndexableDSpaceObject;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.EPersonService;
@@ -219,6 +223,47 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
             throw new RuntimeException(e.getMessage(), e);
         }
         return converter.toRestPage(resourcePolisies, pageable, total, utils.obtainProjection());
+    }
+
+    /**
+     * Find resource policies based on the presence of a start or end date.
+     * If no parameters are provided, it returns all resource policies from the database.
+     *
+     * @param hasStartDate if true, returns policies that have a start date set.
+     * @param hasEndDate   if true, returns policies that have an end date set.
+     * @param pageable     contains the pagination information.
+     * @return a Page of ResourcePolicyRest instances matching the criteria.
+     */
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @SearchRestMethod(name = "embargo")
+    public Page<ResourcePolicyRest> findByDatePresence(
+            @Parameter(value = "hasStartDate", required = false) Boolean hasStartDate,
+            @Parameter(value = "hasEndDate", required = false) Boolean hasEndDate,
+            Pageable pageable) {
+
+        List<ResourcePolicy> policies;
+        long total;
+
+        boolean bHasStartDate = hasStartDate != null && hasStartDate;
+        boolean bHasEndDate = hasEndDate != null && hasEndDate;
+
+        try {
+            Context context = obtainContext();
+            if (!bHasStartDate && !bHasEndDate) {
+                policies = resourcePolicyService.findAll(context,
+                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
+                total = resourcePolicyService.countAll(context);
+            } else {
+                policies = resourcePolicyService.findByDatePresence(context, bHasStartDate, bHasEndDate,
+                        Math.toIntExact(pageable.getOffset()), Math.toIntExact(pageable.getPageSize()));
+                total = resourcePolicyService.countByDatePresence(context, bHasStartDate, bHasEndDate);
+            }
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+
+        return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3935,16 +3935,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=false&hasEndDate=false"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1))) // At least our rpWithoutDates
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")]").exists())
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")].action[0]", is("READ")))
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")].startDate").doesNotExist())
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")].endDate").doesNotExist())
-                // Verify that policies with dates are NOT included
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithStartDate.getID() + ")]").doesNotExist())
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithEndDate.getID() + ")]").doesNotExist())
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")]").doesNotExist());
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1))); // At least our rpWithoutDates
     }
 
     @Test
@@ -3956,6 +3947,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
         Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
         Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
+
+        // DEBUG: Počet policies po vytvorení item
+//        int createdPolicies = resourcePolicyService.countAll(context);
 
         // Získame skupinu Anonymov
         Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
@@ -4010,7 +4004,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo"))
-                .andExpect(jsonPath("$.page.totalElements", is(4))); // rpWithoutDates
+                .andExpect(jsonPath("$.page.totalElements", is(4)));
     }
 
     @Test
@@ -4076,11 +4070,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true&hasEndDate=true"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1))) // At least our rpWithBothDates
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")]").exists())
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")].action[0]", is("READ")))
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")].startDate[0]", is("2019-10-31")))
-                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")].endDate[0]", is("2200-10-31")));
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3745,6 +3745,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoByResourceTest() throws Exception {
+        
         context.turnOffAuthorisationSystem();
 
         // Príprava dát

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3743,116 +3743,79 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     }
 
     /**
-     * Test data container for embargo policy tests
-     */
-    private static class EmbargoTestData {
-        public final Community community;
-        public final Collection collection;
-        public final Item item;
-        public final Date embargoStartDate;
-        public final Date embargoEndDate;
-        public final ResourcePolicy rpWithStartDate;
-        public final ResourcePolicy rpWithEndDate;
-        public final ResourcePolicy rpWithEndDate2;
-        public final ResourcePolicy rpWithBothDates;
-        public final ResourcePolicy rpWithoutDates;
-
-        public EmbargoTestData(Community community, Collection collection, Item item,
-                               Date embargoStartDate, Date embargoEndDate,
-                               ResourcePolicy rpWithStartDate, ResourcePolicy rpWithEndDate,
-                               ResourcePolicy rpWithEndDate2, ResourcePolicy rpWithBothDates,
-                               ResourcePolicy rpWithoutDates) {
-            this.community = community;
-            this.collection = collection;
-            this.item = item;
-            this.embargoStartDate = embargoStartDate;
-            this.embargoEndDate = embargoEndDate;
-            this.rpWithStartDate = rpWithStartDate;
-            this.rpWithEndDate = rpWithEndDate;
-            this.rpWithEndDate2 = rpWithEndDate2;
-            this.rpWithBothDates = rpWithBothDates;
-            this.rpWithoutDates = rpWithoutDates;
-        }
-    }
-
-    /**
-     * Creates test data for embargo policy tests including:
+     * Setups test data for embargo policy tests including:
      * - Community, Collection, and Item
      * - ResourcePolicies with different date combinations
      * - Predefined start and end dates for consistency
      *
-     * @return EmbargoTestData containing all test entities
      * @throws Exception if test data creation fails
      */
-    private EmbargoTestData createEmbargoTestData() throws Exception {
+    private void setupEmbargoTestData() throws Exception {
+        context.turnOffAuthorisationSystem();
 
+        try {
+            // Create test hierarchy
+            Community community = CommunityBuilder.createCommunity(context)
+                    .withName("Test Community").build();
+            Collection collection = CollectionBuilder.createCollection(context, community)
+                    .withName("Test Collection").build();
+            Item item = ItemBuilder.createItem(context, collection)
+                    .withTitle("Item with Embargo").build();
 
-        // Create test hierarchy
-        Community community = CommunityBuilder.createCommunity(context)
-                .withName("Test Community").build();
-        Collection collection = CollectionBuilder.createCollection(context, community)
-                .withName("Test Collection").build();
-        Item item = ItemBuilder.createItem(context, collection)
-                .withTitle("Item with Embargo").build();
+            // Create consistent embargo dates
+            Calendar calendar1 = Calendar.getInstance();
+            calendar1.set(Calendar.YEAR, 2019);
+            calendar1.set(Calendar.MONTH, 9);
+            calendar1.set(Calendar.DATE, 31);
+            Date embargoStartDate = calendar1.getTime();
 
-        // Create consistent embargo dates
-        Calendar calendar1 = Calendar.getInstance();
-        calendar1.set(Calendar.YEAR, 2019);
-        calendar1.set(Calendar.MONTH, 9);
-        calendar1.set(Calendar.DATE, 31);
-        Date embargoStartDate = calendar1.getTime();
+            Calendar calendar2 = Calendar.getInstance();
+            calendar2.set(Calendar.YEAR, 2200);
+            calendar2.set(Calendar.MONTH, 9);
+            calendar2.set(Calendar.DATE, 31);
+            Date embargoEndDate = calendar2.getTime();
 
-        Calendar calendar2 = Calendar.getInstance();
-        calendar2.set(Calendar.YEAR, 2200);
-        calendar2.set(Calendar.MONTH, 9);
-        calendar2.set(Calendar.DATE, 31);
-        Date embargoEndDate = calendar2.getTime();
+            // Create ResourcePolicies with different date combinations
+            ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withStartDate(embargoStartDate)
+                    .build();
 
-        // Create ResourcePolicies with different date combinations
-        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .build();
+            ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withEndDate(embargoEndDate)
+                    .build();
 
-        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
+            ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withEndDate(embargoEndDate)
+                    .build();
 
-        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
+            ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withStartDate(embargoStartDate)
+                    .withEndDate(embargoEndDate)
+                    .build();
 
-        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .build();
-
-        return new EmbargoTestData(community, collection, item, embargoStartDate, embargoEndDate,
-                rpWithStartDate, rpWithEndDate, rpWithEndDate2, rpWithBothDates, rpWithoutDates);
+            ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .build();
+        } finally {
+            context.restoreAuthSystemState();
+        }
     }
 
     @Test
     public void findEmbargoWithStartDate() throws Exception {
-        context.turnOffAuthorisationSystem();
-
         // Baseline count
         int baselineCount = this.resourcePolicyService.countByDatePresence(context, true, null);
 
-        EmbargoTestData testData = createEmbargoTestData();
-
-        context.restoreAuthSystemState();
+        setupEmbargoTestData();
 
         String authToken = getAuthToken(admin.getEmail(), password);
 
@@ -3864,14 +3827,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithEndDate() throws Exception {
-        context.turnOffAuthorisationSystem();
-
         // Baseline count
         int baselineCount = this.resourcePolicyService.countByDatePresence(context, null, true);
 
-        EmbargoTestData testData = createEmbargoTestData();
-
-        context.restoreAuthSystemState();
+        setupEmbargoTestData();
 
         String authToken = getAuthToken(admin.getEmail(), password);
 
@@ -3883,14 +3842,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithoutDates() throws Exception {
-        context.turnOffAuthorisationSystem();
-
         // Baseline count
         int baselineCount = this.resourcePolicyService.countByDatePresence(context, false, false);
 
-        EmbargoTestData testData = createEmbargoTestData();
-
-        context.restoreAuthSystemState();
+        setupEmbargoTestData();
 
         String authToken = getAuthToken(admin.getEmail(), password);
 
@@ -3902,14 +3857,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithAnyDate() throws Exception {
-        context.turnOffAuthorisationSystem();
-
         // Baseline count
         int baselineCount = this.resourcePolicyService.countByDatePresence(context, null, null);
 
-        EmbargoTestData testData = createEmbargoTestData();
-
-        context.restoreAuthSystemState();
+        setupEmbargoTestData();
 
         String authToken = getAuthToken(admin.getEmail(), password);
 
@@ -3921,14 +3872,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithBothDates() throws Exception {
-        context.turnOffAuthorisationSystem();
-
         // Baseline count
         int baselineCount = this.resourcePolicyService.countByDatePresence(context, true, true);
 
-        EmbargoTestData testData = createEmbargoTestData();
-
-        context.restoreAuthSystemState();
+        setupEmbargoTestData();
 
         String authToken = getAuthToken(admin.getEmail(), password);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3740,11 +3740,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                              .andExpect(status().isUnprocessableEntity());
     }
 
-
-
-
     @Test
-    public void findEmbargoByResourceTest() throws Exception {
+    public void findEmbargoWithStartDateOnly() throws Exception {
         
         context.turnOffAuthorisationSystem();
 
@@ -3782,6 +3779,219 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                 .withEndDate(embargoEndDate)
                 .build();
 
+        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true"))
+                .andExpect(jsonPath("$.page.totalElements", is(2))); // rpWithStartDate + rpWithBothDates
+    }
+
+    @Test
+    public void findEmbargoWithEndDateOnly() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        // Príprava dát
+        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
+
+        // Získame skupinu Anonymov
+        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
+
+        // Dátum začiatku embarga
+        Calendar calendar1 = Calendar.getInstance();
+        calendar1.set(Calendar.YEAR, 2019);
+        calendar1.set(Calendar.MONTH, 9);
+        calendar1.set(Calendar.DATE, 31);
+        Date embargoStartDate = calendar1.getTime();
+
+        // Dátum konca embarga
+        Calendar calendar2 = Calendar.getInstance();
+        calendar2.set(Calendar.YEAR, 2200);
+        calendar2.set(Calendar.MONTH, 9);
+        calendar2.set(Calendar.DATE, 31);
+        Date embargoEndDate = calendar2.getTime();
+
+        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasEndDate=true"))
+                .andExpect(jsonPath("$.page.totalElements", is(3))); // rpWithEndDate + rpWithEndDate2 + rpWithBothDates
+    }
+
+    @Test
+    public void findEmbargoWithoutDates() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        // Príprava dát
+        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
+
+        // Získame skupinu Anonymov
+        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
+
+        // Dátum začiatku embarga
+        Calendar calendar1 = Calendar.getInstance();
+        calendar1.set(Calendar.YEAR, 2019);
+        calendar1.set(Calendar.MONTH, 9);
+        calendar1.set(Calendar.DATE, 31);
+        Date embargoStartDate = calendar1.getTime();
+
+        // Dátum konca embarga
+        Calendar calendar2 = Calendar.getInstance();
+        calendar2.set(Calendar.YEAR, 2200);
+        calendar2.set(Calendar.MONTH, 9);
+        calendar2.set(Calendar.DATE, 31);
+        Date embargoEndDate = calendar2.getTime();
+
+        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=false&hasEndDate=false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1))) // At least our rpWithoutDates
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")]").exists())
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")].action[0]", is("READ")))
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")].startDate").doesNotExist())
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithoutDates.getID() + ")].endDate").doesNotExist())
+                // Verify that policies with dates are NOT included
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithStartDate.getID() + ")]").doesNotExist())
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithEndDate.getID() + ")]").doesNotExist())
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")]").doesNotExist());
+    }
+
+    @Test
+    public void findEmbargoWithAnyDate() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        // Príprava dát
+        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
+
+        // Získame skupinu Anonymov
+        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
+
+        // Dátum začiatku embarga
+        Calendar calendar1 = Calendar.getInstance();
+        calendar1.set(Calendar.YEAR, 2019);
+        calendar1.set(Calendar.MONTH, 9);
+        calendar1.set(Calendar.DATE, 31);
+        Date embargoStartDate = calendar1.getTime();
+
+        // Dátum konca embarga
+        Calendar calendar2 = Calendar.getInstance();
+        calendar2.set(Calendar.YEAR, 2200);
+        calendar2.set(Calendar.MONTH, 9);
+        calendar2.set(Calendar.DATE, 31);
+        Date embargoEndDate = calendar2.getTime();
+
+        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
         ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
                 .withAction(Constants.READ)
                 .withDspaceObject(item)
@@ -3800,19 +4010,77 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo"))
+                .andExpect(jsonPath("$.page.totalElements", is(4))); // rpWithoutDates
+    }
+
+    @Test
+    public void findEmbargoWithBothDates() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        // Príprava dát
+        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
+
+        // Získame skupinu Anonymov
+        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
+
+        // Dátum začiatku embarga
+        Calendar calendar1 = Calendar.getInstance();
+        calendar1.set(Calendar.YEAR, 2019);
+        calendar1.set(Calendar.MONTH, 9);
+        calendar1.set(Calendar.DATE, 31);
+        Date embargoStartDate = calendar1.getTime();
+
+        // Dátum konca embarga
+        Calendar calendar2 = Calendar.getInstance();
+        calendar2.set(Calendar.YEAR, 2200);
+        calendar2.set(Calendar.MONTH, 9);
+        calendar2.set(Calendar.DATE, 31);
+        Date embargoEndDate = calendar2.getTime();
+
+        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true&hasEndDate=true"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page.totalElements", is(4)))
-                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
-                        ResourcePolicyMatcher.matchResourcePolicy(rpWithStartDate)
-                )))
-                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
-                        ResourcePolicyMatcher.matchResourcePolicy(rpWithEndDate)
-                )))
-                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
-                        ResourcePolicyMatcher.matchResourcePolicy(rpWithBothDates)
-                )))
-                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
-                        ResourcePolicyMatcher.matchResourcePolicy(rpWithoutDates)
-                )));
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1))) // At least our rpWithBothDates
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")]").exists())
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")].action[0]", is("READ")))
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")].startDate[0]", is("2019-10-31")))
+                .andExpect(jsonPath("$._embedded.resourcepolicies[?(@.id == " + rpWithBothDates.getID() + ")].endDate[0]", is("2200-10-31")));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3858,7 +3858,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true"))
-                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 2))); // rpWithStartDate + rpWithBothDates
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 2)));
+                // rpWithStartDate + rpWithBothDates
     }
 
     @Test
@@ -3876,7 +3877,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasEndDate=true"))
-                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 3))); // rpWithEndDate + rpWithEndDate2 + rpWithBothDates
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 3)));
+                // rpWithEndDate + rpWithEndDate2 + rpWithBothDates
     }
 
     @Test
@@ -3894,7 +3896,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=false&hasEndDate=false"))
-                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(baselineCount + 1))); // rpWithoutDates
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(baselineCount + 1)));
+                // rpWithoutDates
     }
 
     @Test
@@ -3912,7 +3915,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo"))
-                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 4))); // All our rps except rpWithoutDates
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 4)));
+                // All our rps except rpWithoutDates
     }
 
     @Test
@@ -3930,6 +3934,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true&hasEndDate=true"))
-                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 1))); // rpWithBothDates
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 1)));
+                // rpWithBothDates
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3785,6 +3785,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
      * @throws Exception if test data creation fails
      */
     private EmbargoTestData createEmbargoTestData() throws Exception {
+
+
         // Create test hierarchy
         Community community = CommunityBuilder.createCommunity(context)
                 .withName("Test Community").build();
@@ -3842,8 +3844,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     }
 
     @Test
-    public void findEmbargoWithStartDateOnly() throws Exception {
+    public void findEmbargoWithStartDate() throws Exception {
         context.turnOffAuthorisationSystem();
+
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDatePresence(context, true, null);
 
         EmbargoTestData testData = createEmbargoTestData();
 
@@ -3853,12 +3858,15 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true"))
-                .andExpect(jsonPath("$.page.totalElements", is(2))); // rpWithStartDate + rpWithBothDates
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 2))); // rpWithStartDate + rpWithBothDates
     }
 
     @Test
-    public void findEmbargoWithEndDateOnly() throws Exception {
+    public void findEmbargoWithEndDate() throws Exception {
         context.turnOffAuthorisationSystem();
+
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDatePresence(context, null, true);
 
         EmbargoTestData testData = createEmbargoTestData();
 
@@ -3868,12 +3876,15 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasEndDate=true"))
-                .andExpect(jsonPath("$.page.totalElements", is(3))); // rpWithEndDate + rpWithEndDate2 + rpWithBothDates
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 3))); // rpWithEndDate + rpWithEndDate2 + rpWithBothDates
     }
 
     @Test
     public void findEmbargoWithoutDates() throws Exception {
         context.turnOffAuthorisationSystem();
+
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDatePresence(context, false, false);
 
         EmbargoTestData testData = createEmbargoTestData();
 
@@ -3883,12 +3894,15 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=false&hasEndDate=false"))
-                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1))); // At least our rpWithoutDates
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(baselineCount + 1))); // rpWithoutDates
     }
 
     @Test
     public void findEmbargoWithAnyDate() throws Exception {
         context.turnOffAuthorisationSystem();
+
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDatePresence(context, null, null);
 
         EmbargoTestData testData = createEmbargoTestData();
 
@@ -3898,12 +3912,15 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo"))
-                .andExpect(jsonPath("$.page.totalElements", is(4)));
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 4))); // All our rps except rpWithoutDates
     }
 
     @Test
     public void findEmbargoWithBothDates() throws Exception {
         context.turnOffAuthorisationSystem();
+
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDatePresence(context, true, true);
 
         EmbargoTestData testData = createEmbargoTestData();
 
@@ -3913,6 +3930,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
                 .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true&hasEndDate=true"))
-                .andExpect(jsonPath("$.page.totalElements", is(1)));
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 1))); // rpWithBothDates
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -9,7 +9,9 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.data.rest.webmvc.RestMediaTypes.TEXT_URI_LIST_VALUE;
 import static org.springframework.http.MediaType.parseMediaType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -3838,7 +3840,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         return new EmbargoTestData(community, collection, item, embargoStartDate, embargoEndDate,
                 rpWithStartDate, rpWithEndDate, rpWithEndDate2, rpWithBothDates, rpWithoutDates);
     }
-    
+
     @Test
     public void findEmbargoWithStartDateOnly() throws Exception {
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -9,8 +9,7 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.springframework.data.rest.webmvc.RestMediaTypes.TEXT_URI_LIST_VALUE;
 import static org.springframework.http.MediaType.parseMediaType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -3741,4 +3740,78 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                              .andExpect(status().isUnprocessableEntity());
     }
 
+
+
+
+    @Test
+    public void findEmbargoByResourceTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // Príprava dát
+        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
+
+        // Získame skupinu Anonymov
+        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
+
+        // Dátum začiatku embarga
+        Calendar calendar1 = Calendar.getInstance();
+        calendar1.set(Calendar.YEAR, 2019);
+        calendar1.set(Calendar.MONTH, 9);
+        calendar1.set(Calendar.DATE, 31);
+        Date embargoStartDate = calendar1.getTime();
+
+        // Dátum konca embarga
+        Calendar calendar2 = Calendar.getInstance();
+        calendar2.set(Calendar.YEAR, 2200);
+        calendar2.set(Calendar.MONTH, 9);
+        calendar2.set(Calendar.DATE, 31);
+        Date embargoEndDate = calendar2.getTime();
+
+        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .build();
+
+        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .withStartDate(embargoStartDate)
+                .withEndDate(embargoEndDate)
+                .build();
+
+        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                .withAction(Constants.READ)
+                .withDspaceObject(item)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(4)))
+                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
+                        ResourcePolicyMatcher.matchResourcePolicy(rpWithStartDate)
+                )))
+                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
+                        ResourcePolicyMatcher.matchResourcePolicy(rpWithEndDate)
+                )))
+                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
+                        ResourcePolicyMatcher.matchResourcePolicy(rpWithBothDates)
+                )))
+                .andExpect(jsonPath("$._embedded.resourcepolicies", hasItem(
+                        ResourcePolicyMatcher.matchResourcePolicy(rpWithoutDates)
+                )));
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3813,7 +3813,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     @Test
     public void findEmbargoWithStartDate() throws Exception {
         // Baseline count
-        int baselineCount = this.resourcePolicyService.countByDatePresence(context, true, null);
+        int baselineCount = this.resourcePolicyService.countByDate(context, true, null);
 
         setupEmbargoTestData();
 
@@ -3828,7 +3828,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     @Test
     public void findEmbargoWithEndDate() throws Exception {
         // Baseline count
-        int baselineCount = this.resourcePolicyService.countByDatePresence(context, null, true);
+        int baselineCount = this.resourcePolicyService.countByDate(context, null, true);
 
         setupEmbargoTestData();
 
@@ -3843,7 +3843,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     @Test
     public void findEmbargoWithoutDates() throws Exception {
         // Baseline count
-        int baselineCount = this.resourcePolicyService.countByDatePresence(context, false, false);
+        int baselineCount = this.resourcePolicyService.countByDate(context, false, false);
 
         setupEmbargoTestData();
 
@@ -3858,7 +3858,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     @Test
     public void findEmbargoWithAnyDate() throws Exception {
         // Baseline count
-        int baselineCount = this.resourcePolicyService.countByDatePresence(context, null, null);
+        int baselineCount = this.resourcePolicyService.countByDate(context, null, null);
 
         setupEmbargoTestData();
 
@@ -3873,7 +3873,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     @Test
     public void findEmbargoWithBothDates() throws Exception {
         // Baseline count
-        int baselineCount = this.resourcePolicyService.countByDatePresence(context, true, true);
+        int baselineCount = this.resourcePolicyService.countByDate(context, true, true);
 
         setupEmbargoTestData();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -3740,33 +3740,71 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                              .andExpect(status().isUnprocessableEntity());
     }
 
-    @Test
-    public void findEmbargoWithStartDateOnly() throws Exception {
-        
-        context.turnOffAuthorisationSystem();
+    /**
+     * Test data container for embargo policy tests
+     */
+    private static class EmbargoTestData {
+        public final Community community;
+        public final Collection collection;
+        public final Item item;
+        public final Date embargoStartDate;
+        public final Date embargoEndDate;
+        public final ResourcePolicy rpWithStartDate;
+        public final ResourcePolicy rpWithEndDate;
+        public final ResourcePolicy rpWithEndDate2;
+        public final ResourcePolicy rpWithBothDates;
+        public final ResourcePolicy rpWithoutDates;
 
-        // Príprava dát
-        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
-        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
-        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
+        public EmbargoTestData(Community community, Collection collection, Item item,
+                               Date embargoStartDate, Date embargoEndDate,
+                               ResourcePolicy rpWithStartDate, ResourcePolicy rpWithEndDate,
+                               ResourcePolicy rpWithEndDate2, ResourcePolicy rpWithBothDates,
+                               ResourcePolicy rpWithoutDates) {
+            this.community = community;
+            this.collection = collection;
+            this.item = item;
+            this.embargoStartDate = embargoStartDate;
+            this.embargoEndDate = embargoEndDate;
+            this.rpWithStartDate = rpWithStartDate;
+            this.rpWithEndDate = rpWithEndDate;
+            this.rpWithEndDate2 = rpWithEndDate2;
+            this.rpWithBothDates = rpWithBothDates;
+            this.rpWithoutDates = rpWithoutDates;
+        }
+    }
 
-        // Získame skupinu Anonymov
-        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
+    /**
+     * Creates test data for embargo policy tests including:
+     * - Community, Collection, and Item
+     * - ResourcePolicies with different date combinations
+     * - Predefined start and end dates for consistency
+     *
+     * @return EmbargoTestData containing all test entities
+     * @throws Exception if test data creation fails
+     */
+    private EmbargoTestData createEmbargoTestData() throws Exception {
+        // Create test hierarchy
+        Community community = CommunityBuilder.createCommunity(context)
+                .withName("Test Community").build();
+        Collection collection = CollectionBuilder.createCollection(context, community)
+                .withName("Test Collection").build();
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle("Item with Embargo").build();
 
-        // Dátum začiatku embarga
+        // Create consistent embargo dates
         Calendar calendar1 = Calendar.getInstance();
         calendar1.set(Calendar.YEAR, 2019);
         calendar1.set(Calendar.MONTH, 9);
         calendar1.set(Calendar.DATE, 31);
         Date embargoStartDate = calendar1.getTime();
 
-        // Dátum konca embarga
         Calendar calendar2 = Calendar.getInstance();
         calendar2.set(Calendar.YEAR, 2200);
         calendar2.set(Calendar.MONTH, 9);
         calendar2.set(Calendar.DATE, 31);
         Date embargoEndDate = calendar2.getTime();
 
+        // Create ResourcePolicies with different date combinations
         ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
                 .withAction(Constants.READ)
                 .withDspaceObject(item)
@@ -3796,6 +3834,16 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                 .withAction(Constants.READ)
                 .withDspaceObject(item)
                 .build();
+
+        return new EmbargoTestData(community, collection, item, embargoStartDate, embargoEndDate,
+                rpWithStartDate, rpWithEndDate, rpWithEndDate2, rpWithBothDates, rpWithoutDates);
+    }
+    
+    @Test
+    public void findEmbargoWithStartDateOnly() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        EmbargoTestData testData = createEmbargoTestData();
 
         context.restoreAuthSystemState();
 
@@ -3808,60 +3856,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithEndDateOnly() throws Exception {
-
         context.turnOffAuthorisationSystem();
 
-        // Príprava dát
-        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
-        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
-        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
-
-        // Získame skupinu Anonymov
-        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
-
-        // Dátum začiatku embarga
-        Calendar calendar1 = Calendar.getInstance();
-        calendar1.set(Calendar.YEAR, 2019);
-        calendar1.set(Calendar.MONTH, 9);
-        calendar1.set(Calendar.DATE, 31);
-        Date embargoStartDate = calendar1.getTime();
-
-        // Dátum konca embarga
-        Calendar calendar2 = Calendar.getInstance();
-        calendar2.set(Calendar.YEAR, 2200);
-        calendar2.set(Calendar.MONTH, 9);
-        calendar2.set(Calendar.DATE, 31);
-        Date embargoEndDate = calendar2.getTime();
-
-        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .build();
+        EmbargoTestData testData = createEmbargoTestData();
 
         context.restoreAuthSystemState();
 
@@ -3874,60 +3871,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithoutDates() throws Exception {
-
         context.turnOffAuthorisationSystem();
 
-        // Príprava dát
-        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
-        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
-        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
-
-        // Získame skupinu Anonymov
-        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
-
-        // Dátum začiatku embarga
-        Calendar calendar1 = Calendar.getInstance();
-        calendar1.set(Calendar.YEAR, 2019);
-        calendar1.set(Calendar.MONTH, 9);
-        calendar1.set(Calendar.DATE, 31);
-        Date embargoStartDate = calendar1.getTime();
-
-        // Dátum konca embarga
-        Calendar calendar2 = Calendar.getInstance();
-        calendar2.set(Calendar.YEAR, 2200);
-        calendar2.set(Calendar.MONTH, 9);
-        calendar2.set(Calendar.DATE, 31);
-        Date embargoEndDate = calendar2.getTime();
-
-        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .build();
+        EmbargoTestData testData = createEmbargoTestData();
 
         context.restoreAuthSystemState();
 
@@ -3940,63 +3886,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithAnyDate() throws Exception {
-
         context.turnOffAuthorisationSystem();
 
-        // Príprava dát
-        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
-        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
-        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
-
-        // DEBUG: Počet policies po vytvorení item
-//        int createdPolicies = resourcePolicyService.countAll(context);
-
-        // Získame skupinu Anonymov
-        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
-
-        // Dátum začiatku embarga
-        Calendar calendar1 = Calendar.getInstance();
-        calendar1.set(Calendar.YEAR, 2019);
-        calendar1.set(Calendar.MONTH, 9);
-        calendar1.set(Calendar.DATE, 31);
-        Date embargoStartDate = calendar1.getTime();
-
-        // Dátum konca embarga
-        Calendar calendar2 = Calendar.getInstance();
-        calendar2.set(Calendar.YEAR, 2200);
-        calendar2.set(Calendar.MONTH, 9);
-        calendar2.set(Calendar.DATE, 31);
-        Date embargoEndDate = calendar2.getTime();
-
-        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .build();
+        EmbargoTestData testData = createEmbargoTestData();
 
         context.restoreAuthSystemState();
 
@@ -4009,60 +3901,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
     @Test
     public void findEmbargoWithBothDates() throws Exception {
-
         context.turnOffAuthorisationSystem();
 
-        // Príprava dát
-        Community community = CommunityBuilder.createCommunity(context).withName("Test Community").build();
-        Collection collection = CollectionBuilder.createCollection(context, community).withName("Test Collection").build();
-        Item item = ItemBuilder.createItem(context, collection).withTitle("Item with Embargo").build();
-
-        // Získame skupinu Anonymov
-        Group groupAnonymous = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
-
-        // Dátum začiatku embarga
-        Calendar calendar1 = Calendar.getInstance();
-        calendar1.set(Calendar.YEAR, 2019);
-        calendar1.set(Calendar.MONTH, 9);
-        calendar1.set(Calendar.DATE, 31);
-        Date embargoStartDate = calendar1.getTime();
-
-        // Dátum konca embarga
-        Calendar calendar2 = Calendar.getInstance();
-        calendar2.set(Calendar.YEAR, 2200);
-        calendar2.set(Calendar.MONTH, 9);
-        calendar2.set(Calendar.DATE, 31);
-        Date embargoEndDate = calendar2.getTime();
-
-        ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .withStartDate(embargoStartDate)
-                .withEndDate(embargoEndDate)
-                .build();
-
-        ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
-                .withAction(Constants.READ)
-                .withDspaceObject(item)
-                .build();
+        EmbargoTestData testData = createEmbargoTestData();
 
         context.restoreAuthSystemState();
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Add a read-only endpoint GET /api/items/{id}/embargo that returns embargo start_date and end_date (ISO 8601) and a computed status, implemented with controller/service logic, tests, and OpenAPI docs while respecting existing access controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an admin-only REST search endpoint to browse resource policies by embargo date presence (start and/or end dates). Supports optional hasStartDate/hasEndDate filters, pagination, and total counts for precise querying.

- Tests
  - Introduced integration tests covering searches for policies with start dates, end dates, both, none, and any embargo dates to ensure accuracy and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->