### PR TITLE
Add non-root user 'dspace' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ EXPOSE 8080 8000
 ENV JAVA_OPTS=-Xmx2000m
 # On startup, run DSpace Runnable JAR
 
-# We create a 'dspace' user to run DSpace instead of running as root
+# We create a 'dspace' user to run DSpace instead of running as root. An explicit UID is required 
+# because Kubernetes deployment accepts only numeric user IDs when specifying the container user.
 RUN useradd -u 1100 -m -s /bin/bash dspace \
     && chown -Rv dspace: /dspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,10 @@ EXPOSE 8080 8000
 ENV JAVA_OPTS=-Xmx2000m
 # On startup, run DSpace Runnable JAR
 
-# For security reason (requirement on some cloud platforms) we want to run dspace as non-root user.
-RUN chown -R ubuntu:ubuntu /dspace
-USER ubuntu
+# We create a 'dspace' user to run DSpace instead of running as root
+RUN useradd -u 1100 -m -s /bin/bash dspace \
+    && chown -Rv dspace: /dspace
+
+USER dspace
 
 ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar", "--dspace.dir=$DSPACE_INSTALL"]


### PR DESCRIPTION
Create 'dspace' user for running DSpace as non-root.

## Problem description

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot