### PR TITLE
Bump tika.version from 3.2.2 to 3.2.3

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.dspace.content.Bitstream;
@@ -153,8 +153,8 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         // the CropBox is missing or empty because pdfbox will set it to the
         // same size as the MediaBox if it doesn't exist. Also note that we
         // only need to check the first page, since that's what we use for
-        // generating the thumbnail (PDDocument uses a zero-based index).
-        PDPage pdfPage = PDDocument.load(f).getPage(0);
+        // generating the thumbnail (PDPage uses a zero-based index).
+        PDPage pdfPage = Loader.loadPDF(f).getPage(0);
         PDRectangle pdfPageMediaBox = pdfPage.getMediaBox();
         PDRectangle pdfPageCropBox = pdfPage.getCropBox();
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -11,6 +11,8 @@ import java.awt.image.BufferedImage;
 import java.io.InputStream;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -71,7 +73,7 @@ public class PDFBoxThumbnail extends MediaFilter {
         BufferedImage buf;
 
         // Render the page image.
-        try ( PDDocument doc = PDDocument.load(source); ) {
+        try ( PDDocument doc = Loader.loadPDF(new RandomAccessReadBuffer(source)); ) {
             PDFRenderer renderer = new PDFRenderer(doc);
             buf = renderer.renderImage(0);
         } catch (InvalidPasswordException ex) {

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -18,11 +18,11 @@ import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSDocument;
 import org.apache.pdfbox.io.MemoryUsageSetting;
-import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.io.ScratchFile;
-import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.dspace.authorize.AuthorizeException;
@@ -330,19 +330,24 @@ public class PDFPackager
         COSDocument cos = null;
 
         try {
-            ScratchFile scratchFile = null;
+            PDDocument document = null;
+
             try {
-                long useRAM = Runtime.getRuntime().freeMemory() * 80 / 100; // use up to 80% of JVM free memory
-                scratchFile = new ScratchFile(
-                    MemoryUsageSetting.setupMixed(useRAM)); // then fallback to temp file (unlimited size)
+                // Use up to 80% of JVM free memory and fall back to a temp file (unlimited size)
+                long useRAM = Runtime.getRuntime().freeMemory() * 80 / 100;
+                document = Loader.loadPDF(
+                        new RandomAccessReadBuffer(metadata),
+                        () -> new ScratchFile(MemoryUsageSetting.setupMixed(useRAM)));
             } catch (IOException ioe) {
                 log.warn("Error initializing scratch file: " + ioe.getMessage());
             }
 
-            PDFParser parser = new PDFParser(new RandomAccessBufferedFileInputStream(metadata), scratchFile);
-            parser.parse();
-            cos = parser.getDocument();
+            // sanity check: loaded PDF document must not be null.
+            if (document == null) {
+                throw new MetadataValidationException("The provided stream could not be parsed into a PDF document.");
+            }
 
+            cos = document.getDocument();
             // sanity check: PDFBox breaks on encrypted documents, so give up.
             if (cos.getEncryptionDictionary() != null) {
                 throw new MetadataValidationException("This packager cannot accept an encrypted PDF document.");

--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -30,6 +32,7 @@ import org.apache.pdfbox.pdmodel.PDPageTree;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
@@ -304,7 +307,7 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
             Item item = (Item) bitstreamService.getParentObject(context, bitstream);
             final InputStream inputStream = bitstreamService.retrieve(context, bitstream);
             try {
-                sourceDocument = sourceDocument.load(inputStream);
+                sourceDocument = Loader.loadPDF(new RandomAccessReadBuffer(inputStream));
             } finally {
                 inputStream.close();
             }
@@ -335,9 +338,10 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
             int xwidth = 550;
             int ygap = 20;
 
-            PDFont fontHelvetica = PDType1Font.HELVETICA;
-            PDFont fontHelveticaBold = PDType1Font.HELVETICA_BOLD;
-            PDFont fontHelveticaOblique = PDType1Font.HELVETICA_OBLIQUE;
+            PDFont fontHelvetica = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
+            PDFont fontHelveticaBold = new PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD);
+            PDFont fontHelveticaOblique = new PDType1Font(Standard14Fonts.FontName.HELVETICA_OBLIQUE);
+
             contentStream.setNonStrokingColor(Color.BLACK);
 
             String[][] content = {header1};

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -62,6 +62,8 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -1004,7 +1006,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
              Writer writer = new StringWriter();
-             PDDocument pdfDoc = PDDocument.load(source)) {
+             PDDocument pdfDoc = Loader.loadPDF(new RandomAccessReadBuffer(source))) {
 
             pts.writeText(pdfDoc, writer);
             return writer.toString();
@@ -1013,7 +1015,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
     private int getNumberOfPdfPages(byte[] content) throws IOException {
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
-             PDDocument pdfDoc = PDDocument.load(source)) {
+            PDDocument pdfDoc = Loader.loadPDF(new RandomAccessReadBuffer(source))) {
             return pdfDoc.getNumberOfPages();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <pdfbox-version>2.0.34</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <tika.version>2.9.4</tika.version>
+        <tika.version>3.2.3</tika.version>
         <!-- Sync with whatever version Tika uses -->
         <bouncycastle.version>1.81</bouncycastle.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
         <jaxb-runtime.version>2.3.9</jaxb-runtime.version>
         <jcache-version>1.1.1</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
-        <jetty.version>9.4.57.v20241219</jetty.version>
-        <log4j.version>2.25.1</log4j.version>
-        <pdfbox-version>2.0.34</pdfbox-version>
+        <jetty.version>9.4.58.v20250814</jetty.version>
+        <log4j.version>2.25.2</log4j.version>
+        <pdfbox-version>3.0.5</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <slf4j.version>1.7.36</slf4j.version>
         <tika.version>3.2.3</tika.version>


### PR DESCRIPTION
Bumps `tika.version` from 3.2.2 to 3.2.3.

Updates `org.apache.tika:tika-core` from 3.2.2 to 3.2.3
- [Changelog](https://github.com/apache/tika/blob/main/CHANGES.txt)
- [Commits](https://github.com/apache/tika/compare/3.2.2...3.2.3)

Updates `org.apache.tika:tika-parsers-standard-package` from 3.2.2 to 3.2.3

---
updated-dependencies:
- dependency-name: org.apache.tika:tika-core dependency-version: 3.2.3 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.tika:tika-parsers-standard-package dependency-version: 3.2.3 dependency-type: direct:production update-type: version-update:semver-patch ...