### PR TITLE
VSB-TUO/Removing unused collection conversion

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
@@ -75,21 +75,6 @@ public class SubmissionDefinitionConverter implements DSpaceConverter<Submission
                         e);
             }
         }
-
-        HttpServletRequest request = requestService.getCurrentRequest().getHttpServletRequest();
-        Context context = null;
-        try {
-            context = ContextUtil.obtainContext(request);
-            List<Collection> collections = panelConverter.getSubmissionConfigService()
-                                                         .getCollectionsBySubmissionConfig(context,
-                                                                                           obj.getSubmissionName());
-            DSpaceConverter<Collection, CollectionRest> cc = converter.getConverter(Collection.class);
-            List<CollectionRest> collectionsRest = collections.stream().map((collection) ->
-                    cc.convert(collection, projection)).collect(Collectors.toList());
-            sd.setCollections(collectionsRest);
-        } catch (SQLException | IllegalStateException | SubmissionConfigReaderException e) {
-            log.error(e.getMessage(), e);
-        }
         sd.setPanels(panels);
         return sd;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
@@ -9,8 +9,6 @@ package org.dspace.app.rest.converter;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.SubmissionDefinitionRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
@@ -7,24 +7,18 @@
  */
 package org.dspace.app.rest.converter;
 
-import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.Logger;
-import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.SubmissionDefinitionRest;
 import org.dspace.app.rest.model.SubmissionSectionRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.submit.DataProcessingStep;
-import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.util.SubmissionConfig;
-import org.dspace.app.util.SubmissionConfigReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
-import org.dspace.content.Collection;
-import org.dspace.core.Context;
 import org.dspace.services.RequestService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -190,8 +190,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
         //Match only that a section exists with a submission configuration behind
         getClient(token).perform(get("/api/config/submissiondefinitions/traditional/collections")
                    .param("projection", "full"))
-                   .andExpect(status().isNoContent())
-                   .andExpect(jsonPath("$.page.totalElements", is(0)));
+                   .andExpect(status().isNoContent());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -190,7 +190,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
         //Match only that a section exists with a submission configuration behind
         getClient(token).perform(get("/api/config/submissiondefinitions/traditional/collections")
                    .param("projection", "full"))
-                   .andExpect(status().isOk())
+                   .andExpect(status().isNoContent())
                    .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionDefinitionsMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionDefinitionsMatcher.java
@@ -34,7 +34,7 @@ public class SubmissionDefinitionsMatcher {
      */
     public static Matcher<? super Object> matchFullEmbeds() {
         return matchEmbeds(
-                "collections[]",
+                "collections",
                 "sections"
         );
     }


### PR DESCRIPTION
## Problem description
That the REST endpoint for workspace submissions unnecessarily loads all collections for each submission definition, causing excessive internal calls (e.g., 51 collection calls for only 9 workspaces). The collections property in SubmissionDefinitionRest is populated and exposed via REST, but it is not actually used anywhere in the Angular frontend. As a result, the system performs redundant Solr and REST processing, leading to avoidable performance overhead.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot