### PR TITLE
SAV/No files are displayed

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -606,6 +606,8 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
             return true;
         } catch (MissingLicenseAgreementException e) {
             return false;
+        } catch (AuthorizeException e) {
+            return false;
         }
     }
 

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -149,7 +149,7 @@ disable.ssl.check.specific.requests = false
 
 ##### Matomo statistics #####
 # Auth token
-matomo.track.enabled = true
+matomo.track.enabled = false
 matomo.auth.token = 26388b4164695d69e6ee6e2dd527b723
 matomo.site.id = 1
 matomo.tracker.bitstream.site_id = 1


### PR DESCRIPTION
## Problem description
- Fix bitstream access control by checking bundle-level permissions and catching authorization exceptions to prevent 500 errors when anonymous users have bundle READ access but bitstreams require authentication.
- Disable misconfigured Matomo tracking to prevent 400 Bad Request errors during bitstream downloads.

### Manual Testing (if applicable)
- [x] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot