### PR TITLE
UFAL/Provenance when resource policy changes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageTemplates.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceMessageTemplates.java
@@ -24,6 +24,7 @@ public enum ProvenanceMessageTemplates {
     ITEM_METADATA("Item metadata (%s) was %s"),
     BITSTREAM_METADATA("Item metadata (%s) was %s bitstream (%s)"),
     ITEM_REPLACE_SINGLE_METADATA("Item bitstream (%s) metadata (%s) was updated"),
+    RESOURCE_POLICY_UPDATED("Resource policy (%s) was %s"),
     DISCOVERABLE("Item was made %sdiscoverable");
 
     private final String template;

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceService.java
@@ -177,6 +177,16 @@ public interface ProvenanceService {
     void uploadBitstream(Context context, Bundle bundle);
 
     /**
+     * Add a provenance message to the item when a resource policy is updated
+     *
+     * @param context DSpace context object
+     * @param dso DSpace object for which the resource policy is updated
+     * @param resourcePolicy the resource policy that was updated
+     * @param action the action performed (added, updated, removed)
+     */
+    void updateResourcePolicy(Context context, DSpaceObject dso, ResourcePolicy resourcePolicy, String action);
+
+    /**
      * Fetch an Item object using a service and return the first Item object from the list.
      * Log an error if the list is empty or if there is an SQL error
      *

--- a/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/ProvenanceServiceImpl.java
@@ -33,6 +33,7 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
+import org.dspace.core.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -360,5 +361,45 @@ public class ProvenanceServiceImpl implements ProvenanceService {
             }
         }
         return currentLicense;
+    }
+
+    public void updateResourcePolicy(Context context, DSpaceObject dso, ResourcePolicy resourcePolicy, String action) {
+        try {
+            if (dso.getType() == Constants.ITEM) {
+                Item item = (Item) dso;
+                String policyInfo = formatResourcePolicyInfo(resourcePolicy);
+                String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.RESOURCE_POLICY_UPDATED.getTemplate(),
+                        item, policyInfo, action);
+                addProvenanceMetadata(context, item, msg);
+            } else if (dso.getType() == Constants.BITSTREAM) {
+                Bitstream bitstream = (Bitstream) dso;
+                Item item = findItemByBitstream(context, bitstream);
+                if (Objects.nonNull(item)) {
+                    String policyInfo = formatResourcePolicyInfo(resourcePolicy);
+                    String msg = messageProvider.getMessage(context, ProvenanceMessageTemplates.RESOURCE_POLICY_UPDATED.getTemplate(),
+                            item, policyInfo, action);
+                    addProvenanceMetadata(context, item, msg);
+                }
+            }
+        } catch (SQLException | AuthorizeException e) {
+            log.error("Unable to add new provenance metadata when updating resource policy.", e);
+        }
+    }
+
+    private String formatResourcePolicyInfo(ResourcePolicy resourcePolicy) {
+        StringBuilder info = new StringBuilder();
+        if (resourcePolicy.getRpName() != null) {
+            info.append("name: ").append(resourcePolicy.getRpName());
+        }
+        int action = resourcePolicy.getAction();
+        if (action >= 0 && action < Constants.actionText.length) {
+            if (info.length() > 0) info.append(", ");
+            info.append("action: ").append(Constants.actionText[action]);
+        }
+        if (resourcePolicy.getRpType() != null) {
+            if (info.length() > 0) info.append(", ");
+            info.append("type: ").append(resourcePolicy.getRpType());
+        }
+        return info.length() > 0 ? info.toString() : "resource policy";
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyNameAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyNameAddOperation.java
@@ -12,6 +12,7 @@ import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.repository.patch.operation.PatchOperation;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.core.Context;
+import org.dspace.core.ProvenanceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -33,6 +34,9 @@ public class ResourcePolicyNameAddOperation<R> extends PatchOperation<R> {
     @Autowired
     ResourcePolicyUtils resourcePolicyUtils;
 
+    @Autowired
+    private ProvenanceService provenanceService;
+
     @Override
     public R perform(Context context, R resource, Operation operation) {
         checkOperationValue(operation.getValue());
@@ -40,6 +44,11 @@ public class ResourcePolicyNameAddOperation<R> extends PatchOperation<R> {
             ResourcePolicy resourcePolicy = (ResourcePolicy) resource;
             this.checkModelForNotExistingValue(resourcePolicy);
             this.add(resourcePolicy, operation);
+            
+            // Add provenance tracking
+            provenanceService.updateResourcePolicy(context, resourcePolicy.getdSpaceObject(), 
+                    resourcePolicy, "added");
+            
             return resource;
         } else {
             throw new DSpaceBadRequestException(this.getClass() + " does not support this operation");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyNameReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyNameReplaceOperation.java
@@ -12,6 +12,7 @@ import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.repository.patch.operation.PatchOperation;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.core.Context;
+import org.dspace.core.ProvenanceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,18 +35,8 @@ public class ResourcePolicyNameReplaceOperation<R> extends PatchOperation<R> {
     @Autowired
     ResourcePolicyUtils resourcePolicyUtils;
 
-    @Override
-    public R perform(Context context, R resource, Operation operation) {
-        checkOperationValue(operation.getValue());
-        if (this.supports(resource, operation)) {
-            ResourcePolicy resourcePolicy = (ResourcePolicy) resource;
-            resourcePolicyUtils.checkResourcePolicyForExistingNameValue(resourcePolicy, operation);
-            this.replace(resourcePolicy, operation);
-            return resource;
-        } else {
-            throw new DSpaceBadRequestException(this.getClass() + " does not support this operation");
-        }
-    }
+    @Autowired
+    private ProvenanceService provenanceService;
 
     /**
      * Performs the actual replace name of resourcePolicy operation
@@ -55,6 +46,24 @@ public class ResourcePolicyNameReplaceOperation<R> extends PatchOperation<R> {
     private void replace(ResourcePolicy resourcePolicy, Operation operation) {
         String newName = (String) operation.getValue();
         resourcePolicy.setRpName(newName);
+    }
+
+    @Override
+    public R perform(Context context, R resource, Operation operation) {
+        checkOperationValue(operation.getValue());
+        if (this.supports(resource, operation)) {
+            ResourcePolicy resourcePolicy = (ResourcePolicy) resource;
+            resourcePolicyUtils.checkResourcePolicyForExistingNameValue(resourcePolicy, operation);
+            this.replace(resourcePolicy, operation);
+            
+            // Add provenance tracking
+            provenanceService.updateResourcePolicy(context, resourcePolicy.getdSpaceObject(), 
+                    resourcePolicy, "updated");
+            
+            return resource;
+        } else {
+            throw new DSpaceBadRequestException(this.getClass() + " does not support this operation");
+        }
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceExpectedMessages.java
@@ -34,7 +34,8 @@ public enum ProvenanceExpectedMessages {
             " of bitstreams: 0"),
     REMOVE_LICENSE("License (Test) was removed by first (admin) last (admin) (admin@email.com) on " +
             "\nNo. of bitstreams: 1\n"),
-    MOVED_ITEM_COL("Item was moved from collection ");
+    MOVED_ITEM_COL("Item was moved from collection "),
+    UPDATE_RESOURCE_POLICY("Resource policy (name: TestPolicy) was updated by first (admin) last (admin) (admin@email.com) on");
 
     private final String template;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
@@ -34,6 +34,8 @@ import org.dspace.app.rest.model.patch.RemoveOperation;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.ClarinLicenseBuilder;
@@ -72,6 +74,8 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
     private ClarinLicenseLabelService clarinLicenseLabelService;
     @Autowired
     private ClarinLicenseService clarinLicenseService;
+    @Autowired
+    private AuthorizeService authorizeService;
 
     private Collection  collection;
     private Item item;
@@ -371,6 +375,41 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
         deleteCollection(col.getID());
     }
 
+    @Test
+    public void updateResourcePolicyTest() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        
+        // Create a resource policy for the item
+        context.turnOffAuthorisationSystem();
+        ResourcePolicy resourcePolicy = authorizeService.createResourcePolicy(context, item, null, null, 
+                Constants.READ, ResourcePolicy.TYPE_CUSTOM);
+        resourcePolicy.setRpName("TestPolicy");
+        resourcePolicy.setRpDescription("Test policy description");
+        authorizeService.update(context, resourcePolicy);
+        context.commit();
+        context.restoreAuthSystemState();
+        
+        // Update the resource policy name via PATCH
+        List<Operation> ops = new ArrayList<>();
+        ReplaceOperation replaceOperation = new ReplaceOperation("/name", "UpdatedTestPolicy");
+        ops.add(replaceOperation);
+        String patchBody = getPatchContent(ops);
+        
+        getClient(adminToken).perform(patch("/api/authz/resourcepolicies/" + resourcePolicy.getID())
+                        .content(patchBody)
+                        .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+        
+        // Check that the provenance message was added
+        objectCheck(itemService.find(context, item.getID()), 
+                ProvenanceExpectedMessages.UPDATE_RESOURCE_POLICY.getTemplate());
+        
+        // Clean up
+        context.turnOffAuthorisationSystem();
+        authorizeService.delete(context, resourcePolicy);
+        context.commit();
+        context.restoreAuthSystemState();
+    }
 
     private String provenanceMetadataModified(String metadata) {
         // Regex to match the date pattern


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added provenance tracking for Resource Policy changes, recording messages when names are added or updated.
  - Introduced a new provenance message template for resource policy updates.
  - Applies to items directly and to items owning modified bitstreams, enhancing the audit trail.

- Tests
  - Added an integration test to verify provenance messages after updating a Resource Policy via REST PATCH.
  - Updated expected provenance messages to include the new Resource Policy update entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->