### PR TITLE
TUL/Add alternative author names metadata field

### DIFF
--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -138,4 +138,11 @@
       . Check/extend html.xsl for available variables.</scope_note>
   </dc-type>
 
+  <dc-type>
+    <schema>local</schema>
+    <element>author</element>
+    <qualifier>alternative</qualifier>
+    <scope_note>Alternative author names for searchability (e.g., pseudonyms, transliterations, maiden names)</scope_note>
+  </dc-type>
+
 </dspace-dc-types>

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -142,7 +142,7 @@
     <schema>local</schema>
     <element>author</element>
     <qualifier>alternative</qualifier>
-    <scope_note>Alternative author names for searchability (e.g., pseudonyms, transliterations, former names)</scope_note>
+    <scope_note>Alternative author name</scope_note>
   </dc-type>
 
 </dspace-dc-types>

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -142,7 +142,7 @@
     <schema>local</schema>
     <element>author</element>
     <qualifier>alternative</qualifier>
-    <scope_note>Alternative author names for searchability (e.g., pseudonyms, transliterations, maiden names)</scope_note>
+    <scope_note>Alternative author names for searchability (e.g., pseudonyms, transliterations, former names)</scope_note>
   </dc-type>
 
 </dspace-dc-types>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -77,6 +77,18 @@
             </row>
             <row>
                 <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>author</dc-element>
+                    <dc-qualifier>alternative</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Alternativní jména autora</label>
+                    <input-type>onebox</input-type>
+                    <hint>Zadejte alternativní jména autora (pseudonymy, přepisy, dřívější jména)</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
                     <dc-schema>dc</dc-schema>
                     <dc-element>title</dc-element>
                     <dc-qualifier></dc-qualifier>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -81,9 +81,9 @@
                     <dc-element>author</dc-element>
                     <dc-qualifier>alternative</dc-qualifier>
                     <repeatable>true</repeatable>
-                    <label>Alternativní jména autora</label>
+                    <label>Alternativní jméno autora</label>
                     <input-type>onebox</input-type>
-                    <hint>Zadejte alternativní jména autora</hint>
+                    <hint>Zadejte alternativní jméno autora</hint>
                     <required></required>
                 </field>
             </row>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -83,7 +83,7 @@
                     <repeatable>true</repeatable>
                     <label>Alternativní jména autora</label>
                     <input-type>onebox</input-type>
-                    <hint>Zadejte alternativní jména autora (pseudonymy, přepisy, dřívější jména)</hint>
+                    <hint>Zadejte alternativní jména autora</hint>
                     <required></required>
                 </field>
             </row>


### PR DESCRIPTION
## Problem description
DSpace submission workflow lacked a dedicated field for alternative author names (pseudonyms, transliterations, former names), making it difficult for users to search for authors by their variant names. Added `local.author.alternative` metadata field to the metadata registry and integrated it as a repeatable, searchable field in the submission forms (traditionalpageone), enabling authors to be found using alternative name variations.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot