### PR TITLE
VSB-TUO/Fix StatisticsRestRepositoryIT.java tests

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -324,6 +324,9 @@ autocomplete.custom.allowed = solr-author_ac,solr-publisher_ac,solr-dataProvider
 # property is not commented, because of tests
 allow.edit.metadata =
 
+# Based on the failed tests in StatisticsRestRepositoryIT.java
+default.locale = en
+
 # Support of Czech locale for distribution license
 webui.supported.locales = cs
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
For the tests, the default locale is read from dspace.cfg, where it is set to cs instead of the expected en.
