### PR TITLE
Fix CurationScriptIT failing when someone the 123456789/1 community i…

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -667,7 +667,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
                 // MetadataValueLinkChecker uri field with regular link
                 .withMetadata("dc", "description", null, "https://google.com")
                 // MetadataValueLinkChecker uri field with redirect link
-                .withMetadata("dc", "description", "uri", "https://demo7.dspace.org/handle/123456789/1")
+                .withMetadata("dc", "description", "uri", "http://google.com")
                 // MetadataValueLinkChecker uri field with non resolving link
                 .withMetadata("dc", "description", "uri", "https://www.atmire.com/broken-link")
                 .withSubject("ExtraEntry")
@@ -690,9 +690,9 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
 
         // field that should be ignored
         assertFalse(checkIfInfoTextLoggedByHandler(handler, "demo.dspace.org/home"));
-        // redirect links in field that should not be ignored (https) => expect OK
-        assertTrue(checkIfInfoTextLoggedByHandler(handler, "https://demo7.dspace.org/handle/123456789/1 = 200 - OK"));
-        // regular link in field that should not be ignored (http) => expect OK
+        // redirect links in field that should not be ignored => expect OK (even though curl responds with 301)
+        assertTrue(checkIfInfoTextLoggedByHandler(handler, "http://google.com = 200 - OK"));
+        // regular link in field that should not be ignored => expect OK
         assertTrue(checkIfInfoTextLoggedByHandler(handler, "https://google.com = 200 - OK"));
         // nonexistent link in field that should not be ignored => expect 404
         assertTrue(checkIfInfoTextLoggedByHandler(handler, "https://www.atmire.com/broken-link = 404 - FAILED"));


### PR DESCRIPTION
…s removed on demo.dspace.org

HTTP requests to google.com will also result in a redirect status code so we can use that URL instead

(cherry picked from commit 0eba85deec4fcd761a6025fd43ca1b562b49d41b)
