### PR TITLE
[Port to dtq-dev] Fix OpenAIRE integration: null handling and HTTP client lifecycle

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -8,4 +8,5 @@
          on JMockIt Expectations blocks and similar. See https://github.com/checkstyle/checkstyle/issues/3739 -->
     <suppress checks="Indentation" files="src[/\\]test[/\\]java"/>
     <suppress checks="Regexp" files="DSpaceHttpClientFactory\.java"/>
+    <suppress checks="Regexp" files="OpenAIRERestConnectorTest\.java"/>
 </suppressions>

--- a/dspace-api/src/main/java/org/dspace/external/OpenAIRERestConnector.java
+++ b/dspace-api/src/main/java/org/dspace/external/OpenAIRERestConnector.java
@@ -207,8 +207,11 @@ public class OpenAIRERestConnector {
                         break;
                 }
 
-                // do not close this httpClient
-                result = getResponse.getEntity().getContent();
+                // the client will be closed, we need to copy the response stream to a new one that we can return
+                try (InputStream is = getResponse.getEntity().getContent()) {
+                    byte[] bytes = is.readAllBytes();
+                    result = new java.io.ByteArrayInputStream(bytes);
+                }
             }
         } catch (MalformedURLException e1) {
             getGotError(e1, url + '/' + file);

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenAIREFundingDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenAIREFundingDataProvider.java
@@ -169,6 +169,9 @@ public class OpenAIREFundingDataProvider extends AbstractExternalDataProvider {
         String encodedQuery = encodeValue(query);
 
         Response projectResponse = connector.searchProjectByKeywords(0, 0, encodedQuery);
+        if (projectResponse == null || projectResponse.getHeader() == null) {
+            return 0;
+        }
         return Integer.parseInt(projectResponse.getHeader().getTotal());
     }
 

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenAIREFundingDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenAIREFundingDataProvider.java
@@ -172,7 +172,16 @@ public class OpenAIREFundingDataProvider extends AbstractExternalDataProvider {
         if (projectResponse == null || projectResponse.getHeader() == null) {
             return 0;
         }
-        return Integer.parseInt(projectResponse.getHeader().getTotal());
+        String total = projectResponse.getHeader().getTotal();
+        if (StringUtils.isBlank(total)) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(total);
+        } catch (NumberFormatException e) {
+            log.error("Failed to parse search result count from OpenAIRE: {}", e.getMessage());
+            return 0;
+        }
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/external/OpenAIRERestConnectorTest.java
+++ b/dspace-api/src/test/java/org/dspace/external/OpenAIRERestConnectorTest.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.external;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import eu.openaire.jaxb.model.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.dspace.app.client.DSpaceHttpClientFactory;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+
+public class OpenAIRERestConnectorTest {
+
+    @Test
+    public void searchProjectByKeywords() {
+        try (InputStream is = this.getClass().getResourceAsStream("openaire-projects.xml");
+               MockWebServer mockServer = new MockWebServer()) {
+            String projects = new String(is.readAllBytes())
+                    .replaceAll("( mushroom)", "( DEADBEEF)");
+            mockServer.enqueue(new MockResponse().setResponseCode(200).setBody(projects));
+
+            // setup mocks so we don't have to set whole DSpace kernel etc.
+            // still, the idea is to test how the get method behaves
+            CloseableHttpClient httpClient = spy(HttpClientBuilder.create().build());
+            doReturn(httpClient.execute(new HttpGet(mockServer.url("").toString())))
+                    .when(httpClient).execute(Mockito.any());
+
+            DSpaceHttpClientFactory mock = Mockito.mock(DSpaceHttpClientFactory.class);
+            when(mock.build()).thenReturn(httpClient);
+
+            try (MockedStatic<DSpaceHttpClientFactory> mockedFactory =
+                         Mockito.mockStatic(DSpaceHttpClientFactory.class)) {
+                mockedFactory.when(DSpaceHttpClientFactory::getInstance).thenReturn(mock);
+                OpenAIRERestConnector connector = new OpenAIRERestConnector(mockServer.url("").toString());
+                Response response = connector.searchProjectByKeywords(0, 10, "keyword");
+                // Basically check it doesn't throw UnmarshallerException and that we are getting our mocked response
+                assertTrue("Expected the query to contain the replaced keyword",
+                        response.getHeader().getQuery().contains("DEADBEEF"));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/external/OpenAIRERestConnectorTest.java
+++ b/dspace-api/src/test/java/org/dspace/external/OpenAIRERestConnectorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import eu.openaire.jaxb.model.Response;
 import okhttp3.mockwebserver.MockResponse;
@@ -33,7 +34,7 @@ public class OpenAIRERestConnectorTest {
     public void searchProjectByKeywords() {
         try (InputStream is = this.getClass().getResourceAsStream("openaire-projects.xml");
                MockWebServer mockServer = new MockWebServer()) {
-            String projects = new String(is.readAllBytes())
+            String projects = new String(is.readAllBytes(), StandardCharsets.UTF_8)
                     .replaceAll("( mushroom)", "( DEADBEEF)");
             mockServer.enqueue(new MockResponse().setResponseCode(200).setBody(projects));
 

--- a/dspace-api/src/test/java/org/dspace/external/provider/impl/OpenAIREFundingDataProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/external/provider/impl/OpenAIREFundingDataProviderTest.java
@@ -14,7 +14,9 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Optional;
 
+import eu.openaire.jaxb.model.Response;
 import org.dspace.AbstractDSpaceTest;
+import org.dspace.external.OpenAIRERestConnector;
 import org.dspace.external.factory.ExternalServiceFactory;
 import org.dspace.external.model.ExternalDataObject;
 import org.dspace.external.provider.ExternalDataProvider;
@@ -101,5 +103,22 @@ public class OpenAIREFundingDataProviderTest extends AbstractDSpaceTest {
         Optional<ExternalDataObject> result = openAIREFundingDataProvider.getExternalDataObject(id);
 
         assertTrue("openAIREFunding.getExternalDataObject.notExists:WRONGID", result.isEmpty());
+    }
+
+    @Test
+    public void testGetNumberOfResultsWhenResponseIsNull() {
+        // Create a mock connector that returns null
+        OpenAIREFundingDataProvider provider = new OpenAIREFundingDataProvider();
+        provider.setSourceIdentifier("test");
+        provider.setConnector(new OpenAIRERestConnector("test") {
+            @Override
+            public Response searchProjectByKeywords(int page, int size, String... keywords) {
+                return null;
+            }
+        });
+
+        // Should return 0 when response is null, not throw NullPointerException
+        int result = provider.getNumberOfResults("test");
+        assertEquals("Should return 0 when response is null", 0, result);
     }
 }


### PR DESCRIPTION
Port of ufal/clarin-dspace#1330 to `dtq-dev`.