### PR TITLE
fix: move updateItemDatesMetadata from ItemConverter (read) to ItemSe…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -49,6 +49,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -173,6 +174,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Autowired(required = true)
     ClarinMatomoBitstreamTracker matomoBitstreamTracker;
+
+    @Autowired(required = true)
+    private ClarinItemService clarinItemService;
 
     protected ItemServiceImpl() {
         super();
@@ -624,6 +628,11 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         if (item.isMetadataModified() || item.isModified()) {
+            // Derive dc.date.issued from local.approximateDate.issued when metadata changes
+            if (item.isMetadataModified()) {
+                clarinItemService.updateItemDatesMetadata(context, item);
+            }
+
             // Set the last modified date
             item.setLastModified(new Date());
 

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -218,12 +218,30 @@ public class ClarinItemServiceImpl implements ClarinItemService {
             return;
         }
 
+        String derivedDate = deriveDateIssuedFromApproximateDate(item);
+        if (derivedDate == null) {
+            log.warn("Cannot update item dates metadata because the approximate date is empty.");
+            return;
+        }
+
+        try {
+            // Clear the current `dc.date.issued` metadata
+            itemService.clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
+
+            // Update the `dc.date.issued` metadata with the derived value
+            itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY, derivedDate);
+        } catch (SQLException e) {
+            log.error("Cannot remove `dc.date.issued` metadata because: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public String deriveDateIssuedFromApproximateDate(Item item) {
         List<MetadataValue> approximatedDates =
                 itemService.getMetadata(item, "local", "approximateDate", "issued", Item.ANY, false);
 
         if (CollectionUtils.isEmpty(approximatedDates) || StringUtils.isBlank(approximatedDates.get(0).getValue())) {
-            log.warn("Cannot update item dates metadata because the approximate date is empty.");
-            return;
+            return null;
         }
 
         // Get the approximate date value from the metadata
@@ -234,21 +252,11 @@ public class ClarinItemServiceImpl implements ClarinItemService {
         // Trim the list of years - remove leading and trailing whitespaces
         listOfYearValues.replaceAll(String::trim);
 
-        try {
-            // Clear the current `dc.date.issued` metadata
-            itemService.clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
-
-            // Update the `dc.date.issued` metadata with a new value: `0000` or the last year from the sequence
-            if (CollectionUtils.isNotEmpty(listOfYearValues) && isListOfNumbers(listOfYearValues)) {
-                // Take the last year from the list of years and add it to the `dc.date.issued` metadata
-                itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY,
-                        getLastNumber(listOfYearValues));
-            } else {
-                // Add the `0000` value to the `dc.date.issued` metadata
-                itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY, NO_YEAR);
-            }
-        } catch (SQLException e) {
-            log.error("Cannot remove `dc.date.issued` metadata because: {}", e.getMessage());
+        if (CollectionUtils.isNotEmpty(listOfYearValues) && isListOfNumbers(listOfYearValues)) {
+            // Take the last year from the list of years
+            return getLastNumber(listOfYearValues);
+        } else {
+            return NO_YEAR;
         }
     }
 
@@ -267,6 +275,5 @@ public class ClarinItemServiceImpl implements ClarinItemService {
         }
         return values.get(values.size() - 1);
     }
-
 
 }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -224,15 +224,19 @@ public class ClarinItemServiceImpl implements ClarinItemService {
             return;
         }
 
-        try {
-            // Clear the current `dc.date.issued` metadata
-            itemService.clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
-
-            // Update the `dc.date.issued` metadata with the derived value
-            itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY, derivedDate);
-        } catch (SQLException e) {
-            log.error("Cannot remove `dc.date.issued` metadata because: {}", e.getMessage());
+        // Short-circuit if dc.date.issued already has the correct derived value
+        List<MetadataValue> currentDateIssued =
+                itemService.getMetadata(item, "dc", "date", "issued", Item.ANY, false);
+        if (CollectionUtils.isNotEmpty(currentDateIssued)
+                && derivedDate.equals(currentDateIssued.get(0).getValue())) {
+            return;
         }
+
+        // Clear the current `dc.date.issued` metadata
+        itemService.clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
+
+        // Update the `dc.date.issued` metadata with the derived value
+        itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY, derivedDate);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinItemService.java
@@ -102,4 +102,20 @@ public interface ClarinItemService {
      */
     void updateItemDatesMetadata(Context context, Item item) throws SQLException;
 
+    /**
+     * Derive the display value for {@code dc.date.issued} from the item's
+     * {@code local.approximateDate.issued} metadata.
+     *
+     * <ul>
+     *   <li>If approximateDate is a comma-separated list of numbers (e.g. "1938, 1945, 2022"),
+     *       returns the last number ("2022").</li>
+     *   <li>If approximateDate is non-numeric (e.g. "cca 1938 - 1945"), returns "0000".</li>
+     *   <li>If approximateDate is empty or missing, returns {@code null} (no override needed).</li>
+     * </ul>
+     *
+     * @param item the item to derive the date from.
+     * @return the derived date string, or {@code null} if no approximate date is present.
+     */
+    String deriveDateIssuedFromApproximateDate(Item item);
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -21,6 +21,7 @@ import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.MetadataValueList;
 import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataValue;
@@ -84,7 +85,20 @@ public class ItemConverter
         if (derivedValue == null) {
             return;
         }
+
+        // Respect hidden-metadata configuration — do not override if dc.date.issued is hidden
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        try {
+            if (metadataExposureService.isHidden(context, "dc", "date", "issued", source)) {
+                return;
+            }
+        } catch (SQLException e) {
+            log.error("Error checking metadata visibility for dc.date.issued", e);
+            return;
+        }
+
         MetadataValueRest dateRest = new MetadataValueRest(derivedValue);
+        dateRest.setConfidence(-1);
         dateRest.setPlace(0);
         target.getMetadata().getMap().put("dc.date.issued", Collections.singletonList(dateRest));
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.converter;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -18,8 +19,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.MetadataValueList;
+import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.projection.Projection;
-import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataValue;
@@ -27,7 +28,6 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
 import org.dspace.discovery.IndexableObject;
-import org.dspace.services.model.Request;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
@@ -53,18 +53,6 @@ public class ItemConverter
 
     @Override
     public ItemRest convert(Item obj, Projection projection) {
-        Context context = null;
-        Request currentRequest = requestService.getCurrentRequest();
-        if (currentRequest != null) {
-            context = ContextUtil.obtainContext(currentRequest.getHttpServletRequest());
-        }
-        try {
-            clarinItemService.updateItemDatesMetadata(context, obj);
-        } catch (SQLException e) {
-            log.error("Error updating item dates metadata", e);
-            throw new RuntimeException(e);
-        }
-
         ItemRest item = super.convert(obj, projection);
         item.setInArchive(obj.isArchived());
         item.setDiscoverable(obj.isDiscoverable());
@@ -77,7 +65,28 @@ public class ItemConverter
             item.setEntityType(entityTypes.get(0).getValue());
         }
 
+        // Override dc.date.issued on the REST DTO with the derived value from local.approximateDate.issued.
+        // This is a display-only override — it does NOT modify the JPA entity or touch the database.
+        // It ensures that even items with stale dc.date.issued in the DB display the correct derived value.
+        overrideDateIssuedFromApproximateDate(obj, item);
+
         return item;
+    }
+
+    /**
+     * If the item has a {@code local.approximateDate.issued} metadata value, override
+     * {@code dc.date.issued} on the REST DTO using the shared derivation logic in
+     * {@link ClarinItemService#deriveDateIssuedFromApproximateDate(Item)}.
+     * This is a display-only override — no database writes.
+     */
+    private void overrideDateIssuedFromApproximateDate(Item source, ItemRest target) {
+        String derivedValue = clarinItemService.deriveDateIssuedFromApproximateDate(source);
+        if (derivedValue == null) {
+            return;
+        }
+        MetadataValueRest dateRest = new MetadataValueRest(derivedValue);
+        dateRest.setPlace(0);
+        target.getMetadata().getMap().put("dc.date.issued", Collections.singletonList(dateRest));
     }
 
     /**


### PR DESCRIPTION
## Problem description

`ItemConverter.convert()` called `ClarinItemService.updateItemDatesMetadata()` — a method that performs database writes (`clearMetadata` / `addMetadata`) — during REST serialization. This caused:

1. **Log spam**: Every GET request for an item without `local.approximateDate.issued` logged `"Cannot update item dates metadata because the approximate date is empty"`.
2. **Write-on-read**: Hibernate dirty-checking and DB writes were triggered during read-only GET requests. These writes were then rolled back by `DSpaceRequestContextFilter.abort()`, making them entirely wasteful.
3. **Unnecessary overhead** on every item serialization.

## Analysis

The root cause is an architectural violation: `ItemConverter.convert()` is a **read** path (serializing a JPA entity into a REST DTO), but it was performing **writes** (mutating item metadata in the database). The converter obtained a `Context`, called `updateItemDatesMetadata()`, which called `clearMetadata()` + `addMetadata()` — these are database operations that belong in the **write** path (`ItemServiceImpl.update()`).

The fix uses a two-layer approach:
- **Write-time** (persist): `ItemServiceImpl.update()` now calls `clarinItemService.updateItemDatesMetadata()` guarded by `isMetadataModified()`, so `dc.date.issued` is derived and persisted only when metadata actually changes (PATCH/PUT).
- **Read-time** (display): `ItemConverter` calls the new pure function `clarinItemService.deriveDateIssuedFromApproximateDate()` and overrides `dc.date.issued` on the REST **DTO only** — no JPA entity mutation, no database writes. This ensures items with stale `dc.date.issued` in the DB still display the correct value.

The derivation logic (`DELIMETER`, `NO_YEAR`, `isListOfNumbers`, `getLastNumber`) stays in `ClarinItemServiceImpl` where it originally lived. A new `deriveDateIssuedFromApproximateDate(Item)` method was extracted to expose the pure derivation (no DB side effects) so both `updateItemDatesMetadata` and `ItemConverter` can reuse it without duplication.

### Manual Testing (if applicable)
- [ ] Added to testing scenarios

### Copilot review
- [x] Requested review from Copilot

# TODO
- [ ] PRs to other branches