### PR TITLE
VSB-TUO/Footer theme by dataquest title

### DIFF
--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -237,7 +237,7 @@ identifiers.item-status.register-doi = false
 
 ##### Dataquest URL - sing in the footer #####
 themed.by.url = https://www.dataquest.sk/dspace
-themed.by.company.name = dataquest s.r.o.
+themed.by.company.name = + dataquest
 
 
 #### Authority configuration `authority.cfg`


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In other versions of DSpace we use `+ dataquest`, not `dataquest s.r.o.` .
We have changed it by redefining the value of `themed.by.company.name` in _clarin-dspace.cfg_ .