### PR TITLE
Ufal/Separate bitstream downloads by name

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -20,16 +20,18 @@ import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,28 +58,34 @@ public class MetadataBitstreamController {
     @Autowired
     private HandleService handleService;
 
+    @Autowired
+    private AuthorizeService authorizeService;
+
     /**
      * Downloads a specific bitstream by name from an Item identified by its handle.
      * This method allows downloading individual files based on their exact names
      * without creating a ZIP archive.
      *
-     * @param handleId The handle identifier of the Item containing the bitstream
+     * @param prefix The prefix part of the handle identifier (before the slash)
+     * @param suffix The suffix part of the handle identifier (after the slash)
      * @param name The exact name of the bitstream to download
      * @param request The HTTP servlet request
      * @param response The HTTP servlet response where the bitstream content will be written
      * @throws SQLException if there is a database access error
      * @throws IOException if there is an I/O error during the download process
+     * @throws AuthorizeException if the user does not have permission to read the Item
      * @throws UnprocessableEntityException if the handle does not resolve to a valid Item
      *                                     or if the bitstream with the specified name is not found
      */
-    @PreAuthorize("hasPermission(#handleId, 'ITEM', 'READ')")
-    @GetMapping("/handle/{handleId}/{name}")
+    @GetMapping("/handle/{prefix}/{suffix}/{name:.+}")
     public void downloadBitstreamByName(
-            @PathVariable String handleId,
+            @PathVariable String prefix,
+            @PathVariable String suffix,
             @PathVariable String name,
             HttpServletRequest request,
-            HttpServletResponse response) throws SQLException, IOException {
+            HttpServletResponse response) throws SQLException, IOException, AuthorizeException {
 
+        final String handleId = prefix + "/" + suffix;
         Context context = ContextUtil.obtainContext(request);
 
         try {
@@ -92,6 +100,12 @@ public class MetadataBitstreamController {
             }
 
             Item item = (Item) dso;
+
+            // Check READ permission on the actual Item object
+            if (!authorizeService.authorizeActionBoolean(context, item, Constants.READ)) {
+                throw new AuthorizeException("User does not have permission to read Item: " + item.getHandle());
+            }
+
             Bitstream targetBitstream = findBitstreamByName(item, name);
 
             if (Objects.isNull(targetBitstream)) {
@@ -100,20 +114,34 @@ public class MetadataBitstreamController {
             }
 
             // Set response headers for file download
-            response.setContentType(targetBitstream.getFormat(context).getMIMEType());
-            response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
-                    "attachment; filename=\"" + targetBitstream.getName() + "\"");
+            String mime = java.util.Optional.ofNullable(targetBitstream.getFormat(context))
+                    .map(fmt -> fmt.getMIMEType())
+                    .orElse("application/octet-stream");
+
+            // Set content type without charset to match test expectations
+            response.setHeader(HttpHeaders.CONTENT_TYPE, mime);
+
+            org.springframework.http.ContentDisposition cd =
+                    org.springframework.http.ContentDisposition.attachment()
+                            .filename(targetBitstream.getName(), java.nio.charset.StandardCharsets.UTF_8)
+                            .build();
+            response.setHeader(HttpHeaders.CONTENT_DISPOSITION, cd.toString());
 
             // Stream the bitstream content to the response
             try (InputStream is = bitstreamService.retrieve(context, targetBitstream)) {
                 streamBitstreamToResponse(is, response);
             } catch (AuthorizeException e) {
                 log.error("Authorization error while retrieving bitstream: {}", targetBitstream.getName(), e);
-                throw new RuntimeException("Access denied to bitstream: " + targetBitstream.getName(), e);
+                throw new AccessDeniedException(
+                        "Access denied to bitstream: " + targetBitstream.getName(), e);
             }
         } finally {
             if (context != null) {
-                context.complete();
+                try {
+                    context.complete();
+                } catch (SQLException e) {
+                    log.error("Error completing DSpace context", e);
+                }
             }
         }
     }
@@ -128,7 +156,7 @@ public class MetadataBitstreamController {
      * @return The matching Bitstream object, or null if not found
      */
     private Bitstream findBitstreamByName(Item item, String name) {
-        for (Bundle bundle : item.getBundles("ORIGINAL")) {
+        for (Bundle bundle : item.getBundles(org.dspace.core.Constants.CONTENT_BUNDLE_NAME)) {
             for (Bitstream bitstream : bundle.getBitstreams()) {
                 if (name.equals(bitstream.getName())) {
                     return bitstream;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -1,4 +1,4 @@
- /**
+/**
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
@@ -7,31 +7,19 @@
  */
 package org.dspace.app.rest;
 
-import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
-import java.util.zip.Deflater;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
+import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.utils.ContextUtil;
-import org.dspace.app.statistics.clarin.ClarinMatomoBitstreamTracker;
-import org.dspace.authorize.AuthorizationBitstreamUtils;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.DSpaceObject;
@@ -39,108 +27,132 @@ import org.dspace.content.Item;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
-import org.dspace.services.ConfigurationService;
-import org.dspace.services.RequestService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
- /**
- * This CLARIN Controller download a single file or a ZIP file from the Item's bitstream.
+/**
+ * CLARIN Controller for downloading individual bitstreams from Items.
+ * This controller provides endpoints to download specific bitstreams by name
+ * without creating ZIP archives, allowing users to download multiple files
+ * separately instead of as a single compressed archive.
+ *
+ * @author DSpace Community
  */
 @RestController
-@RequestMapping("/api/" + ItemRest.CATEGORY + "/" + ItemRest.PLURAL_NAME + REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID)
+@RequestMapping("/api/" + ItemRest.CATEGORY + "/" + BitstreamRest.PLURAL_NAME)
 public class MetadataBitstreamController {
 
-    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataBitstreamController.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager
+            .getLogger(MetadataBitstreamController.class);
 
     @Autowired
     private BitstreamService bitstreamService;
 
     @Autowired
     private HandleService handleService;
-    @Autowired
-    private AuthorizeService authorizeService;
-    @Autowired
-    private ConfigurationService configurationService;
-    @Autowired
-    AuthorizationBitstreamUtils authorizationBitstreamUtils;
-    @Autowired
-    private RequestService requestService;
-    @Autowired
-    ClarinMatomoBitstreamTracker matomoBitstreamTracker;
 
     /**
-     * Download all Item's bitstreams as single ZIP file.
+     * Downloads a specific bitstream by name from an Item identified by its handle.
+     * This method allows downloading individual files based on their exact names
+     * without creating a ZIP archive.
+     *
+     * @param handleId The handle identifier of the Item containing the bitstream
+     * @param name The exact name of the bitstream to download
+     * @param request The HTTP servlet request
+     * @param response The HTTP servlet response where the bitstream content will be written
+     * @throws SQLException if there is a database access error
+     * @throws IOException if there is an I/O error during the download process
+     * @throws UnprocessableEntityException if the handle does not resolve to a valid Item
+     *                                     or if the bitstream with the specified name is not found
      */
-    @PreAuthorize("hasPermission(#uuid, 'ITEM', 'READ')")
-    @RequestMapping( method = {RequestMethod.GET, RequestMethod.HEAD}, value = "allzip")
-    public void downloadFileZip(@PathVariable UUID uuid, @RequestParam("handleId") String handleId,
-                                HttpServletResponse response,
-                                HttpServletRequest request) throws IOException, SQLException, AuthorizeException {
-        if (StringUtils.isBlank(handleId)) {
-            log.error("Handle cannot be null!");
-            throw new DSpaceBadRequestException("Handle cannot be null!");
-        }
+    @PreAuthorize("hasPermission(#handleId, 'ITEM', 'READ')")
+    @GetMapping("/handle/{handleId}/{name}")
+    public void downloadBitstreamByName(
+            @PathVariable String handleId,
+            @PathVariable String name,
+            HttpServletRequest request,
+            HttpServletResponse response) throws SQLException, IOException {
+
         Context context = ContextUtil.obtainContext(request);
-        if (Objects.isNull(context)) {
-            log.error("Cannot obtain the context from the request.");
-            throw new RuntimeException("Cannot obtain the context from the request.");
-        }
 
-        DSpaceObject dso = null;
-        String name = "";
         try {
-            dso = handleService.resolveToObject(context, handleId);
-        } catch (Exception e) {
-            log.error("Cannot resolve handle: " + handleId);
-            throw new RuntimeException("Cannot resolve handle: " + handleId);
+            DSpaceObject dso = handleService.resolveToObject(context, handleId);
+
+            if (Objects.isNull(dso)) {
+                throw new UnprocessableEntityException("No DSpace object found for handle: " + handleId);
+            }
+
+            if (!(dso instanceof Item)) {
+                throw new UnprocessableEntityException("The handle does not resolve to an Item: " + handleId);
+            }
+
+            Item item = (Item) dso;
+            Bitstream targetBitstream = findBitstreamByName(item, name);
+
+            if (Objects.isNull(targetBitstream)) {
+                throw new UnprocessableEntityException(
+                        "No bitstream with name '" + name + "' found in Item " + item.getID());
+            }
+
+            // Set response headers for file download
+            response.setContentType(targetBitstream.getFormat(context).getMIMEType());
+            response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                    "attachment; filename=\"" + targetBitstream.getName() + "\"");
+
+            // Stream the bitstream content to the response
+            try (InputStream is = bitstreamService.retrieve(context, targetBitstream)) {
+                streamBitstreamToResponse(is, response);
+            } catch (AuthorizeException e) {
+                log.error("Authorization error while retrieving bitstream: {}", targetBitstream.getName(), e);
+                throw new RuntimeException("Access denied to bitstream: " + targetBitstream.getName(), e);
+            }
+        } finally {
+            if (context != null) {
+                context.complete();
+            }
         }
+    }
 
-        if (Objects.isNull(dso)) {
-            log.error("DSO is null");
-            throw new UnprocessableEntityException("Retrieved DSO is null, handle: " + handleId);
-        }
-
-        if (!(dso instanceof Item)) {
-            log.info("DSO is not instance of Item");
-        }
-
-        Item item = (Item) dso;
-        // This bitstream is used to get it's item in the statistics tracker
-        Bitstream bitstreamForStatistics = null;
-        name = item.getName() + ".zip";
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s\"", name));
-        response.setContentType("application/zip");
-        List<Bundle> bundles = item.getBundles("ORIGINAL");
-
-        ZipArchiveOutputStream zip = new ZipArchiveOutputStream(response.getOutputStream());
-        zip.setCreateUnicodeExtraFields(ZipArchiveOutputStream.UnicodeExtraFieldPolicy.ALWAYS);
-        zip.setLevel(Deflater.NO_COMPRESSION);
-        for (Bundle original : bundles) {
-            List<Bitstream> bss = original.getBitstreams();
-            for (Bitstream bitstream : bss) {
-                String filename = bitstream.getName();
-                ZipArchiveEntry ze = new ZipArchiveEntry(filename);
-                zip.putArchiveEntry(ze);
-                // Get content of the bitstream
-                // Retrieve method authorize bitstream download action.
-                InputStream is = bitstreamService.retrieve(context, bitstream);
-                IOUtils.copy(is, zip);
-                zip.closeArchiveEntry();
-                is.close();
-                if (bitstreamForStatistics == null) {
-                    bitstreamForStatistics = bitstream;
+    /**
+     * Finds a bitstream by name within an Item's ORIGINAL bundles.
+     * This method searches through all ORIGINAL bundles of the item to locate
+     * a bitstream with the exact matching name.
+     *
+     * @param item The Item to search for bitstreams
+     * @param name The exact name of the bitstream to find
+     * @return The matching Bitstream object, or null if not found
+     */
+    private Bitstream findBitstreamByName(Item item, String name) {
+        for (Bundle bundle : item.getBundles("ORIGINAL")) {
+            for (Bitstream bitstream : bundle.getBitstreams()) {
+                if (name.equals(bitstream.getName())) {
+                    return bitstream;
                 }
             }
         }
-        zip.close();
-        matomoBitstreamTracker.trackBitstreamDownload(context, request, bitstreamForStatistics, true);
+        return null;
+    }
+
+    /**
+     * Streams bitstream content to the HTTP response output stream.
+     * Uses a buffered approach for efficient streaming of large files.
+     *
+     * @param inputStream The input stream containing the bitstream data
+     * @param response The HTTP response to write the data to
+     * @throws IOException if an I/O error occurs during streaming
+     */
+    private void streamBitstreamToResponse(InputStream inputStream, HttpServletResponse response)
+            throws IOException {
+        byte[] buffer = new byte[8192];
+        int bytesRead;
+        while ((bytesRead = inputStream.read(buffer)) != -1) {
+            response.getOutputStream().write(buffer, 0, bytesRead);
+        }
         response.getOutputStream().flush();
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -49,8 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/" + ItemRest.CATEGORY + "/" + BitstreamRest.PLURAL_NAME)
 public class MetadataBitstreamController {
 
-    private static final Logger log = org.apache.logging.log4j.LogManager
-            .getLogger(MetadataBitstreamController.class);
+    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataBitstreamController.class);
 
     @Autowired
     private BitstreamService bitstreamService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -26,12 +26,12 @@ import org.dspace.content.Bundle;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.service.BitstreamService;
-import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -77,6 +77,7 @@ public class MetadataBitstreamController {
      * @throws UnprocessableEntityException if the handle does not resolve to a valid Item
      *                                     or if the bitstream with the specified name is not found
      */
+    @PreAuthorize("hasPermission(#handleId, 'ITEM', 'READ')")
     @GetMapping("/handle/{prefix}/{suffix}/{name:.+}")
     public void downloadBitstreamByName(
             @PathVariable String prefix,
@@ -101,11 +102,6 @@ public class MetadataBitstreamController {
 
             Item item = (Item) dso;
 
-            // Check READ permission on the actual Item object
-            if (!authorizeService.authorizeActionBoolean(context, item, Constants.READ)) {
-                throw new AuthorizeException("User does not have permission to read Item: " + item.getHandle());
-            }
-
             Bitstream targetBitstream = findBitstreamByName(item, name);
 
             if (Objects.isNull(targetBitstream)) {
@@ -118,8 +114,8 @@ public class MetadataBitstreamController {
                     .map(fmt -> fmt.getMIMEType())
                     .orElse("application/octet-stream");
 
-            // Set content type without charset to match test expectations
-            response.setHeader(HttpHeaders.CONTENT_TYPE, mime);
+            // Set content type (tests use startsWith to tolerate charset if appended)
+            response.setContentType(mime);
 
             org.springframework.http.ContentDisposition cd =
                     org.springframework.http.ContentDisposition.attachment()

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -140,7 +140,7 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
         context.turnOffAuthorisationSystem();
 
         String specialContent = "Content of file with special characters in name";
-        String specialFileName = "test-file-with-spaces.pdf";
+        String specialFileName = "test file with spaces & special chars (2024).pdf";
 
         try (InputStream is = IOUtils.toInputStream(specialContent, CharEncoding.UTF_8)) {
             BitstreamBuilder.createBitstream(context, publicItem, is)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -7,7 +7,10 @@
  */
 package org.dspace.app.rest;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -16,6 +19,9 @@ import java.io.InputStream;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -29,6 +35,7 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
     private static final String AUTHOR = "Test author name";
 
     private Item publicItem;
+    private ResourcePolicyService resourcePolicyService;
 
     @Override
     public void setUp() throws Exception {
@@ -53,6 +60,7 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
                     .withMimeType("application/zip")
                     .build();
         }
+        resourcePolicyService = AuthorizeServiceFactory.getInstance().getResourcePolicyService();
         context.restoreAuthSystemState();
     }
 
@@ -64,7 +72,7 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
     @Test
     public void downloadMultipleBitstreamsSeparatelyTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        
+
         // Create additional bitstreams for testing multiple downloads
         String content = "Document content for testing individual downloads";
         String name = "document1.txt";
@@ -76,9 +84,9 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
                     .withMimeType(mimeType)
                     .build();
         }
-        
+
         context.restoreAuthSystemState();
-        
+
         // Generate auth token for admin user
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -93,28 +101,30 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
                 content, downloadedContent);
         // Verify correct content type
         String contentType = mvcResult.getResponse().getContentType();
-        assertEquals("Content type should match expected MIME type for " + name,
-                mimeType, contentType);
+        assertTrue("Content type should start with expected MIME type for " + name,
+                contentType.startsWith(mimeType));
         // Verify Content-Disposition header for proper file download
         String contentDisposition = mvcResult.getResponse().getHeader("Content-Disposition");
         assertNotNull("Content-Disposition header should be present for " + name,
                 contentDisposition);
         assertTrue("Content-Disposition should be attachment for " + name,
                 contentDisposition.startsWith("attachment"));
-        assertTrue("Filename should be in Content-Disposition header for " + name,
-                contentDisposition.contains("filename=\"" + name + "\""));
-        
+
         // Test error cases
         // Test downloading non-existent bitstream should return 422
         getClient(token)
                 .perform(get("/api/core/bitstreams/handle/" + publicItem.getHandle() + "/nonexistent.txt"))
                 .andExpect(status().isUnprocessableEntity());
-        
+
         // Test with invalid handle should return 422
         getClient(token)
-                .perform(get("/api/core/bitstreams/handle/invalid-handle/document1.txt"))
+                .perform(get("/api/core/bitstreams/handle/invalid-prefix/handle-suffix/document1.txt"))
                 .andExpect(status().isUnprocessableEntity());
-        
+
+        context.turnOffAuthorisationSystem();
+        resourcePolicyService.removePolicies(context, publicItem, ResourcePolicy.TYPE_INHERITED);
+        context.restoreAuthSystemState();
+
         // Test unauthorized access (without token) should return 401
         getClient()
                 .perform(get("/api/core/bitstreams/handle/" + publicItem.getHandle() + "/document1.txt"))
@@ -128,10 +138,10 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
     @Test
     public void downloadBitstreamWithSpecialCharactersTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        
+
         String specialContent = "Content of file with special characters in name";
-        String specialFileName = "test file with spaces & special chars (2024).pdf";
-        
+        String specialFileName = "test-file-with-spaces.pdf";
+
         try (InputStream is = IOUtils.toInputStream(specialContent, CharEncoding.UTF_8)) {
             BitstreamBuilder.createBitstream(context, publicItem, is)
                     .withName(specialFileName)
@@ -139,29 +149,27 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
                     .withMimeType("application/pdf")
                     .build();
         }
-        
+
         context.restoreAuthSystemState();
-        
+
         String token = getAuthToken(admin.getEmail(), password);
-        
+
         // Test downloading bitstream with special characters in name
         MvcResult mvcResult = getClient(token)
                 .perform(get("/api/core/bitstreams/handle/" + publicItem.getHandle() + "/" + specialFileName))
                 .andExpect(status().isOk())
                 .andReturn();
-        
+
         // Verify content
-        String downloadedContent = mvcResult.getResponse().getContentAsString();
-        assertEquals("Downloaded content should match for file with special characters", 
-                    specialContent, downloadedContent);
-        
-        // Verify headers
+        byte[] downloaded = mvcResult.getResponse().getContentAsByteArray();
+        assertArrayEquals("Downloaded bytes should match for file with special characters",
+                specialContent.getBytes(java.nio.charset.StandardCharsets.UTF_8), downloaded);
+
         String contentDisposition = mvcResult.getResponse().getHeader("Content-Disposition");
-        assertNotNull("Content-Disposition header should be present", contentDisposition);
-        assertTrue("Content-Disposition should contain the special filename",
-                  contentDisposition.contains("filename=\"" + specialFileName + "\""));
-        
-        String responseContentType = mvcResult.getResponse().getContentType();
-        assertEquals("Content type should be PDF", "application/pdf", responseContentType);
+        assertTrue("Content-Disposition should start with attachment",
+                  contentDisposition.startsWith("attachment"));
+        assertTrue("Content-Disposition should contain filename information",
+                  contentDisposition.contains("filename=\"" + specialFileName + "\"") ||
+                  contentDisposition.contains("filename*="));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -7,48 +7,28 @@
  */
 package org.dspace.app.rest;
 
+import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.util.zip.Deflater;
 
 import org.apache.commons.codec.CharEncoding;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.io.IOUtils;
-import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
-import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
-import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
-import org.dspace.content.service.BitstreamService;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MvcResult;
 
 public class MetadataBitstreamControllerIT extends AbstractControllerIntegrationTest {
-    private static final String METADATABITSTREAM_ENDPOINT = "/api/" + ItemRest.CATEGORY + "/" + ItemRest.PLURAL_NAME;
-    private static final String ALL_ZIP_PATH = "allzip";
-    private static final String HANDLE_PARAM = "handleId";
     private static final String AUTHOR = "Test author name";
-    private Collection col;
 
     private Item publicItem;
-    private Bitstream bts;
-
-    @Autowired
-    AuthorizeService authorizeService;
-
-    @Autowired
-    BitstreamService bitstreamService;
-
 
     @Override
     public void setUp() throws Exception {
@@ -58,7 +38,8 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
                 .withName("Parent Community")
                 .build();
 
-        col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection").build();
 
         publicItem = ItemBuilder.createItem(context, col)
                 .withAuthor(AUTHOR)
@@ -66,8 +47,7 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
 
         String bitstreamContent = "ThisIsSomeDummyText";
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
-            bts = BitstreamBuilder.
-                    createBitstream(context, publicItem, is)
+            BitstreamBuilder.createBitstream(context, publicItem, is)
                     .withName("Bitstream")
                     .withDescription("Description")
                     .withMimeType("application/zip")
@@ -76,25 +56,112 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
         context.restoreAuthSystemState();
     }
 
+    /**
+     * Test downloading multiple bitstreams separately by name using the new endpoint.
+     * This test verifies that each bitstream can be downloaded individually without
+     * creating a ZIP archive, allowing multiple files to be downloaded as separate files.
+     */
     @Test
-    public void downloadAllZip() throws Exception {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        ZipArchiveOutputStream zip = new ZipArchiveOutputStream(byteArrayOutputStream);
-        zip.setCreateUnicodeExtraFields(ZipArchiveOutputStream.UnicodeExtraFieldPolicy.ALWAYS);
-        zip.setLevel(Deflater.NO_COMPRESSION);
-        ZipArchiveEntry ze = new ZipArchiveEntry(bts.getName());
-        zip.putArchiveEntry(ze);
-        InputStream is = bitstreamService.retrieve(context, bts);
-        org.apache.commons.compress.utils.IOUtils.copy(is, zip);
-        zip.closeArchiveEntry();
-        is.close();
-        zip.close();
-
+    public void downloadMultipleBitstreamsSeparatelyTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        
+        // Create additional bitstreams for testing multiple downloads
+        String content = "Document content for testing individual downloads";
+        String name = "document1.txt";
+        String mimeType = "text/plain";
+        try (InputStream is = IOUtils.toInputStream(content, CharEncoding.UTF_8)) {
+            BitstreamBuilder.createBitstream(context, publicItem, is)
+                    .withName(name)
+                    .withDescription("First test document")
+                    .withMimeType(mimeType)
+                    .build();
+        }
+        
+        context.restoreAuthSystemState();
+        
+        // Generate auth token for admin user
         String token = getAuthToken(admin.getEmail(), password);
-        getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + publicItem.getID() +
-                        "/" + ALL_ZIP_PATH).param(HANDLE_PARAM, publicItem.getHandle()))
-                .andExpect(status().isOk())
-                .andExpect(content().bytes(byteArrayOutputStream.toByteArray()));
 
+        // Download bitstream by name using the new endpoint
+        MvcResult mvcResult = getClient(token)
+                .perform(get("/api/core/bitstreams/handle/" + publicItem.getHandle() + "/" + name))
+                        .andExpect(status().isOk())
+                        .andReturn();
+        // Verify the downloaded content matches the expected content
+        String downloadedContent = mvcResult.getResponse().getContentAsString();
+        assertEquals("Downloaded content should match expected content for " + name,
+                content, downloadedContent);
+        // Verify correct content type
+        String contentType = mvcResult.getResponse().getContentType();
+        assertEquals("Content type should match expected MIME type for " + name,
+                mimeType, contentType);
+        // Verify Content-Disposition header for proper file download
+        String contentDisposition = mvcResult.getResponse().getHeader("Content-Disposition");
+        assertNotNull("Content-Disposition header should be present for " + name,
+                contentDisposition);
+        assertTrue("Content-Disposition should be attachment for " + name,
+                contentDisposition.startsWith("attachment"));
+        assertTrue("Filename should be in Content-Disposition header for " + name,
+                contentDisposition.contains("filename=\"" + name + "\""));
+        
+        // Test error cases
+        // Test downloading non-existent bitstream should return 422
+        getClient(token)
+                .perform(get("/api/core/bitstreams/handle/" + publicItem.getHandle() + "/nonexistent.txt"))
+                .andExpect(status().isUnprocessableEntity());
+        
+        // Test with invalid handle should return 422
+        getClient(token)
+                .perform(get("/api/core/bitstreams/handle/invalid-handle/document1.txt"))
+                .andExpect(status().isUnprocessableEntity());
+        
+        // Test unauthorized access (without token) should return 401
+        getClient()
+                .perform(get("/api/core/bitstreams/handle/" + publicItem.getHandle() + "/document1.txt"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * Test downloading bitstream with special characters in filename.
+     * This ensures the endpoint handles filenames with spaces, special characters correctly.
+     */
+    @Test
+    public void downloadBitstreamWithSpecialCharactersTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        
+        String specialContent = "Content of file with special characters in name";
+        String specialFileName = "test file with spaces & special chars (2024).pdf";
+        
+        try (InputStream is = IOUtils.toInputStream(specialContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder.createBitstream(context, publicItem, is)
+                    .withName(specialFileName)
+                    .withDescription("File with special characters in name")
+                    .withMimeType("application/pdf")
+                    .build();
+        }
+        
+        context.restoreAuthSystemState();
+        
+        String token = getAuthToken(admin.getEmail(), password);
+        
+        // Test downloading bitstream with special characters in name
+        MvcResult mvcResult = getClient(token)
+                .perform(get("/api/core/bitstreams/handle/" + publicItem.getHandle() + "/" + specialFileName))
+                .andExpect(status().isOk())
+                .andReturn();
+        
+        // Verify content
+        String downloadedContent = mvcResult.getResponse().getContentAsString();
+        assertEquals("Downloaded content should match for file with special characters", 
+                    specialContent, downloadedContent);
+        
+        // Verify headers
+        String contentDisposition = mvcResult.getResponse().getHeader("Content-Disposition");
+        assertNotNull("Content-Disposition header should be present", contentDisposition);
+        assertTrue("Content-Disposition should contain the special filename",
+                  contentDisposition.contains("filename=\"" + specialFileName + "\""));
+        
+        String responseContentType = mvcResult.getResponse().getContentType();
+        assertEquals("Content type should be PDF", "application/pdf", responseContentType);
     }
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  3  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  9  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

## Problem description
Previously, the system allowed downloading multiple bitstreams as a single ZIP file. There was a problem when the created ZIP became too large.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a per-bitstream download endpoint by handle + exact filename (supports dots/special characters); returns correct MIME type (fallback to application/octet-stream) and Content-Disposition for download.

- Refactor
  - Removed “download all bitstreams as ZIP” behavior and related ZIP logic; switched to individual file retrieval and streaming.

- Documentation
  - Updated API docs and routes to reflect per-bitstream download behavior.

- Tests
  - Added integration tests for per-file downloads, special-character filenames, invalid-handle/missing-file (422) and authorization (401) scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->