### PR TITLE
VSB-TUO/Context language when sending the archive email upon submission

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import java.util.UUID;
 import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
@@ -658,8 +659,17 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
             EPerson ep = item.getSubmitter();
             // send the notification to the submitter unless the submitter eperson has been deleted
             if (null != ep) {
-                // Get the Locale
-                Email email = Email.getEmail(I18nUtil.getEmailFilename(context.getCurrentLocale(), "submit_archive"));
+                // Get the Locale - prioritize context locale over EPerson locale
+                Locale contextLocale = context.getCurrentLocale();
+                Locale epersonLocale = I18nUtil.getEPersonLocale(ep);
+                Locale curLocale = Optional.ofNullable(contextLocale)
+                        .orElseGet(() -> epersonLocale);
+                
+                // Log locale selection for debugging/testing
+                log.info("notifyOfArchive locale selection - Context: {}, EPerson: {}, Selected: {}", 
+                        contextLocale, epersonLocale, curLocale);
+                        
+                Email email = Email.getEmail(I18nUtil.getEmailFilename(curLocale, "submit_archive"));
 
                 // Get the item handle to email to user
                 String handle = handleService.findHandle(context, item);

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -664,11 +664,8 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                 Locale epersonLocale = I18nUtil.getEPersonLocale(ep);
                 Locale curLocale = Optional.ofNullable(contextLocale)
                         .orElseGet(() -> epersonLocale);
-                
-                // Log locale selection for debugging/testing
-                log.info("notifyOfArchive locale selection - Context: {}, EPerson: {}, Selected: {}", 
+                log.debug("notifyOfArchive locale selection - Context: {}, EPerson: {}, Selected: {}",
                         contextLocale, epersonLocale, curLocale);
-                        
                 Email email = Email.getEmail(I18nUtil.getEmailFilename(curLocale, "submit_archive"));
 
                 // Get the item handle to email to user

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -659,8 +659,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
             // send the notification to the submitter unless the submitter eperson has been deleted
             if (null != ep) {
                 // Get the Locale
-                Locale supportedLocale = I18nUtil.getEPersonLocale(ep);
-                Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_archive"));
+                Email email = Email.getEmail(I18nUtil.getEmailFilename(context.getCurrentLocale(), "submit_archive"));
 
                 // Get the item handle to email to user
                 String handle = handleService.findHandle(context, item);

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
@@ -7,10 +7,10 @@
  */
 package org.dspace.xmlworkflow;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -213,47 +213,50 @@ public class XmlWorkflowServiceIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testLocaleSelectionLogic_ContextTakesPrecedenceOverEPerson() throws Exception {
         context.turnOffAuthorisationSystem();
-        
+
         // Create EPerson with English preference
         EPerson submitter = EPersonBuilder.createEPerson(context)
                 .withEmail("submitter@example.org")
                 .withLanguage("en") // English preference
                 .build();
-        
+
         context.restoreAuthSystemState();
-        
+
         // Test 1: Context locale takes precedence
         context.setCurrentLocale(new java.util.Locale("cs")); // Czech context
-        
+
         // This is the exact logic from notifyOfArchive
         java.util.Locale contextLocale = context.getCurrentLocale();
         java.util.Locale epersonLocale = org.dspace.core.I18nUtil.getEPersonLocale(submitter);
         java.util.Locale selectedLocale = java.util.Optional.ofNullable(contextLocale)
                 .orElseGet(() -> epersonLocale);
-        
+
         // Verify Czech context locale was selected over English EPerson locale
         assertEquals("Context locale should take precedence", "cs", selectedLocale.getLanguage());
-        assertNotEquals("Should not use EPerson locale when context is available", "en", selectedLocale.getLanguage());
-        
+        assertNotEquals("Should not use EPerson locale when context is available", "en",
+                selectedLocale.getLanguage());
+
         // Test 2: EPerson locale fallback when context is null
         context.setCurrentLocale(null);
-        
+
         java.util.Locale contextLocale2 = context.getCurrentLocale();
         java.util.Locale epersonLocale2 = org.dspace.core.I18nUtil.getEPersonLocale(submitter);
         java.util.Locale selectedLocale2 = java.util.Optional.ofNullable(contextLocale2)
                 .orElseGet(() -> epersonLocale2);
-        
+
         // Verify EPerson locale is used as fallback
         assertEquals("EPerson locale should be used when context is null", "en", selectedLocale2.getLanguage());
-        
+
         // Test 3: Verify email filename generation works with selected locale
-        String czechFilename = org.dspace.core.I18nUtil.getEmailFilename(new java.util.Locale("cs"), "submit_archive");
-        String englishFilename = org.dspace.core.I18nUtil.getEmailFilename(new java.util.Locale("en"), "submit_archive");
-        
+        String czechFilename = org.dspace.core.I18nUtil.getEmailFilename(new java.util.Locale("cs"),
+                "submit_archive");
+        String englishFilename = org.dspace.core.I18nUtil.getEmailFilename(new java.util.Locale("en"),
+                "submit_archive");
+
         // The filenames should be different or at least the method should work without errors
         assertNotNull("Czech email filename should be generated", czechFilename);
         assertNotNull("English email filename should be generated", englishFilename);
-        
+
         assertTrue("Locale selection and email filename generation completed successfully", true);
     }
 

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
@@ -8,6 +8,9 @@
 package org.dspace.xmlworkflow;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -205,6 +208,53 @@ public class XmlWorkflowServiceIT extends AbstractIntegrationTestWithDatabase {
             }
         }
         return false;
+    }
+
+    @Test
+    public void testLocaleSelectionLogic_ContextTakesPrecedenceOverEPerson() throws Exception {
+        context.turnOffAuthorisationSystem();
+        
+        // Create EPerson with English preference
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                .withEmail("submitter@example.org")
+                .withLanguage("en") // English preference
+                .build();
+        
+        context.restoreAuthSystemState();
+        
+        // Test 1: Context locale takes precedence
+        context.setCurrentLocale(new java.util.Locale("cs")); // Czech context
+        
+        // This is the exact logic from notifyOfArchive
+        java.util.Locale contextLocale = context.getCurrentLocale();
+        java.util.Locale epersonLocale = org.dspace.core.I18nUtil.getEPersonLocale(submitter);
+        java.util.Locale selectedLocale = java.util.Optional.ofNullable(contextLocale)
+                .orElseGet(() -> epersonLocale);
+        
+        // Verify Czech context locale was selected over English EPerson locale
+        assertEquals("Context locale should take precedence", "cs", selectedLocale.getLanguage());
+        assertNotEquals("Should not use EPerson locale when context is available", "en", selectedLocale.getLanguage());
+        
+        // Test 2: EPerson locale fallback when context is null
+        context.setCurrentLocale(null);
+        
+        java.util.Locale contextLocale2 = context.getCurrentLocale();
+        java.util.Locale epersonLocale2 = org.dspace.core.I18nUtil.getEPersonLocale(submitter);
+        java.util.Locale selectedLocale2 = java.util.Optional.ofNullable(contextLocale2)
+                .orElseGet(() -> epersonLocale2);
+        
+        // Verify EPerson locale is used as fallback
+        assertEquals("EPerson locale should be used when context is null", "en", selectedLocale2.getLanguage());
+        
+        // Test 3: Verify email filename generation works with selected locale
+        String czechFilename = org.dspace.core.I18nUtil.getEmailFilename(new java.util.Locale("cs"), "submit_archive");
+        String englishFilename = org.dspace.core.I18nUtil.getEmailFilename(new java.util.Locale("en"), "submit_archive");
+        
+        // The filenames should be different or at least the method should work without errors
+        assertNotNull("Czech email filename should be generated", czechFilename);
+        assertNotNull("English email filename should be generated", englishFilename);
+        
+        assertTrue("Locale selection and email filename generation completed successfully", true);
     }
 
     private void executeWorkflowAction(HttpServletRequest httpServletRequest, Workflow workflow, ClaimedTask task)


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

## Problem Description
The system does not send the email in English when I create an item — it always sends it in Czech.

## Solution
Use the context language when sending the archive email upon submission.