### PR TITLE
UFAL/Embargo provenance - missing start date and end date

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -287,7 +287,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                         ProvenanceMessageTemplates.ITEM_REPLACE_SINGLE_METADATA.getTemplate(), item,
                         messageProvider.getMessage(bitstream),
                         messageProvider.getMetadata(messageProvider.getMetadataField(metadataField), oldMtdVal));
-                addProvenanceMetadata(context, item, msg);;
+                addProvenanceMetadata(context, item, msg);
             }
         } catch (SQLException | AuthorizeException e) {
             log.error("Unable to add new provenance metadata when replacing metadata in a item.", e);

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -325,9 +325,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
 
     private String extractAccessConditions(List<AccessCondition> accessConditions) {
         return accessConditions.stream()
-                .map(ac -> ac.getName() +
-                    (ac.getStartDate() != null ? " [from: " + ac.getStartDate().toString() + "]" : "") +
-                    (ac.getEndDate() != null ? " [till: " + ac.getEndDate() + "]" : ""))
+                    (ac.getEndDate() != null ? " [till: " + ac.getEndDate().toString() + "]" : ""))
                 .collect(Collectors.joining(";"));
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -325,6 +325,8 @@ public class ProvenanceServiceImpl implements ProvenanceService {
 
     private String extractAccessConditions(List<AccessCondition> accessConditions) {
         return accessConditions.stream()
+                .map(ac -> ac.getName() +
+                    (ac.getStartDate() != null ? " [from: " + ac.getStartDate().toString() + "]" : "") +
                     (ac.getEndDate() != null ? " [till: " + ac.getEndDate().toString() + "]" : ""))
                 .collect(Collectors.joining(";"));
     }

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -325,7 +325,9 @@ public class ProvenanceServiceImpl implements ProvenanceService {
 
     private String extractAccessConditions(List<AccessCondition> accessConditions) {
         return accessConditions.stream()
-                .map(AccessCondition::getName)
+                .map(ac -> ac.getName() +
+                    (ac.getStartDate() != null ? " [from: " + ac.getStartDate().toString() + "]" : "") +
+                    (ac.getEndDate() != null ? " [till: " + ac.getEndDate() + "]" : ""))
                 .collect(Collectors.joining(";"));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
@@ -389,7 +389,7 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
         List<AccessCondition> acList = new ArrayList<>();
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         cal.set(2030, Calendar.JANUARY, 1, 0, 0, 0);
-        cal.set(java.util.Calendar.MILLISECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
         AccessCondition embargo = new AccessCondition("embargo", "test", cal.getTime(), null);
         acList.add(embargo);
         bitstreamNode.setAccessConditions(acList);
@@ -397,7 +397,12 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
 
         provenanceService.setBitstreamPolicies(context, bitstream, item, bulk);
 
-        objectCheck(itemService.find(context, item.getID()), "Access condition (embargo [from:");
+        // Build full expected message
+        String expected = "Access condition (embargo [from: " + cal.getTime() + "]) was added to bitstream ("
+                + bitstream.getID() + ") by first (admin) last (admin) ("
+                + admin.getEmail() + ") on \nNo. of bitstreams: 1\n";
+
+        objectCheck(itemService.find(context, item.getID()), expected);
 
         deleteBitstream(bitstream);
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
@@ -20,14 +20,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.ws.rs.core.MediaType;
 
+import org.dspace.app.bulkaccesscontrol.model.AccessCondition;
+import org.dspace.app.bulkaccesscontrol.model.AccessConditionBitstream;
+import org.dspace.app.bulkaccesscontrol.model.BulkAccessControlInput;
 import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.RemoveOperation;
@@ -55,6 +60,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinLicenseLabelService;
 import org.dspace.content.service.clarin.ClarinLicenseService;
 import org.dspace.core.Constants;
+import org.dspace.core.ProvenanceService;
 import org.dspace.discovery.SearchServiceException;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -72,6 +78,8 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
     private ClarinLicenseLabelService clarinLicenseLabelService;
     @Autowired
     private ClarinLicenseService clarinLicenseService;
+    @Autowired
+    private ProvenanceService provenanceService;
 
     private Collection  collection;
     private Item item;
@@ -371,6 +379,28 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
         deleteCollection(col.getID());
     }
 
+    @Test
+    public void checkEmbargoProvenanceTest() throws Exception {
+        context.setCurrentUser(admin);
+        Bitstream bitstream = createBitstream(item, Constants.CONTENT_BUNDLE_NAME);
+
+        BulkAccessControlInput bulk = new BulkAccessControlInput();
+        AccessConditionBitstream bitstreamNode = new AccessConditionBitstream();
+        List<AccessCondition> acList = new ArrayList<>();
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        cal.set(2030, Calendar.JANUARY, 1, 0, 0, 0);
+        cal.set(java.util.Calendar.MILLISECOND, 0);
+        AccessCondition embargo = new AccessCondition("embargo", "test", cal.getTime(), null);
+        acList.add(embargo);
+        bitstreamNode.setAccessConditions(acList);
+        bulk.setBitstream(bitstreamNode);
+
+        provenanceService.setBitstreamPolicies(context, bitstream, item, bulk);
+
+        objectCheck(itemService.find(context, item.getID()), "Access condition (embargo [from:");
+
+        deleteBitstream(bitstream);
+    }
 
     private String provenanceMetadataModified(String metadata) {
         // Regex to match the date pattern

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
@@ -24,7 +24,6 @@ import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.TimeZone;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -387,7 +386,7 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
         BulkAccessControlInput bulk = new BulkAccessControlInput();
         AccessConditionBitstream bitstreamNode = new AccessConditionBitstream();
         List<AccessCondition> acList = new ArrayList<>();
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar cal = Calendar.getInstance();
         cal.set(2030, Calendar.JANUARY, 1, 0, 0, 0);
         cal.set(Calendar.MILLISECOND, 0);
         AccessCondition embargo = new AccessCondition("embargo", "test", cal.getTime(), null);
@@ -400,7 +399,7 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
         // Build full expected message
         String expected = "Access condition (embargo [from: " + cal.getTime() + "]) was added to bitstream ("
                 + bitstream.getID() + ") by first (admin) last (admin) ("
-                + admin.getEmail() + ") on \nNo. of bitstreams: 1\n";
+                + admin.getEmail() + ") on ";
 
         objectCheck(itemService.find(context, item.getID()), expected);
 


### PR DESCRIPTION
Linked issue: [#1030](https://github.com/dataquest-dev/DSpace/issues/1030)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provenance/audit messages now include access-condition time ranges: when available, a start date is shown ("from: <date>") and an end date is shown ("till: <date>"), clarifying time-limited access restrictions in audit views.

* **Tests**
  * Added integration tests to verify embargo-related provenance entries and expected embargo text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->