### PR TITLE
MENDELU/Uncomment bulkedit.export.max.items property

### DIFF
--- a/dspace/config/modules/bulkedit.cfg
+++ b/dspace/config/modules/bulkedit.cfg
@@ -44,4 +44,4 @@ bulkedit.change.commit.count = 100
 # The maximum amount of items that can be exported using the "metadata-export" / "metadata-export-search" script
 # Recommend to keep this at a feasible number, as exporting large amounts of items can be resource intensive
 # If not set, this will default to 500 items
-# bulkedit.export.max.items = 500
+bulkedit.export.max.items = 500


### PR DESCRIPTION
## Problem description
Uncomment default bulkedit.export.max.items property to prevent FE 404 error on search page.

### Copilot review
- [x] Requested review from Copilot