### PR TITLE
UFAL/Health report item summary

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
@@ -152,9 +152,15 @@ public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> impleme
     @Override
     public int countWithNoPolicy(Context context) throws SQLException {
         Query query = createQuery(context,
-                                  "SELECT count(bit.id) from Bitstream bit where bit.deleted<>true and bit.id not in" +
-                                      " (select res.dSpaceObject from ResourcePolicy res where res.resourceTypeId = " +
-                                      ":typeId )");
+                "SELECT count(bit.id) " +
+                        "FROM Bitstream bit " +
+                        "WHERE bit.deleted <> true " +
+                        "AND NOT EXISTS (" +
+                        "    SELECT 1 FROM ResourcePolicy res " +
+                        "    WHERE res.resourceTypeId = :typeId " +
+                        "      AND res.dSpaceObject.id = bit.id" +
+                        ")"
+        );
         query.setParameter("typeId", Constants.BITSTREAM);
         return count(query);
     }


### PR DESCRIPTION
* used not exists instead of not null|

* used id of dspace object

Cherry-picked from VSB-TUO to improve the performance of the health report item summary.