### PR TITLE
UFAL/Metadata value added to provenance when added metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
@@ -9,6 +9,7 @@ package org.dspace.core;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.dspace.authorize.AuthorizeException;
@@ -91,13 +92,9 @@ public class ProvenanceMessageFormatter {
     }
 
     public String getMetadataReplacement(String metadataKey, String oldValue, String newValue) {
-        if (oldValue == null) {
-            oldValue = "[empty]";
-        }
-        if (newValue == null) {
-            newValue = "[empty]";
-        }
-        return String.format("%s [%s -> %s]", metadataKey, oldValue, newValue);
+        return String.format("%s [%s -> %s]", metadataKey,
+                Objects.toString(oldValue, "empty"),
+                Objects.toString(newValue, "empty"));
     }
 
     public String getMetadataField(MetadataField metadataField) {

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
@@ -91,9 +91,12 @@ public class ProvenanceMessageFormatter {
     }
 
     public String getMetadataReplacement(String metadataKey, String oldValue, String newValue) {
-        if (oldValue == null) oldValue = "[empty]";
-        if (newValue == null) newValue = "[empty]";
-        
+        if (oldValue == null) {
+            oldValue = "[empty]";
+        }
+        if (newValue == null) {
+            newValue = "[empty]";
+        }
         return String.format("%s [%s → %s]", metadataKey, oldValue, newValue);
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
@@ -97,7 +97,7 @@ public class ProvenanceMessageFormatter {
         if (newValue == null) {
             newValue = "[empty]";
         }
-        return String.format("%s [%s → %s]", metadataKey, oldValue, newValue);
+        return String.format("%s [%s -> %s]", metadataKey, oldValue, newValue);
     }
 
     public String getMetadataField(MetadataField metadataField) {

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageFormatter.java
@@ -90,6 +90,13 @@ public class ProvenanceMessageFormatter {
         return oldMtdKey + ": " + oldMtdValue;
     }
 
+    public String getMetadataReplacement(String metadataKey, String oldValue, String newValue) {
+        if (oldValue == null) oldValue = "[empty]";
+        if (newValue == null) newValue = "[empty]";
+        
+        return String.format("%s [%s → %s]", metadataKey, oldValue, newValue);
+    }
+
     public String getMetadataField(MetadataField metadataField) {
         return metadataField.toString()
                 .replace('_', '.');

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
@@ -116,8 +116,9 @@ public interface ProvenanceService {
      * @param context DSpace context object
      * @param dso DSpace object to which the metadata is added
      * @param metadataField metadata field that is added
+     * @param metadataValue metadata value that is added
      */
-    void addMetadata(Context context, DSpaceObject dso, MetadataField metadataField);
+    void addMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String metadataValue);
 
     /**
      * Add a provenance message to the item when metadata is removed

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
@@ -140,14 +140,16 @@ public interface ProvenanceService {
                                int indexInt);
 
     /**
-     * Add a provenance message to the item when metadata is replaced
+     * Add a provenance message to the item when metadata is replaced, showing both old and new values
      *
      * @param context DSpace context object
      * @param dso DSpace object to which the metadata is replaced
      * @param metadataField metadata field that is replaced
      * @param oldMtdVal old metadata value
+     * @param newMtdVal new metadata value
      */
-    void replaceMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String oldMtdVal);
+    void replaceMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String oldMtdVal,
+                         String newMtdVal);
 
     /**
      * Add a provenance message to the item when metadata is replaced

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
@@ -160,7 +160,7 @@ public interface ProvenanceService {
      * @param oldMtdVal old metadata value
      */
     void replaceMetadataSingle(Context context, DSpaceObject dso, MetadataField metadataField,
-                               String oldMtdVal);
+                               String oldMtdVal, String newMtdVal);
 
     /**
      * Add a provenance message to the item when metadata is updated

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -289,8 +289,8 @@ public class ProvenanceServiceImpl implements ProvenanceService {
             if (Objects.nonNull(item)) {
                 String msg = messageProvider.getMessage(context,
                         ProvenanceMessageTemplates.ITEM_REPLACE_SINGLE_METADATA.getTemplate(), item,
-                        messageProvider.getMessage(bitstream), messageProvider.getMetadataReplacement(
-                                messageProvider.getMetadataField(metadataField), oldMtdVal, newMtdVal));
+                        messageProvider.getMessage(bitstream),
+                        messageProvider.getMetadata(messageProvider.getMetadataField(metadataField), oldMtdVal));
                 addProvenanceMetadata(context, item, msg);;
             }
         } catch (SQLException | AuthorizeException e) {

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -190,9 +190,9 @@ public class ProvenanceServiceImpl implements ProvenanceService {
     public void addMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String metadataValue) {
         try {
             if (Constants.ITEM == dso.getType()) {
-                String mtdKey = messageProvider.getMetadataField(metadataField);
+                String metadataKey = messageProvider.getMetadataField(metadataField);
                 String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                        (Item) dso, messageProvider.getMetadata(mtdKey, metadataValue), "added");
+                        (Item) dso, messageProvider.getMetadata(metadataKey, metadataValue), "added");
                 addProvenanceMetadata(context, (Item) dso, msg);
             }
 
@@ -200,10 +200,10 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                 Bitstream bitstream = (Bitstream) dso;
                 Item item = findItemByBitstream(context, bitstream);
                 if (Objects.nonNull(item)) {
-                    String mtdKey = messageProvider.getMetadataField(metadataField);
+                    String metadataKey = messageProvider.getMetadataField(metadataField);
                     String msg = messageProvider.getMessage(context,
                             ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(), item,
-                            messageProvider.getMetadata(mtdKey, metadataValue),
+                            messageProvider.getMetadata(metadataKey, metadataValue),
                             "added by", messageProvider.getMessage(bitstream));
                     addProvenanceMetadata(context, item, msg);
                 }

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -201,7 +201,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                 Item item = findItemByBitstream(context, bitstream);
                 if (Objects.nonNull(item)) {
                     String msg = messageProvider.getMessage(context,
-                            ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(),
+                            ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(), item,
                             messageProvider.getMetadata(
                                     messageProvider.getMetadataField(metadataField), metadataValue), "added by",
                             messageProvider.getMessage(bitstream));

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -231,7 +231,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
             Item item = findItemByBitstream(context, bitstream);
             if (Objects.nonNull(item)) {
                 String msg = messageProvider.getMessage(context,
-                        ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(), item,
+                        ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(),
                         messageProvider.getMetadata(messageProvider.getMetadataField(oldMtdKey), oldMtdValue),
                         "deleted from", messageProvider.getMessage(bitstream));
                 addProvenanceMetadata(context, item, msg);
@@ -252,7 +252,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
         String oldMtdValue = metadataValues.get(indexInt).getValue();
         try {
             String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                    (Item) dso, messageProvider.getMetadata(oldMtdKey, oldMtdValue), "deleted");
+                    messageProvider.getMetadata(oldMtdKey, oldMtdValue), "deleted");
             addProvenanceMetadata(context, (Item) dso, msg);
         } catch (SQLException | AuthorizeException e) {
             log.error("Unable to add new provenance metadata when removing metadata at a specific index " +
@@ -268,7 +268,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
 
         try {
             String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                    (Item) dso, messageProvider.getMetadataReplacement(
+                    messageProvider.getMetadataReplacement(
                             messageProvider.getMetadataField(metadataField), oldMtdVal, newMtdVal), "updated");
             addProvenanceMetadata(context, (Item) dso, msg);
         } catch (SQLException | AuthorizeException e) {
@@ -288,7 +288,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
             Item item = findItemByBitstream(context, bitstream);
             if (Objects.nonNull(item)) {
                 String msg = messageProvider.getMessage(context,
-                        ProvenanceMessageTemplates.ITEM_REPLACE_SINGLE_METADATA.getTemplate(), item,
+                        ProvenanceMessageTemplates.ITEM_REPLACE_SINGLE_METADATA.getTemplate(),
                         messageProvider.getMessage(bitstream),
                         messageProvider.getMetadata(messageProvider.getMetadataField(metadataField), oldMtdVal));
                 addProvenanceMetadata(context, item, msg);

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -187,11 +187,12 @@ public class ProvenanceServiceImpl implements ProvenanceService {
         }
     }
 
-    public void addMetadata(Context context, DSpaceObject dso, MetadataField metadataField) {
+    public void addMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String metadataValue) {
         try {
             if (Constants.ITEM == dso.getType()) {
                 String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                        messageProvider.getMetadataField(metadataField), "added");
+                        (Item) dso, messageProvider.getMetadata(
+                                messageProvider.getMetadataField(metadataField), metadataValue), "added");
                 addProvenanceMetadata(context, (Item) dso, msg);
             }
 
@@ -200,8 +201,9 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                 Item item = findItemByBitstream(context, bitstream);
                 if (Objects.nonNull(item)) {
                     String msg = messageProvider.getMessage(context,
-                            ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(), item,
-                            messageProvider.getMetadataField(metadataField), "added by",
+                            ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(),
+                            messageProvider.getMetadata(
+                                    messageProvider.getMetadataField(metadataField), metadataValue), "added by",
                             messageProvider.getMessage(bitstream));
                     addProvenanceMetadata(context, item, msg);
                 }

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -260,14 +260,15 @@ public class ProvenanceServiceImpl implements ProvenanceService {
         }
     }
 
-    public void replaceMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String oldMtdVal) {
+    public void replaceMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String oldMtdVal,
+                                String newMtdVal) {
         if (dso.getType() != Constants.ITEM) {
             return;
         }
         try {
             String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                    (Item) dso,messageProvider.getMetadata(messageProvider.getMetadataField(metadataField),
-                            oldMtdVal), "updated");
+                    (Item) dso, messageProvider.getMetadataReplacement(
+                            messageProvider.getMetadataField(metadataField), oldMtdVal, newMtdVal), "updated");
             addProvenanceMetadata(context, (Item) dso, msg);
         } catch (SQLException | AuthorizeException e) {
             log.error("Unable to add new provenance metadata when replacing metadata in a dso.", e);

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -265,6 +265,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
         if (dso.getType() != Constants.ITEM) {
             return;
         }
+
         try {
             String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
                     (Item) dso, messageProvider.getMetadataReplacement(
@@ -277,7 +278,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
     }
 
     public void replaceMetadataSingle(Context context, DSpaceObject dso, MetadataField metadataField,
-                                      String oldMtdVal) {
+                                      String oldMtdVal, String newMtdVal) {
         if (dso.getType() != Constants.BITSTREAM) {
             return;
         }
@@ -288,8 +289,8 @@ public class ProvenanceServiceImpl implements ProvenanceService {
             if (Objects.nonNull(item)) {
                 String msg = messageProvider.getMessage(context,
                         ProvenanceMessageTemplates.ITEM_REPLACE_SINGLE_METADATA.getTemplate(), item,
-                        messageProvider.getMessage(bitstream),
-                        messageProvider.getMetadata(messageProvider.getMetadataField(metadataField), oldMtdVal));
+                        messageProvider.getMessage(bitstream), messageProvider.getMetadataReplacement(
+                                messageProvider.getMetadataField(metadataField), oldMtdVal, newMtdVal));
                 addProvenanceMetadata(context, item, msg);;
             }
         } catch (SQLException | AuthorizeException e) {

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -291,7 +291,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                         ProvenanceMessageTemplates.ITEM_REPLACE_SINGLE_METADATA.getTemplate(), item,
                         messageProvider.getMessage(bitstream),
                         messageProvider.getMetadata(messageProvider.getMetadataField(metadataField), oldMtdVal));
-                addProvenanceMetadata(context, item, msg);;
+                addProvenanceMetadata(context, item, msg);
             }
         } catch (SQLException | AuthorizeException e) {
             log.error("Unable to add new provenance metadata when replacing metadata in a item.", e);

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -190,9 +190,9 @@ public class ProvenanceServiceImpl implements ProvenanceService {
     public void addMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String metadataValue) {
         try {
             if (Constants.ITEM == dso.getType()) {
+                String mtdKey = messageProvider.getMetadataField(metadataField);
                 String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                        (Item) dso, messageProvider.getMetadata(
-                                messageProvider.getMetadataField(metadataField), metadataValue), "added");
+                        (Item) dso, messageProvider.getMetadata(mtdKey, metadataValue), "added");
                 addProvenanceMetadata(context, (Item) dso, msg);
             }
 
@@ -200,11 +200,11 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                 Bitstream bitstream = (Bitstream) dso;
                 Item item = findItemByBitstream(context, bitstream);
                 if (Objects.nonNull(item)) {
+                    String mtdKey = messageProvider.getMetadataField(metadataField);
                     String msg = messageProvider.getMessage(context,
                             ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(), item,
-                            messageProvider.getMetadata(
-                                    messageProvider.getMetadataField(metadataField), metadataValue), "added by",
-                            messageProvider.getMessage(bitstream));
+                            messageProvider.getMetadata(mtdKey, metadataValue),
+                            "added by", messageProvider.getMessage(bitstream));
                     addProvenanceMetadata(context, item, msg);
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -190,9 +190,9 @@ public class ProvenanceServiceImpl implements ProvenanceService {
     public void addMetadata(Context context, DSpaceObject dso, MetadataField metadataField, String metadataValue) {
         try {
             if (Constants.ITEM == dso.getType()) {
-                String metadataKey = messageProvider.getMetadataField(metadataField);
                 String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                        (Item) dso, messageProvider.getMetadata(metadataKey, metadataValue), "added");
+                        (Item) dso, messageProvider.getMetadata(
+                                messageProvider.getMetadataField(metadataField), metadataValue), "added");
                 addProvenanceMetadata(context, (Item) dso, msg);
             }
 
@@ -200,11 +200,11 @@ public class ProvenanceServiceImpl implements ProvenanceService {
                 Bitstream bitstream = (Bitstream) dso;
                 Item item = findItemByBitstream(context, bitstream);
                 if (Objects.nonNull(item)) {
-                    String metadataKey = messageProvider.getMetadataField(metadataField);
                     String msg = messageProvider.getMessage(context,
                             ProvenanceMessageTemplates.BITSTREAM_METADATA.getTemplate(), item,
-                            messageProvider.getMetadata(metadataKey, metadataValue),
-                            "added by", messageProvider.getMessage(bitstream));
+                            messageProvider.getMetadata(
+                                    messageProvider.getMetadataField(metadataField), metadataValue), "added by",
+                            messageProvider.getMessage(bitstream));
                     addProvenanceMetadata(context, item, msg);
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -268,7 +268,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
 
         try {
             String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                    (Item) dso, messageProvider.getMetadataReplacement(
+                     messageProvider.getMetadataReplacement(
                             messageProvider.getMetadataField(metadataField), oldMtdVal, newMtdVal), "updated");
             addProvenanceMetadata(context, (Item) dso, msg);
         } catch (SQLException | AuthorizeException e) {

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -191,7 +191,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
         try {
             if (Constants.ITEM == dso.getType()) {
                 String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                        (Item) dso, messageProvider.getMetadata(
+                        messageProvider.getMetadata(
                                 messageProvider.getMetadataField(metadataField), metadataValue), "added");
                 addProvenanceMetadata(context, (Item) dso, msg);
             }
@@ -268,7 +268,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
 
         try {
             String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.ITEM_METADATA.getTemplate(),
-                     messageProvider.getMetadataReplacement(
+                    (Item) dso, messageProvider.getMetadataReplacement(
                             messageProvider.getMetadataField(metadataField), oldMtdVal, newMtdVal), "updated");
             addProvenanceMetadata(context, (Item) dso, msg);
         } catch (SQLException | AuthorizeException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
@@ -75,7 +75,7 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
             dsoService.addAndShiftRightMetadata(context, dso, metadataField.getMetadataSchema().getName(),
                     metadataField.getElement(), metadataField.getQualifier(), metadataValue.getLanguage(),
                     metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence(), indexInt);
-            provenanceService.addMetadata(context, dso, metadataField);
+            provenanceService.addMetadata(context, dso, metadataField, metadataValue.getValue());
         } catch (SQLException e) {
             String msg;
             msg = "SQLException in DspaceObjectMetadataAddOperation.add trying to add " +

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -201,6 +201,7 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
                 // Alter only asked propertyOfMd
                 MetadataValue existingMdv = metadataValues.get(indexInt);
                 String oldMtdVal = existingMdv.getValue();
+                String newMtdVal = oldMtdVal;
 
                 if (propertyOfMd.equals("authority")) {
                     existingMdv.setAuthority(valueMdProperty);
@@ -212,10 +213,11 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
                     existingMdv.setLanguage(valueMdProperty);
                 }
                 if (propertyOfMd.equals("value")) {
+                    newMtdVal = valueMdProperty;
                     existingMdv.setValue(valueMdProperty);
                 }
                 dsoService.setMetadataModified(dso);
-                provenanceService.replaceMetadataSingle(context, dso, metadataField, oldMtdVal);
+                provenanceService.replaceMetadataSingle(context, dso, metadataField, oldMtdVal, newMtdVal);
             } else {
                 throw new UnprocessableEntityException("There is no metadata of this type at that index");
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -165,12 +165,13 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
                 // Alter this existing md
                 MetadataValue existingMdv = metadataValues.get(indexInt);
                 String oldMtdVal = existingMdv.getValue();
+                String newMtdVal = metadataValue.getValue();
                 existingMdv.setAuthority(metadataValue.getAuthority());
                 existingMdv.setConfidence(metadataValue.getConfidence());
                 existingMdv.setLanguage(metadataValue.getLanguage());
                 existingMdv.setValue(metadataValue.getValue());
                 dsoService.setMetadataModified(dso);
-                provenanceService.replaceMetadata(context, dso, metadataField, oldMtdVal);
+                provenanceService.replaceMetadata(context, dso, metadataField, oldMtdVal, newMtdVal);
             } else {
                 throw new UnprocessableEntityException("There is no metadata of this type at that index");
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
@@ -24,7 +24,7 @@ public enum ProvenanceExpectedMessages {
     REMOVE_ITEM_MTD("Item metadata (dc.title: Public item 1) was deleted by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 0"),
     REMOVE_BITSTREAM_MTD("Item metadata (dc.description: test) was added by bitstream"),
-    REPLACE_BITSTREAM_MTD("metadata (dc.title: test) was updated by first (admin) last (admin) " +
+    REPLACE_BITSTREAM_MTD("metadata (dc.title [test -> test 1]) was updated by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 1\n"),
     REMOVE_BITSTREAM("was deleted bitstream"),
     ADD_BITSTREAM("Item was added bitstream to bundle"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
@@ -20,7 +20,7 @@ public enum ProvenanceExpectedMessages {
     MAPPED_COL("was mapped to collection"),
     ADD_ITEM_MTD("Item metadata (dc.title: Test) was added by first (admin) last (admin) (admin@email.com) on"),
     REPLACE_ITEM_MTD("Item metadata (dc.title [Public item 1 -> Test]) was updated by first (admin) last (admin) " +
-            "(admin@email.com) on \nNo. of bitstreams: 0"),
+            "(admin@email.com) on "),
     REMOVE_ITEM_MTD("Item metadata (dc.title: Public item 1) was deleted by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 0"),
     REMOVE_BITSTREAM_MTD("Item metadata (dc.description: test) was added by bitstream"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
@@ -24,7 +24,7 @@ public enum ProvenanceExpectedMessages {
     REMOVE_ITEM_MTD("Item metadata (dc.title: Public item 1) was deleted by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 0"),
     REMOVE_BITSTREAM_MTD("Item metadata (dc.description: test) was added by bitstream"),
-    REPLACE_BITSTREAM_MTD("metadata (dc.title [test -> test 1]) was updated by first (admin) last (admin) " +
+    REPLACE_BITSTREAM_MTD("metadata (dc.title: test) was updated by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 1\n"),
     REMOVE_BITSTREAM("was deleted bitstream"),
     ADD_BITSTREAM("Item was added bitstream to bundle"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
@@ -18,12 +18,12 @@ public enum ProvenanceExpectedMessages {
     NON_DISCOVERABLE("Item was made non-discoverable by first (admin) last (admin) (admin@email.com) on " +
             "\nNo. of bitstreams: 0\nItem was in collections:\n"),
     MAPPED_COL("was mapped to collection"),
-    ADD_ITEM_MTD("Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on"),
+    ADD_ITEM_MTD("Item metadata (dc.title: Test) was added by first (admin) last (admin) (admin@email.com) on"),
     REPLACE_ITEM_MTD("Item metadata (dc.title: Public item 1) was updated by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 0"),
     REMOVE_ITEM_MTD("Item metadata (dc.title: Public item 1) was deleted by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 0"),
-    REMOVE_BITSTREAM_MTD("Item metadata (dc.description) was added by bitstream"),
+    REMOVE_BITSTREAM_MTD("Item metadata (dc.description: test) was added by bitstream"),
     REPLACE_BITSTREAM_MTD("metadata (dc.title: test) was updated by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 1\n"),
     REMOVE_BITSTREAM("was deleted bitstream"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
@@ -22,10 +22,10 @@ public enum ProvenanceExpectedMessages {
     REPLACE_ITEM_MTD("Item metadata (dc.title [Public item 1 -> Test]) was updated by first (admin) last (admin) " +
             "(admin@email.com) on "),
     REMOVE_ITEM_MTD("Item metadata (dc.title: Public item 1) was deleted by first (admin) last (admin) " +
-            "(admin@email.com) on \nNo. of bitstreams: 0"),
+            "(admin@email.com) on "),
     REMOVE_BITSTREAM_MTD("Item metadata (dc.description: test) was added by bitstream"),
     REPLACE_BITSTREAM_MTD("metadata (dc.title: test) was updated by first (admin) last (admin) " +
-            "(admin@email.com) on \nNo. of bitstreams: 1\n"),
+            "(admin@email.com) on "),
     REMOVE_BITSTREAM("was deleted bitstream"),
     ADD_BITSTREAM("Item was added bitstream to bundle"),
     UPDATE_LICENSE("License (Test 1) was updated by first (admin) last (admin) (admin@email.com) " +

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
@@ -19,7 +19,7 @@ public enum ProvenanceExpectedMessages {
             "\nNo. of bitstreams: 0\nItem was in collections:\n"),
     MAPPED_COL("was mapped to collection"),
     ADD_ITEM_MTD("Item metadata (dc.title: Test) was added by first (admin) last (admin) (admin@email.com) on"),
-    REPLACE_ITEM_MTD("Item metadata (dc.title: Public item 1) was updated by first (admin) last (admin) " +
+    REPLACE_ITEM_MTD("Item metadata (dc.title [Public item 1 -> Test]) was updated by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 0"),
     REMOVE_ITEM_MTD("Item metadata (dc.title: Public item 1) was deleted by first (admin) last (admin) " +
             "(admin@email.com) on \nNo. of bitstreams: 0"),

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
@@ -125,7 +125,9 @@
           {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1},
           {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
-            "language":"en","authority":null,"confidence":-1,"place":2}
+            "language":"en","authority":null,"confidence":-1,"place":2},
+          {"value":"Item metadata (dc.title [最後のタイトル → title A]) was updated by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+            "language":"en","authority":null,"confidence":-1,"place":3}
         ],
         "dc.title": [
           { "value": "title 0", "language": null, "authority": null, "confidence": -1 ,"place": 0 },

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
@@ -23,7 +23,7 @@
       ],
       "expect": {
         "dc.description.provenance" : [
-          { "value" : "Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0", "language" : "en", "authority" : null, "confidence" : -1, "place" : 0}
+          { "value" : "Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ", "language" : "en", "authority" : null, "confidence" : -1, "place" : 0}
         ],
         "dc.title": [
           { "value": "title 1", "language": null, "authority": null, "confidence": -1, "place": 0}
@@ -65,11 +65,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -90,11 +90,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -120,11 +120,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -145,11 +145,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -174,11 +174,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":2},
           {"value":"Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":3},
@@ -202,11 +202,11 @@
       "expect": {
         "dc.description.provenance": [
           {
-            "value": "Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+            "value": "Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ",
             "language": "en", "authority": null, "confidence": -1, "place": 0},
-          {"value": "Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value": "Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on ",
             "language": "en", "authority": null, "confidence": -1, "place": 1},
-          {"value": "Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value": "Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language": "en", "authority": null, "confidence": -1, "place": 2},
           {"value": "Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language": "en", "authority": null, "confidence": -1, "place": 3},

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
@@ -180,9 +180,9 @@
             "language":"en","authority":null,"confidence":-1,"place":1},
           {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":2},
-          {"value":"Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":3},
-          {"value":"Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":4}
         ],
         "dc.title": [
@@ -208,9 +208,9 @@
             "language": "en", "authority": null, "confidence": -1, "place": 1},
           {"value": "Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on ",
             "language": "en", "authority": null, "confidence": -1, "place": 2},
-          {"value": "Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value": "Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on ",
             "language": "en", "authority": null, "confidence": -1, "place": 3},
-          {"value": "Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value": "Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on ",
             "language": "en", "authority": null, "confidence": -1, "place": 4}
         ]
       }

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
@@ -125,9 +125,7 @@
           {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1},
           {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
-            "language":"en","authority":null,"confidence":-1,"place":2},
-          {"value":"Item metadata (dc.title [最後のタイトル → title A]) was updated by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
-            "language":"en","authority":null,"confidence":-1,"place":3}
+            "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
           { "value": "title 0", "language": null, "authority": null, "confidence": -1 ,"place": 0 },

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
@@ -41,9 +41,9 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on ",
             "language":"en","authority":null,"confidence":-1,"place":1}
         ],
         "dc.title": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/item-metadata-patch-suite.json
@@ -23,7 +23,7 @@
       ],
       "expect": {
         "dc.description.provenance" : [
-          { "value" : "Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ", "language" : "en", "authority" : null, "confidence" : -1, "place" : 0}
+          { "value" : "Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0", "language" : "en", "authority" : null, "confidence" : -1, "place" : 0}
         ],
         "dc.title": [
           { "value": "title 1", "language": null, "authority": null, "confidence": -1, "place": 0}
@@ -41,9 +41,9 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1}
         ],
         "dc.title": [
@@ -65,11 +65,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -90,11 +90,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -120,11 +120,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -145,11 +145,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":2}
         ],
         "dc.title": [
@@ -174,11 +174,11 @@
       ],
       "expect": {
         "dc.description.provenance":[
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":0},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":1},
-          {"value":"Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value":"Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":2},
           {"value":"Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language":"en","authority":null,"confidence":-1,"place":3},
@@ -202,11 +202,11 @@
       "expect": {
         "dc.description.provenance": [
           {
-            "value": "Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+            "value": "Item metadata (dc.title: title 1) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language": "en", "authority": null, "confidence": -1, "place": 0},
-          {"value": "Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value": "Item metadata (dc.title: 最後のタイトル) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language": "en", "authority": null, "confidence": -1, "place": 1},
-          {"value": "Item metadata (dc.title) was added by first (admin) last (admin) (admin@email.com) on ",
+          {"value": "Item metadata (dc.title: title 0) was added by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language": "en", "authority": null, "confidence": -1, "place": 2},
           {"value": "Item metadata (dc.title: title A) was deleted by first (admin) last (admin) (admin@email.com) on \nNo. of bitstreams: 0",
             "language": "en", "authority": null, "confidence": -1, "place": 3},


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Metadata value is not shown when the new metadata is added or updated.

How it should looks like
<img width="638" height="462" alt="image" src="https://github.com/user-attachments/assets/fb5b1680-d3f2-4867-84fa-7dd9f9816fd8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provenance/audit logs now include the actual metadata value when adding metadata and show old→new transitions for replacements (including single-value edits).

* **Bug Fixes**
  * Null/empty metadata normalized to "empty" for consistent provenance messages; item and bitstream provenance formatting made more consistent (some trailing bitstream counts removed).

* **Tests**
  * Updated provenance templates and test fixtures to match new value-aware message formats and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->