### PR TITLE
VSB-TUO/Fix authority control failing tests orcid

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -337,3 +337,9 @@ default.language = en
 
 dspace.name = DSpace at My University
 plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
+
+# Added due to failing tests based on changes in enable-orcid.cfg
+# Failed tests:
+# ItemTest.java#testAddMetadata_list_with_virtual_metadata
+# ItemTest.java#testAddMetadata_7args_1_noauthority
+authority.controlled.dc.contributor.author = false


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  1  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1.25  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The tests ItemTest.java#testAddMetadata_list_with_virtual_metadata and ItemTest.java#testAddMetadata_7args_1_noauthority are failed. 

## Problems
When new metadata dc.contributor.author is added, dc_metadataAuthorityService.isAuthorityControlled(metadataField) returns true instead of false. The reason is that this is enabled in the added configuration enable-orcid.cfg.
