### PR TITLE
Fix/Get version null exception

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/VersionHistoryServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersionHistoryServiceImpl.java
@@ -109,9 +109,6 @@ public class VersionHistoryServiceImpl implements VersionHistoryService {
         throws SQLException {
         Version v = versioningService.getVersion(context, item);
         if (v != null) {
-            ;
-        }
-        {
             if (versionHistory.equals(v.getVersionHistory())) {
                 return v;
             }


### PR DESCRIPTION
## Problem description
When a version does not exist in the version history, we get an exception instead of null.