### PR TITLE
Port 1299 to dtq-dev

### DIFF
--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -16,26 +16,6 @@
     <bean id="org.dspace.services.ConfigurationService"
           class="org.dspace.servicemanager.config.DSpaceConfigurationService" scope="singleton"/>
 
-    <!-- provider for exposing default Handle services implementaion. -->
-    <!--bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.HandleIdentifierProvider"
-          scope="singleton">
-        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
-    </bean-->
-
-<!-- Uncomment if you want to use the VersionedHandleIdentifierProvider as an identify provider. -->
-<!--    <bean id="org.dspace.identifier.VersionedHandleIdentifierProvider"-->
-<!--          class="org.dspace.identifier.VersionedHandleIdentifierProvider"-->
-<!--          scope="singleton">-->
-<!--        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>-->
-<!--    </bean>-->
-
-<!-- Comment it out if you do not want to use the ClarinVersionedHandleIdentifierProvider as an identify provider. -->
-    <bean id="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
-          class="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
-          scope="singleton">
-        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
-    </bean>
-
     <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true" scope="prototype"/>
 
     <!-- Register all our Flyway callback classes (which run before/after database migrations) -->

--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -16,6 +16,12 @@
     <bean id="org.dspace.services.ConfigurationService"
           class="org.dspace.servicemanager.config.DSpaceConfigurationService" scope="singleton"/>
 
+    <!-- provider for exposing default Handle services implementaion. -->
+    <!--bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.HandleIdentifierProvider"
+          scope="singleton">
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    </bean-->
+
     <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true" scope="prototype"/>
 
     <!-- Register all our Flyway callback classes (which run before/after database migrations) -->

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -37,7 +37,6 @@
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
 
-
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -24,9 +24,11 @@
          The VersionedHandleIdentifierProvider creates a new versioned
          handle for every new version.
          -->
+    <!--
     <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProvider" scope="singleton">
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
+    -->
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -29,6 +29,15 @@
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
     -->
+
+    <!-- Comment it out if you do not want to use the ClarinVersionedHandleIdentifierProvider as an identify provider. -->
+    <bean id="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
+          class="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
+          scope="singleton">
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    </bean>
+
+
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever


### PR DESCRIPTION
port https://github.com/ufal/clarin-dspace/pull/1301 to dtq-dev

This is the fix for https://github.com/ufal/clarin-dspace/issues/1299

The **ClarinVersionedHandleIdentifierProvider** overrides the **VersionedHandleIdentifierProvider**, so there is no sense to register both.

Also moved **ClarinVersionedHandleIdentifierProvide**r to identifier-service.xml.
