### PR TITLE
VSB-TUO/Fix bitstreamuuid query

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseResourceMappingDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseResourceMappingDAOImpl.java
@@ -8,6 +8,7 @@
 package org.dspace.content.dao.impl.clarin;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.persistence.Query;
@@ -42,12 +43,24 @@ public class ClarinLicenseResourceMappingDAOImpl extends AbstractHibernateDAO<Cl
         if (bitstreamUUIDs == null || bitstreamUUIDs.isEmpty()) {
             return List.of();
         }
-        Query query = createQuery(context, "SELECT clrm " +
-                "FROM ClarinLicenseResourceMapping clrm " +
-                "WHERE clrm.bitstream.id IN :bitstreamUUIDs");
-        query.setParameter("bitstreamUUIDs", bitstreamUUIDs);
-        query.setHint("org.hibernate.cacheable", Boolean.TRUE);
-        return list(query);
+        // PostgreSQL limit is 65,535 parameters, we stay well below that.
+        final int BATCH_SIZE = 10000;
+        List<ClarinLicenseResourceMapping> results = new ArrayList<>();
+
+        for (int i = 0; i < bitstreamUUIDs.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, bitstreamUUIDs.size());
+            List<UUID> batch = bitstreamUUIDs.subList(i, end);
+
+            Query query = createQuery(context,
+                    "SELECT clrm FROM ClarinLicenseResourceMapping clrm " +
+                            "WHERE clrm.bitstream.id IN :bitstreamUUIDs");
+            query.setParameter("bitstreamUUIDs", batch);
+            query.setHint("org.hibernate.cacheable", Boolean.TRUE);
+
+            results.addAll(list(query));
+        }
+
+        return results;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseResourceMappingDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseResourceMappingDAOImpl.java
@@ -24,6 +24,11 @@ public class ClarinLicenseResourceMappingDAOImpl extends AbstractHibernateDAO<Cl
         super();
     }
 
+    /**
+     * Maximum number of UUIDs to include per query batch.
+     */
+    private static final int BATCH_SIZE = 10_000;
+
     @Override
     public List<ClarinLicenseResourceMapping> findByBitstreamUUID(Context context, UUID bitstreamUUID)
             throws SQLException {
@@ -43,8 +48,6 @@ public class ClarinLicenseResourceMappingDAOImpl extends AbstractHibernateDAO<Cl
         if (bitstreamUUIDs == null || bitstreamUUIDs.isEmpty()) {
             return List.of();
         }
-        // PostgreSQL limit is 65,535 parameters, we stay well below that.
-        final int BATCH_SIZE = 10000;
         List<ClarinLicenseResourceMapping> results = new ArrayList<>();
 
         for (int i = 0; i < bitstreamUUIDs.size(); i += BATCH_SIZE) {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The HealthReport (LicenseCheck) fails when processing many bitstreams because the query in findByBitstreamUUIDs exceeds PostgreSQL’s 65,535 parameter limit.

@milanmajchrak Maybe changes from health report should be also in dtq-dev not only in customer/vsb-tuo
