### PR TITLE
UFAL/Do not create handle during items import

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinWorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinWorkspaceItemServiceImpl.java
@@ -44,8 +44,9 @@ public class ClarinWorkspaceItemServiceImpl implements ClarinWorkspaceItemServic
                                 boolean template, boolean isNewVersion) throws AuthorizeException, SQLException {
 
         //create empty workspace item with item
-        // The isNewVersion parameter controls whether a new handle is created for the item;
-        // its value is determined by the caller.
+        // The isNewVersion parameter controls handle creation:
+        //   - If isNewVersion is true, no new handle is created (existing handles are preserved).
+        //   - If isNewVersion is false, a new handle is generated for the item.
         WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, false, isNewVersion);
         //set workspace item values based on input values
         workspaceItem.setPublishedBefore(publishedBefore);

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinWorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinWorkspaceItemServiceImpl.java
@@ -44,7 +44,8 @@ public class ClarinWorkspaceItemServiceImpl implements ClarinWorkspaceItemServic
                                 boolean template, boolean isNewVersion) throws AuthorizeException, SQLException {
 
         //create empty workspace item with item
-        // Since we are importing, we don't want to create a new handle for the item -> isNewVersion = true
+        // The isNewVersion parameter controls whether a new handle is created for the item;
+        // its value is determined by the caller.
         WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, false, isNewVersion);
         //set workspace item values based on input values
         workspaceItem.setPublishedBefore(publishedBefore);

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinWorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinWorkspaceItemServiceImpl.java
@@ -41,10 +41,11 @@ public class ClarinWorkspaceItemServiceImpl implements ClarinWorkspaceItemServic
     @Override
     public WorkspaceItem create(Context context, Collection collection, boolean multipleTitles, boolean publishedBefore,
                                 boolean multipleFiles, Integer stageReached, Integer pageReached,
-                                boolean template) throws AuthorizeException, SQLException {
+                                boolean template, boolean isNewVersion) throws AuthorizeException, SQLException {
 
         //create empty workspace item with item
-        WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, false);
+        // Since we are importing, we don't want to create a new handle for the item -> isNewVersion = true
+        WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, false, isNewVersion);
         //set workspace item values based on input values
         workspaceItem.setPublishedBefore(publishedBefore);
         workspaceItem.setMultipleFiles(multipleFiles);

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinWorkspaceItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinWorkspaceItemService.java
@@ -36,6 +36,7 @@ public interface ClarinWorkspaceItemService {
      * @param pageReached     page reached
      * @param template        if <code>true</code>, the workspace item starts as a copy
      *                        of the collection's template item
+     * @param isNewVersion    whether we are creating a new workspace item version of an existing item
      * @return created workspace item
      * @throws AuthorizeException if authorization error
      * @throws SQLException       if database error
@@ -43,7 +44,7 @@ public interface ClarinWorkspaceItemService {
     public WorkspaceItem create(Context context, Collection collection,
                                 boolean multipleTitles, boolean publishedBefore,
                                 boolean multipleFiles, Integer stageReached,
-                                Integer pageReached, boolean template)
+                                Integer pageReached, boolean template, boolean isNewVersion)
             throws AuthorizeException, SQLException;
 
     /***

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinWorkspaceItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinWorkspaceItemService.java
@@ -36,7 +36,9 @@ public interface ClarinWorkspaceItemService {
      * @param pageReached     page reached
      * @param template        if <code>true</code>, the workspace item starts as a copy
      *                        of the collection's template item
-     * @param isNewVersion    whether we are creating a new workspace item version of an existing item
+     * @param isNewVersion    controls handle creation behavior during import operations:
+     *                        if <code>false</code>, a new handle is created;
+     *                        if <code>true</code>, the existing handle is preserved.
      * @return created workspace item
      * @throws AuthorizeException if authorization error
      * @throws SQLException       if database error

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinItemImportController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinItemImportController.java
@@ -172,8 +172,9 @@ public class ClarinItemImportController {
         context.setCurrentUser(eperson);
         //we have to turn off authorization system, because in service there are authorization controls
         context.turnOffAuthorisationSystem();
+        // Since we are importing, we don't want to create a new handle for the item -> isNewVersion = true
         WorkspaceItem workspaceItem = clarinWorkspaceItemService.create(context, collection, multipleTitles,
-                publishedBefore, multipleFiles, stageReached, pageReached,false);
+                publishedBefore, multipleFiles, stageReached, pageReached, false, true);
         context.restoreAuthSystemState();
         //set current user back to saved current user
         context.setCurrentUser(currUser);
@@ -317,7 +318,7 @@ public class ClarinItemImportController {
         EPerson eperson = ePersonService.find(context, epersonUUID);
         context.setCurrentUser(eperson);
         context.turnOffAuthorisationSystem();
-        WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, false);
+        WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, false, true);
         // created item
         Item item = workspaceItem.getItem();
         // if the created item has pre-registered PID and the importing Item has handle which must be imported, the


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
During the item import process, a new handle is being created for an item that should instead use the handle from the dump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imports can now be created as new versions, preserving original handles for better version history and continuity.
  * Consistent behavior across workspace and direct item imports when treating imports as new versions.

* **Bug Fixes**
  * Prevents unintended creation of new handles during item imports, reducing duplication and ensuring stable references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->