### PR TITLE
VSB-TUO/Health report item summary

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
@@ -152,9 +152,15 @@ public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> impleme
     @Override
     public int countWithNoPolicy(Context context) throws SQLException {
         Query query = createQuery(context,
-                                  "SELECT count(bit.id) from Bitstream bit where bit.deleted<>true and bit.id not in" +
-                                      " (select res.dSpaceObject from ResourcePolicy res where res.resourceTypeId = " +
-                                      ":typeId )");
+                "SELECT count(bit.id) " +
+                        "FROM Bitstream bit " +
+                        "WHERE bit.deleted <> true " +
+                        "AND NOT EXISTS (" +
+                        "    SELECT 1 FROM ResourcePolicy res " +
+                        "    WHERE res.resourceTypeId = :typeId " +
+                        "      AND res.dSpaceObject = bit.id" +
+                        ")"
+        );
         query.setParameter("typeId", Constants.BITSTREAM);
         return count(query);
     }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
@@ -158,7 +158,7 @@ public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> impleme
                         "AND NOT EXISTS (" +
                         "    SELECT 1 FROM ResourcePolicy res " +
                         "    WHERE res.resourceTypeId = :typeId " +
-                        "      AND res.dSpaceObject = bit.id" +
+                        "      AND res.dSpaceObject.id = bit.id" +
                         ")"
         );
         query.setParameter("typeId", Constants.BITSTREAM);


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
There was a SELECT statement that used NOT NULL. In that case, the left side returned 555,375 results and the right side 643,715 results, so there were more than 357 billion comparisons.