### PR TITLE
Update comment for 'dspace' user creation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ RUN ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server
 WORKDIR /usr/local/tomcat/bin
 RUN chmod u+x redebug.sh undebug.sh custom_run.sh
 
-# We create a 'dspace' user to run DSpace instead of running as root
+# We create a 'dspace' user to run DSpace instead of running as root. An explicit UID is required 
+# because Kubernetes deployment accepts only numeric user IDs when specifying the container user.
 RUN useradd -u 1100 -m -s /bin/bash dspace \
     && chown -Rv dspace: /dspace /usr/local/tomcat
 


### PR DESCRIPTION
Clarified comment about creating 'dspace' user for DSpace with UID requirement for Kubernetes.

## Problem description

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot