### PR TITLE
UFAL/Add CCMM 1.1.0 OAI-PMH crosswalk (ccmm-xml metadataPrefix)

### DIFF
--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/CcmmXslTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/CcmmXslTest.java
@@ -133,6 +133,57 @@ public class CcmmXslTest extends AbstractXSLTest {
         assertThat(result, is(ccmm().withXPath("//ccmm:title", equalTo("Test Webpage"))));
     }
 
+    // ---- Fallback scenario tests ----
+
+    @Test
+    public void ccmmFallbackTitleIsUntitled() throws Exception {
+        // When dc.title is missing, fallback to "Untitled"
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-minimal-test.xml"));
+        assertThat(result, is(ccmm().withXPath("//ccmm:dataset/ccmm:title", equalTo("Untitled"))));
+    }
+
+    @Test
+    public void ccmmFallbackPublicationYearIs9999() throws Exception {
+        // When dc.date.issued and dc.date.accessioned are missing, fallback to "9999"
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-minimal-test.xml"));
+        assertThat(result, is(ccmm().withXPath("//ccmm:dataset/ccmm:publication_year", equalTo("9999"))));
+    }
+
+    @Test
+    public void ccmmFallbackSubjectIsUnspecified() throws Exception {
+        // When dc.subject is missing, fallback to "unspecified"
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-minimal-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:subject/ccmm:title", equalTo("unspecified"))));
+    }
+
+    @Test
+    public void ccmmFallbackIdentifierUsesOthersHandle() throws Exception {
+        // When dc.identifier.uri and dc.identifier.doi are missing, use others/handle
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-minimal-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:identifier/ccmm:value",
+            equalTo("http://hdl.handle.net/99999/test-1"))));
+    }
+
+    @Test
+    public void ccmmFallbackRepositoryNameIsUnknown() throws Exception {
+        // When repository/name is missing, fallback to "Unknown Repository"
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-minimal-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:metadata_identification/ccmm:qualified_relation/ccmm:relation/ccmm:organization/ccmm:name",
+            equalTo("Unknown Repository"))));
+    }
+
+    @Test
+    public void ccmmFallbackLicenseIsUnspecified() throws Exception {
+        // When dc.rights.uri is missing but dc.rights text exists, license IRI is unspecified
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-minimal-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:terms_of_use/ccmm:license/ccmm:iri",
+            equalTo("https://model.ccmm.cz/vocabulary/ccmm/license/unspecified"))));
+    }
+
     private XmlMatcherBuilder ccmm() {
         return xml()
             .withNamespace("ccmm", CCMM_NS);

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/CcmmXslTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/CcmmXslTest.java
@@ -1,0 +1,140 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.tests.stylesheets;
+
+import static org.dspace.xoai.tests.support.XmlMatcherBuilder.xml;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import org.dspace.xoai.tests.support.XmlMatcherBuilder;
+import org.junit.Test;
+
+/**
+ * Tests for the CCMM (Czech Common Metadata Model) 1.1.0 OAI-PMH crosswalk.
+ *
+ * @see <a href="https://github.com/techlib/CCMM">CCMM Schema</a>
+ * @see <a href="https://github.com/ufal/clarin-dspace/issues/1145">Issue #1145</a>
+ */
+public class CcmmXslTest extends AbstractXSLTest {
+
+    private static final String CCMM_NS = "https://schema.ccmm.cz/research-data/1.1";
+
+    @Test
+    public void ccmmCanTransformInput() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath("//ccmm:title", equalTo("Czech NLP Dataset v2.0"))));
+    }
+
+    @Test
+    public void ccmmContainsPublicationYear() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath("//ccmm:publication_year", equalTo("2025"))));
+    }
+
+    @Test
+    public void ccmmContainsIdentifier() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:identifier/ccmm:value",
+            equalTo("http://hdl.handle.net/11234/1-5678"))));
+    }
+
+    @Test
+    public void ccmmContainsCreator() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:qualified_relation[1]/ccmm:relation/ccmm:person/ccmm:name",
+            equalTo("Novak, Jan"))));
+    }
+
+    @Test
+    public void ccmmContainsSubjects() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:subject[1]/ccmm:title",
+            equalTo("linguistics"))));
+    }
+
+    @Test
+    public void ccmmContainsResourceType() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:resource_type/ccmm:label",
+            equalTo("corpus"))));
+    }
+
+    @Test
+    public void ccmmContainsDescription() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:description/ccmm:description_text",
+            equalTo("A sample dataset for testing CCMM crosswalk output in the OAI-PMH protocol."))));
+    }
+
+    @Test
+    public void ccmmContainsLicense() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:terms_of_use/ccmm:license/ccmm:iri",
+            equalTo("https://creativecommons.org/licenses/by/4.0/"))));
+    }
+
+    @Test
+    public void ccmmContainsAccessRights() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:terms_of_use/ccmm:access_rights/ccmm:iri",
+            equalTo("http://purl.org/coar/access_right/c_abf2"))));
+    }
+
+    @Test
+    public void ccmmContainsPrimaryLanguage() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:primary_language/ccmm:label",
+            equalTo("ces"))));
+    }
+
+    @Test
+    public void ccmmContainsAlternateTitle() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:alternate_title/ccmm:title",
+            equalTo("CND 2.0"))));
+    }
+
+    @Test
+    public void ccmmContainsPublisher() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:qualified_relation[ccmm:role/ccmm:label='Distributor']/ccmm:relation/ccmm:organization/ccmm:name",
+            equalTo("Charles University, Faculty of Mathematics and Physics, Institute of Formal and Applied Linguistics"))));
+    }
+
+    @Test
+    public void ccmmContainsMetadataIdentification() throws Exception {
+        String result = apply("ccmm.xsl").to(resource("xoai-ccmm-test.xml"));
+        assertThat(result, is(ccmm().withXPath(
+            "//ccmm:dataset/ccmm:metadata_identification/ccmm:conforms_to_standard/ccmm:iri",
+            equalTo("https://schema.ccmm.cz/research-data/1.1"))));
+    }
+
+    @Test
+    public void ccmmCanTransformBasicXoaiInput() throws Exception {
+        // Test with the default xoai-test1.xml (simpler data) to ensure crosswalk
+        // handles missing fields gracefully
+        String result = apply("ccmm.xsl").to(resource("xoai-test1.xml"));
+        assertThat(result, is(ccmm().withXPath("//ccmm:title", equalTo("Test Webpage"))));
+    }
+
+    private XmlMatcherBuilder ccmm() {
+        return xml()
+            .withNamespace("ccmm", CCMM_NS);
+    }
+}

--- a/dspace-oai/src/test/resources/xoai-ccmm-minimal-test.xml
+++ b/dspace-oai/src/test/resources/xoai-ccmm-minimal-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Minimal XOAI metadata XML for CCMM crosswalk fallback testing.
+    Missing most DC fields to trigger fallback behavior for required CCMM elements:
+      - title (missing -> "Untitled")
+      - publication_year (missing issued/accessioned -> "9999")
+      - subject (missing -> "unspecified")
+      - identifier (only others/handle available)
+      - repository name (missing -> "Unknown Repository")
+-->
+<metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+    <element name="dc">
+        <element name="rights">
+            <element name="none">
+                <field name="value">All rights reserved</field>
+            </element>
+        </element>
+    </element>
+    <element name="others">
+        <field name="handle">99999/test-1</field>
+        <field name="identifier">oai:test.repository:99999/test-1</field>
+        <field name="lastModifyDate">2025-01-01 00:00:00.000</field>
+    </element>
+</metadata>

--- a/dspace-oai/src/test/resources/xoai-ccmm-test.xml
+++ b/dspace-oai/src/test/resources/xoai-ccmm-test.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Test XOAI metadata XML for CCMM crosswalk testing.
+    Includes fields commonly found in NMD/NRP dataset submissions.
+-->
+<metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+    <element name="dc">
+        <element name="contributor">
+            <element name="author">
+                <element name="none">
+                    <field name="value">Novak, Jan</field>
+                    <field name="value">Svobodova, Marie</field>
+                </element>
+            </element>
+        </element>
+        <element name="date">
+            <element name="accessioned">
+                <element name="none">
+                    <field name="value">2025-06-15T10:30:00Z</field>
+                </element>
+            </element>
+            <element name="available">
+                <element name="none">
+                    <field name="value">2025-06-15T10:30:00Z</field>
+                </element>
+            </element>
+            <element name="issued">
+                <element name="none">
+                    <field name="value">2025-03-20</field>
+                </element>
+            </element>
+        </element>
+        <element name="identifier">
+            <element name="uri">
+                <element name="none">
+                    <field name="value">http://hdl.handle.net/11234/1-5678</field>
+                </element>
+            </element>
+        </element>
+        <element name="description">
+            <element name="abstract">
+                <element name="en">
+                    <field name="value">A sample dataset for testing CCMM crosswalk output in the OAI-PMH protocol.</field>
+                </element>
+            </element>
+        </element>
+        <element name="language">
+            <element name="iso">
+                <element name="none">
+                    <field name="value">ces</field>
+                </element>
+            </element>
+        </element>
+        <element name="publisher">
+            <element name="none">
+                <field name="value">Charles University, Faculty of Mathematics and Physics, Institute of Formal and Applied Linguistics</field>
+            </element>
+        </element>
+        <element name="rights">
+            <element name="none">
+                <field name="value">Creative Commons - Attribution 4.0 International</field>
+            </element>
+            <element name="uri">
+                <element name="none">
+                    <field name="value">https://creativecommons.org/licenses/by/4.0/</field>
+                </element>
+            </element>
+            <element name="label">
+                <element name="none">
+                    <field name="value">CC BY 4.0</field>
+                </element>
+            </element>
+        </element>
+        <element name="subject">
+            <element name="none">
+                <field name="value">linguistics</field>
+                <field name="value">Czech language</field>
+                <field name="value">NLP</field>
+            </element>
+        </element>
+        <element name="title">
+            <element name="none">
+                <field name="value">Czech NLP Dataset v2.0</field>
+            </element>
+            <element name="alternative">
+                <element name="none">
+                    <field name="value">CND 2.0</field>
+                </element>
+            </element>
+        </element>
+        <element name="type">
+            <element name="none">
+                <field name="value">corpus</field>
+            </element>
+        </element>
+    </element>
+    <element name="others">
+        <field name="handle">11234/1-5678</field>
+        <field name="identifier">oai:lindat.mff.cuni.cz:11234/1-5678</field>
+        <field name="lastModifyDate">2025-06-15 10:30:00.000</field>
+    </element>
+    <element name="repository">
+        <field name="name">LINDAT/CLARIAH-CZ</field>
+        <field name="mail">lindat-help@ufal.mff.cuni.cz</field>
+    </element>
+</metadata>

--- a/dspace/config/crosswalks/oai/metadataFormats/ccmm.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/ccmm.xsl
@@ -18,6 +18,15 @@
 
     <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
+    <!-- ============================================================ -->
+    <!-- Fallback constants: extracted for maintainability             -->
+    <!-- ============================================================ -->
+    <xsl:variable name="FALLBACK_REPOSITORY_NAME" select="'Unknown Repository'"/>
+    <xsl:variable name="FALLBACK_REPOSITORY_URL" select="'http://unknown.repository'"/>
+    <xsl:variable name="FALLBACK_TITLE" select="'Untitled'"/>
+    <xsl:variable name="FALLBACK_SUBJECT" select="'unspecified'"/>
+    <xsl:variable name="FALLBACK_PUBLICATION_YEAR" select="'9999'"/>
+
     <!-- Main template -->
     <xsl:template match="/">
         <ccmm:dataset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -88,7 +97,7 @@
                                 <xsl:when test="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']">
                                     <xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']"/>
                                 </xsl:when>
-                                <xsl:otherwise>Unknown Repository</xsl:otherwise>
+                                <xsl:otherwise><xsl:value-of select="$FALLBACK_REPOSITORY_NAME"/></xsl:otherwise>
                             </xsl:choose>
                         </ccmm:name>
                     </ccmm:organization>
@@ -109,7 +118,11 @@
                     <xsl:choose>
                         <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
                             <xsl:variable name="uri" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value'][1]"/>
-                            <!-- Extract base URL from handle URI -->
+                            <!--
+                                Extract repository base URL from Handle URI.
+                                Assumes DSpace-style URLs like https://repo.example.org/handle/123/456.
+                                Also handles hdl.handle.net URIs as-is.
+                            -->
                             <xsl:choose>
                                 <xsl:when test="contains($uri, '/handle/')">
                                     <xsl:value-of select="substring-before($uri, '/handle/')"/>
@@ -119,7 +132,7 @@
                                 </xsl:otherwise>
                             </xsl:choose>
                         </xsl:when>
-                        <xsl:otherwise>http://unknown.repository</xsl:otherwise>
+                        <xsl:otherwise><xsl:value-of select="$FALLBACK_REPOSITORY_URL"/></xsl:otherwise>
                     </xsl:choose>
                 </ccmm:iri>
                 <xsl:if test="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']">
@@ -169,8 +182,12 @@
                 </ccmm:identifier>
             </xsl:if>
         </xsl:for-each>
-        <!-- Fallback: if no identifiers found, use the handle from others section -->
-        <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='doi']/doc:element/doc:field[@name='value'])">
+        <!--
+            Fallback: use handle from 'others' section if no Handle or DOI
+            was found from dc.identifier.uri/doi. This covers cases where
+            dc.identifier.uri exists but contains non-Handle URIs.
+        -->
+        <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value'][contains(., 'hdl.handle.net') or contains(., '/handle/')]) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='doi']/doc:element/doc:field[@name='value'])">
             <xsl:if test="doc:metadata/doc:element[@name='others']/doc:field[@name='handle']">
                 <ccmm:identifier>
                     <ccmm:value>
@@ -205,7 +222,7 @@
                 <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
                     <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']"/>
                 </xsl:when>
-                <xsl:otherwise>Untitled</xsl:otherwise>
+                <xsl:otherwise><xsl:value-of select="$FALLBACK_TITLE"/></xsl:otherwise>
             </xsl:choose>
         </ccmm:title>
     </xsl:template>
@@ -284,7 +301,12 @@
                 </ccmm:role>
             </ccmm:qualified_relation>
         </xsl:for-each>
-        <!-- dc.publisher -> Publisher (organization) -->
+        <!--
+            dc.publisher mapped to Distributor role.
+            In CCMM/DataCite vocabulary, the DSpace publisher typically acts as
+            the distributing organization rather than the original publisher.
+            See https://model.ccmm.cz/vocabulary/datacite/contributorType/Distributor
+        -->
         <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
             <ccmm:qualified_relation>
                 <ccmm:relation>
@@ -312,7 +334,7 @@
                 <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']">
                     <xsl:value-of select="substring(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value'], 1, 4)"/>
                 </xsl:when>
-                <xsl:otherwise>9999</xsl:otherwise>
+                <xsl:otherwise><xsl:value-of select="$FALLBACK_PUBLICATION_YEAR"/></xsl:otherwise>
             </xsl:choose>
         </ccmm:publication_year>
     </xsl:template>
@@ -369,12 +391,16 @@
                 </ccmm:date_type>
             </ccmm:time_reference>
         </xsl:for-each>
-        <!-- Fallback: if no dates at all, create a minimal time_reference from accessioned -->
-        <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='available']/doc:element/doc:field[@name='value'])">
+        <!-- Fallback: if no issued/available dates, create a minimal time_reference from accessioned -->
+        <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='available']/doc:element/doc:field[@name='value']) and doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']">
+            <xsl:variable name="accessionedDate"
+                          select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value'][1]"/>
             <ccmm:time_reference>
                 <ccmm:temporal_representation>
                     <ccmm:time_instant>
-                        <ccmm:date>9999-01-01</ccmm:date>
+                        <xsl:call-template name="FormatDate">
+                            <xsl:with-param name="dateStr" select="$accessionedDate"/>
+                        </xsl:call-template>
                     </ccmm:time_instant>
                 </ccmm:temporal_representation>
                 <ccmm:date_type>
@@ -519,7 +545,7 @@
         <!-- Fallback: if no subjects, provide a placeholder -->
         <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value'])">
             <ccmm:subject>
-                <ccmm:title xml:lang="en">unspecified</ccmm:title>
+                <ccmm:title xml:lang="en"><xsl:value-of select="$FALLBACK_SUBJECT"/></ccmm:title>
             </ccmm:subject>
         </xsl:if>
     </xsl:template>
@@ -623,9 +649,17 @@
             <xsl:when test="string-length($dateStr) = 4">
                 <ccmm:date><xsl:value-of select="concat($dateStr, '-01-01')"/></ccmm:date>
             </xsl:when>
-            <!-- Fallback -->
+            <!-- Fallback: attempt to derive a date only if the first 4 chars form a valid year -->
             <xsl:otherwise>
-                <ccmm:date><xsl:value-of select="concat(substring($dateStr, 1, 4), '-01-01')"/></ccmm:date>
+                <xsl:variable name="year" select="substring($dateStr, 1, 4)"/>
+                <xsl:choose>
+                    <xsl:when test="string-length($dateStr) &gt;= 4 and not(translate($year, '0123456789', ''))">
+                        <ccmm:date><xsl:value-of select="concat($year, '-01-01')"/></ccmm:date>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <ccmm:date/>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/dspace/config/crosswalks/oai/metadataFormats/ccmm.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/ccmm.xsl
@@ -1,0 +1,633 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    CCMM (Czech Common Metadata Model) crosswalk for OAI-PMH export.
+    Produces CCMM 1.1.0 dataset XML from the XOAI internal DSpace metadata format.
+
+    CCMM schema: https://techlib.github.io/CCMM/dataset/schema.xsd
+    Namespace:   https://schema.ccmm.cz/research-data/1.1
+    metadataPrefix: ccmm-xml
+
+    See: https://github.com/techlib/CCMM
+         https://github.com/ufal/clarin-dspace/issues/1145
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:doc="http://www.lyncode.com/xoai"
+                xmlns:ccmm="https://schema.ccmm.cz/research-data/1.1"
+                exclude-result-prefixes="doc"
+                version="2.0">
+
+    <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
+
+    <!-- Main template -->
+    <xsl:template match="/">
+        <ccmm:dataset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="https://schema.ccmm.cz/research-data/1.1 https://techlib.github.io/CCMM/dataset/schema.xsd">
+
+            <!-- metadata_identification (required, unbounded) -->
+            <xsl:call-template name="MetadataIdentification"/>
+
+            <!-- identifier (required, unbounded) -->
+            <xsl:call-template name="Identifiers"/>
+
+            <!-- version (optional) -->
+            <xsl:call-template name="Version"/>
+
+            <!-- title (required) -->
+            <xsl:call-template name="Title"/>
+
+            <!-- alternate_title (optional, unbounded) -->
+            <xsl:call-template name="AlternateTitles"/>
+
+            <!-- qualified_relation (optional, unbounded) - creators, contributors -->
+            <xsl:call-template name="QualifiedRelations"/>
+
+            <!-- publication_year (required) -->
+            <xsl:call-template name="PublicationYear"/>
+
+            <!-- time_reference (required, unbounded) -->
+            <xsl:call-template name="TimeReferences"/>
+
+            <!-- resource_type (optional) -->
+            <xsl:call-template name="ResourceType"/>
+
+            <!-- primary_language (optional) -->
+            <xsl:call-template name="PrimaryLanguage"/>
+
+            <!-- other_language (optional, unbounded) -->
+            <xsl:call-template name="OtherLanguages"/>
+
+            <!-- terms_of_use (required) -->
+            <xsl:call-template name="TermsOfUse"/>
+
+            <!-- subject (required, unbounded) -->
+            <xsl:call-template name="Subjects"/>
+
+            <!-- description (optional, unbounded) -->
+            <xsl:call-template name="Descriptions"/>
+
+            <!-- funding_reference (optional, unbounded) -->
+            <xsl:call-template name="FundingReferences"/>
+
+            <!-- related_resource (optional, unbounded) -->
+            <xsl:call-template name="RelatedResources"/>
+
+        </ccmm:dataset>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- metadata_identification                                       -->
+    <!-- ============================================================ -->
+    <xsl:template name="MetadataIdentification">
+        <ccmm:metadata_identification>
+            <!-- qualified_relation for metadata record - use repository as curator -->
+            <ccmm:qualified_relation>
+                <ccmm:relation>
+                    <ccmm:organization>
+                        <ccmm:name>
+                            <xsl:choose>
+                                <xsl:when test="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']">
+                                    <xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']"/>
+                                </xsl:when>
+                                <xsl:otherwise>Unknown Repository</xsl:otherwise>
+                            </xsl:choose>
+                        </ccmm:name>
+                    </ccmm:organization>
+                </ccmm:relation>
+                <ccmm:role>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/contributorType/DataCurator</ccmm:iri>
+                    <ccmm:label xml:lang="en">DataCurator</ccmm:label>
+                </ccmm:role>
+            </ccmm:qualified_relation>
+            <!-- conforms_to_standard -->
+            <ccmm:conforms_to_standard>
+                <ccmm:iri>https://schema.ccmm.cz/research-data/1.1</ccmm:iri>
+                <ccmm:label xml:lang="en">CCMM 1.1</ccmm:label>
+            </ccmm:conforms_to_standard>
+            <!-- original_repository -->
+            <ccmm:original_repository>
+                <ccmm:iri>
+                    <xsl:choose>
+                        <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
+                            <xsl:variable name="uri" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value'][1]"/>
+                            <!-- Extract base URL from handle URI -->
+                            <xsl:choose>
+                                <xsl:when test="contains($uri, '/handle/')">
+                                    <xsl:value-of select="substring-before($uri, '/handle/')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="$uri"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:when>
+                        <xsl:otherwise>http://unknown.repository</xsl:otherwise>
+                    </xsl:choose>
+                </ccmm:iri>
+                <xsl:if test="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']">
+                    <ccmm:label xml:lang="en">
+                        <xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']"/>
+                    </ccmm:label>
+                </xsl:if>
+            </ccmm:original_repository>
+        </ccmm:metadata_identification>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- identifier                                                    -->
+    <!-- ============================================================ -->
+    <xsl:template name="Identifiers">
+        <!-- Handle identifier -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
+            <xsl:if test="contains(., 'hdl.handle.net') or contains(., '/handle/')">
+                <ccmm:identifier>
+                    <ccmm:value><xsl:value-of select="."/></ccmm:value>
+                    <ccmm:scheme>
+                        <ccmm:iri>https://hdl.handle.net/</ccmm:iri>
+                        <ccmm:label xml:lang="en">Handle</ccmm:label>
+                    </ccmm:scheme>
+                </ccmm:identifier>
+            </xsl:if>
+        </xsl:for-each>
+        <!-- DOI identifier -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='doi']/doc:element/doc:field[@name='value']">
+            <ccmm:identifier>
+                <ccmm:value><xsl:value-of select="."/></ccmm:value>
+                <ccmm:scheme>
+                    <ccmm:iri>https://doi.org/</ccmm:iri>
+                    <ccmm:label xml:lang="en">DOI</ccmm:label>
+                </ccmm:scheme>
+            </ccmm:identifier>
+        </xsl:for-each>
+        <!-- Other URI identifiers (non-handle) -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
+            <xsl:if test="not(contains(., 'hdl.handle.net')) and not(contains(., '/handle/'))">
+                <ccmm:identifier>
+                    <ccmm:value><xsl:value-of select="."/></ccmm:value>
+                    <ccmm:scheme>
+                        <ccmm:iri>https://www.w3.org/ns/iana/uri-schemes</ccmm:iri>
+                        <ccmm:label xml:lang="en">URI</ccmm:label>
+                    </ccmm:scheme>
+                </ccmm:identifier>
+            </xsl:if>
+        </xsl:for-each>
+        <!-- Fallback: if no identifiers found, use the handle from others section -->
+        <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='doi']/doc:element/doc:field[@name='value'])">
+            <xsl:if test="doc:metadata/doc:element[@name='others']/doc:field[@name='handle']">
+                <ccmm:identifier>
+                    <ccmm:value>
+                        <xsl:value-of select="concat('http://hdl.handle.net/', doc:metadata/doc:element[@name='others']/doc:field[@name='handle'])"/>
+                    </ccmm:value>
+                    <ccmm:scheme>
+                        <ccmm:iri>https://hdl.handle.net/</ccmm:iri>
+                        <ccmm:label xml:lang="en">Handle</ccmm:label>
+                    </ccmm:scheme>
+                </ccmm:identifier>
+            </xsl:if>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- version (optional)                                            -->
+    <!-- ============================================================ -->
+    <xsl:template name="Version">
+        <xsl:if test="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='version']/doc:element/doc:field[@name='value']">
+            <ccmm:version>
+                <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='version']/doc:element/doc:field[@name='value']"/>
+            </ccmm:version>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- title (required)                                              -->
+    <!-- ============================================================ -->
+    <xsl:template name="Title">
+        <ccmm:title>
+            <xsl:choose>
+                <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
+                    <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']"/>
+                </xsl:when>
+                <xsl:otherwise>Untitled</xsl:otherwise>
+            </xsl:choose>
+        </ccmm:title>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- alternate_title (optional)                                    -->
+    <!-- ============================================================ -->
+    <xsl:template name="AlternateTitles">
+        <!-- dc.title.alternative mapped to alternate_title -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element[@name='alternative']/doc:element/doc:field[@name='value']">
+            <ccmm:alternate_title>
+                <ccmm:title xml:lang="en">
+                    <xsl:value-of select="."/>
+                </ccmm:title>
+            </ccmm:alternate_title>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- qualified_relation (creators and contributors)                -->
+    <!-- ============================================================ -->
+    <xsl:template name="QualifiedRelations">
+        <!-- dc.contributor.author -> Creator role -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
+            <ccmm:qualified_relation>
+                <ccmm:relation>
+                    <ccmm:person>
+                        <ccmm:name><xsl:value-of select="."/></ccmm:name>
+                    </ccmm:person>
+                </ccmm:relation>
+                <ccmm:role>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/contributorType/Creator</ccmm:iri>
+                    <ccmm:label xml:lang="en">Creator</ccmm:label>
+                </ccmm:role>
+            </ccmm:qualified_relation>
+        </xsl:for-each>
+        <!-- dc.creator -> Creator role -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='creator']/doc:element/doc:field[@name='value']">
+            <ccmm:qualified_relation>
+                <ccmm:relation>
+                    <ccmm:person>
+                        <ccmm:name><xsl:value-of select="."/></ccmm:name>
+                    </ccmm:person>
+                </ccmm:relation>
+                <ccmm:role>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/contributorType/Creator</ccmm:iri>
+                    <ccmm:label xml:lang="en">Creator</ccmm:label>
+                </ccmm:role>
+            </ccmm:qualified_relation>
+        </xsl:for-each>
+        <!-- dc.contributor.editor -> Editor role -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='editor']/doc:element/doc:field[@name='value']">
+            <ccmm:qualified_relation>
+                <ccmm:relation>
+                    <ccmm:person>
+                        <ccmm:name><xsl:value-of select="."/></ccmm:name>
+                    </ccmm:person>
+                </ccmm:relation>
+                <ccmm:role>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/contributorType/Editor</ccmm:iri>
+                    <ccmm:label xml:lang="en">Editor</ccmm:label>
+                </ccmm:role>
+            </ccmm:qualified_relation>
+        </xsl:for-each>
+        <!-- dc.contributor.other -> Other role -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='other']/doc:element/doc:field[@name='value']">
+            <ccmm:qualified_relation>
+                <ccmm:relation>
+                    <ccmm:person>
+                        <ccmm:name><xsl:value-of select="."/></ccmm:name>
+                    </ccmm:person>
+                </ccmm:relation>
+                <ccmm:role>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/contributorType/Other</ccmm:iri>
+                    <ccmm:label xml:lang="en">Other</ccmm:label>
+                </ccmm:role>
+            </ccmm:qualified_relation>
+        </xsl:for-each>
+        <!-- dc.publisher -> Publisher (organization) -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
+            <ccmm:qualified_relation>
+                <ccmm:relation>
+                    <ccmm:organization>
+                        <ccmm:name><xsl:value-of select="."/></ccmm:name>
+                    </ccmm:organization>
+                </ccmm:relation>
+                <ccmm:role>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/contributorType/Distributor</ccmm:iri>
+                    <ccmm:label xml:lang="en">Distributor</ccmm:label>
+                </ccmm:role>
+            </ccmm:qualified_relation>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- publication_year (required)                                    -->
+    <!-- ============================================================ -->
+    <xsl:template name="PublicationYear">
+        <ccmm:publication_year>
+            <xsl:choose>
+                <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']">
+                    <xsl:value-of select="substring(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value'], 1, 4)"/>
+                </xsl:when>
+                <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']">
+                    <xsl:value-of select="substring(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value'], 1, 4)"/>
+                </xsl:when>
+                <xsl:otherwise>9999</xsl:otherwise>
+            </xsl:choose>
+        </ccmm:publication_year>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- time_reference (required, unbounded)                          -->
+    <!-- ============================================================ -->
+    <xsl:template name="TimeReferences">
+        <!-- dc.date.issued -> Issued -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']">
+            <ccmm:time_reference>
+                <ccmm:temporal_representation>
+                    <ccmm:time_instant>
+                        <xsl:call-template name="FormatDate">
+                            <xsl:with-param name="dateStr" select="."/>
+                        </xsl:call-template>
+                    </ccmm:time_instant>
+                </ccmm:temporal_representation>
+                <ccmm:date_type>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/dateType/Issued</ccmm:iri>
+                    <ccmm:label xml:lang="en">Issued</ccmm:label>
+                </ccmm:date_type>
+            </ccmm:time_reference>
+        </xsl:for-each>
+        <!-- dc.date.accessioned -> Accepted -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']">
+            <ccmm:time_reference>
+                <ccmm:temporal_representation>
+                    <ccmm:time_instant>
+                        <xsl:call-template name="FormatDate">
+                            <xsl:with-param name="dateStr" select="."/>
+                        </xsl:call-template>
+                    </ccmm:time_instant>
+                </ccmm:temporal_representation>
+                <ccmm:date_type>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/dateType/Accepted</ccmm:iri>
+                    <ccmm:label xml:lang="en">Accepted</ccmm:label>
+                </ccmm:date_type>
+            </ccmm:time_reference>
+        </xsl:for-each>
+        <!-- dc.date.available -> Available -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='available']/doc:element/doc:field[@name='value']">
+            <ccmm:time_reference>
+                <ccmm:temporal_representation>
+                    <ccmm:time_instant>
+                        <xsl:call-template name="FormatDate">
+                            <xsl:with-param name="dateStr" select="."/>
+                        </xsl:call-template>
+                    </ccmm:time_instant>
+                </ccmm:temporal_representation>
+                <ccmm:date_type>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/dateType/Available</ccmm:iri>
+                    <ccmm:label xml:lang="en">Available</ccmm:label>
+                </ccmm:date_type>
+            </ccmm:time_reference>
+        </xsl:for-each>
+        <!-- Fallback: if no dates at all, create a minimal time_reference from accessioned -->
+        <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='available']/doc:element/doc:field[@name='value'])">
+            <ccmm:time_reference>
+                <ccmm:temporal_representation>
+                    <ccmm:time_instant>
+                        <ccmm:date>9999-01-01</ccmm:date>
+                    </ccmm:time_instant>
+                </ccmm:temporal_representation>
+                <ccmm:date_type>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/dateType/Issued</ccmm:iri>
+                    <ccmm:label xml:lang="en">Issued</ccmm:label>
+                </ccmm:date_type>
+            </ccmm:time_reference>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- resource_type (optional)                                      -->
+    <!-- ============================================================ -->
+    <xsl:template name="ResourceType">
+        <xsl:variable name="dctype" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field[@name='value']"/>
+        <xsl:if test="$dctype">
+            <ccmm:resource_type>
+                <ccmm:iri>
+                    <xsl:choose>
+                        <xsl:when test="$dctype='Dataset' or $dctype='corpus' or $dctype='lexicalConceptualResource' or $dctype='languageDescription'">https://model.ccmm.cz/vocabulary/datacite/resourceTypeGeneral/Dataset</xsl:when>
+                        <xsl:when test="$dctype='Software' or $dctype='toolService'">https://model.ccmm.cz/vocabulary/datacite/resourceTypeGeneral/Software</xsl:when>
+                        <xsl:when test="$dctype='Text' or $dctype='text'">https://model.ccmm.cz/vocabulary/datacite/resourceTypeGeneral/Text</xsl:when>
+                        <xsl:when test="$dctype='Image' or $dctype='image'">https://model.ccmm.cz/vocabulary/datacite/resourceTypeGeneral/Image</xsl:when>
+                        <xsl:when test="$dctype='Collection'">https://model.ccmm.cz/vocabulary/datacite/resourceTypeGeneral/Collection</xsl:when>
+                        <xsl:otherwise>https://model.ccmm.cz/vocabulary/datacite/resourceTypeGeneral/Other</xsl:otherwise>
+                    </xsl:choose>
+                </ccmm:iri>
+                <ccmm:label xml:lang="en"><xsl:value-of select="$dctype"/></ccmm:label>
+            </ccmm:resource_type>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- primary_language (optional)                                    -->
+    <!-- ============================================================ -->
+    <xsl:template name="PrimaryLanguage">
+        <xsl:variable name="lang" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element[@name='iso']/doc:element/doc:field[@name='value']"/>
+        <xsl:variable name="langAlt" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:field[@name='value']"/>
+        <xsl:choose>
+            <xsl:when test="$lang">
+                <ccmm:primary_language>
+                    <ccmm:iri>
+                        <xsl:value-of select="concat('https://iso639-3.sil.org/code/', $lang)"/>
+                    </ccmm:iri>
+                    <ccmm:label xml:lang="en"><xsl:value-of select="$lang"/></ccmm:label>
+                </ccmm:primary_language>
+            </xsl:when>
+            <xsl:when test="$langAlt">
+                <ccmm:primary_language>
+                    <ccmm:iri>
+                        <xsl:value-of select="concat('https://iso639-3.sil.org/code/', $langAlt)"/>
+                    </ccmm:iri>
+                    <ccmm:label xml:lang="en"><xsl:value-of select="$langAlt"/></ccmm:label>
+                </ccmm:primary_language>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- other_language (optional)                                     -->
+    <!-- ============================================================ -->
+    <xsl:template name="OtherLanguages">
+        <!-- If there are multiple language values, the first one becomes primary, rest become other -->
+        <xsl:variable name="langs" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element[@name='iso']/doc:element/doc:field[@name='value']"/>
+        <xsl:for-each select="$langs[position() > 1]">
+            <ccmm:other_language>
+                <ccmm:iri>
+                    <xsl:value-of select="concat('https://iso639-3.sil.org/code/', .)"/>
+                </ccmm:iri>
+                <ccmm:label xml:lang="en"><xsl:value-of select="."/></ccmm:label>
+            </ccmm:other_language>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- terms_of_use (required)                                       -->
+    <!-- ============================================================ -->
+    <xsl:template name="TermsOfUse">
+        <ccmm:terms_of_use>
+            <!-- access_rights -->
+            <ccmm:access_rights>
+                <xsl:choose>
+                    <xsl:when test="doc:metadata/doc:element[@name='local']/doc:element[@name='embargo']/doc:element[@name='termslift']/doc:element/doc:field[@name='value']">
+                        <ccmm:iri>http://purl.org/coar/access_right/c_f1cf</ccmm:iri>
+                        <ccmm:label xml:lang="en">embargoed access</ccmm:label>
+                    </xsl:when>
+                    <xsl:when test="doc:metadata/doc:element[@name='others']/doc:field[@name='restrictedAccess']/text()='true'">
+                        <ccmm:iri>http://purl.org/coar/access_right/c_16ec</ccmm:iri>
+                        <ccmm:label xml:lang="en">restricted access</ccmm:label>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <ccmm:iri>http://purl.org/coar/access_right/c_abf2</ccmm:iri>
+                        <ccmm:label xml:lang="en">open access</ccmm:label>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </ccmm:access_rights>
+            <!-- license -->
+            <ccmm:license>
+                <xsl:choose>
+                    <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
+                        <ccmm:iri>
+                            <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element[@name='uri']/doc:element/doc:field[@name='value']"/>
+                        </ccmm:iri>
+                        <xsl:if test="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element[@name='label']/doc:element/doc:field[@name='value']">
+                            <ccmm:label xml:lang="en">
+                                <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element[@name='label']/doc:element/doc:field[@name='value']"/>
+                            </ccmm:label>
+                        </xsl:if>
+                    </xsl:when>
+                    <xsl:when test="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']">
+                        <!-- Use the rights text itself as a fallback label -->
+                        <ccmm:iri>https://model.ccmm.cz/vocabulary/ccmm/license/unspecified</ccmm:iri>
+                        <ccmm:label xml:lang="en">
+                            <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']"/>
+                        </ccmm:label>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <ccmm:iri>https://model.ccmm.cz/vocabulary/ccmm/license/unspecified</ccmm:iri>
+                        <ccmm:label xml:lang="en">unspecified</ccmm:label>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </ccmm:license>
+        </ccmm:terms_of_use>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- subject (required, unbounded)                                 -->
+    <!-- ============================================================ -->
+    <xsl:template name="Subjects">
+        <!-- dc.subject -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:field[@name='value']">
+            <ccmm:subject>
+                <ccmm:title xml:lang="en"><xsl:value-of select="."/></ccmm:title>
+            </ccmm:subject>
+        </xsl:for-each>
+        <!-- dc.subject.* (nested qualifiers) -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value']">
+            <ccmm:subject>
+                <ccmm:title xml:lang="en"><xsl:value-of select="."/></ccmm:title>
+            </ccmm:subject>
+        </xsl:for-each>
+        <!-- Fallback: if no subjects, provide a placeholder -->
+        <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:field[@name='value']) and not(doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value'])">
+            <ccmm:subject>
+                <ccmm:title xml:lang="en">unspecified</ccmm:title>
+            </ccmm:subject>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- description (optional, unbounded)                             -->
+    <!-- ============================================================ -->
+    <xsl:template name="Descriptions">
+        <!-- dc.description (abstract) -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='abstract']/doc:element/doc:field[@name='value']">
+            <ccmm:description>
+                <ccmm:description_text xml:lang="en"><xsl:value-of select="."/></ccmm:description_text>
+                <ccmm:description_type>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/descriptionType/Abstract</ccmm:iri>
+                    <ccmm:label xml:lang="en">Abstract</ccmm:label>
+                </ccmm:description_type>
+            </ccmm:description>
+        </xsl:for-each>
+        <!-- dc.description (general, non-qualified) -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element/doc:field[@name='value']">
+            <ccmm:description>
+                <ccmm:description_text xml:lang="en"><xsl:value-of select="."/></ccmm:description_text>
+                <ccmm:description_type>
+                    <ccmm:iri>https://model.ccmm.cz/vocabulary/datacite/descriptionType/Abstract</ccmm:iri>
+                    <ccmm:label xml:lang="en">Abstract</ccmm:label>
+                </ccmm:description_type>
+            </ccmm:description>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- funding_reference (optional, unbounded)                       -->
+    <!-- ============================================================ -->
+    <xsl:template name="FundingReferences">
+        <!-- dc.relation with info:eu-repo/grantAgreement pattern -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:field[@name='value']">
+            <xsl:if test="starts-with(., 'info:')">
+                <xsl:variable name="parts" select="tokenize(., '/')"/>
+                <ccmm:funding_reference>
+                    <xsl:if test="count($parts) >= 5">
+                        <ccmm:local_identifier><xsl:value-of select="$parts[5]"/></ccmm:local_identifier>
+                    </xsl:if>
+                    <ccmm:funder>
+                        <ccmm:organization>
+                            <ccmm:name>
+                                <xsl:choose>
+                                    <xsl:when test="$parts[3]='EC'">European Commission</xsl:when>
+                                    <xsl:otherwise><xsl:value-of select="$parts[3]"/></xsl:otherwise>
+                                </xsl:choose>
+                            </ccmm:name>
+                        </ccmm:organization>
+                    </ccmm:funder>
+                </ccmm:funding_reference>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- related_resource (optional, unbounded)                        -->
+    <!-- ============================================================ -->
+    <xsl:template name="RelatedResources">
+        <!-- dc.relation.uri -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
+            <ccmm:related_resource>
+                <ccmm:identifier>
+                    <ccmm:value><xsl:value-of select="."/></ccmm:value>
+                    <ccmm:scheme>
+                        <ccmm:iri>https://www.w3.org/ns/iana/uri-schemes</ccmm:iri>
+                        <ccmm:label xml:lang="en">URI</ccmm:label>
+                    </ccmm:scheme>
+                </ccmm:identifier>
+            </ccmm:related_resource>
+        </xsl:for-each>
+        <!-- dc.relation.ispartof -->
+        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element[@name='ispartof']/doc:element/doc:field[@name='value']">
+            <ccmm:related_resource>
+                <ccmm:title><xsl:value-of select="."/></ccmm:title>
+            </ccmm:related_resource>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- ============================================================ -->
+    <!-- Helper: Format a date string to xs:date or xs:dateTime        -->
+    <!-- ============================================================ -->
+    <xsl:template name="FormatDate">
+        <xsl:param name="dateStr"/>
+        <xsl:choose>
+            <!-- Full ISO dateTime: 2024-01-15T10:30:00Z -->
+            <xsl:when test="contains($dateStr, 'T')">
+                <ccmm:date_time><xsl:value-of select="$dateStr"/></ccmm:date_time>
+            </xsl:when>
+            <!-- Full date: 2024-01-15 -->
+            <xsl:when test="string-length($dateStr) >= 10 and substring($dateStr, 5, 1) = '-' and substring($dateStr, 8, 1) = '-'">
+                <ccmm:date><xsl:value-of select="substring($dateStr, 1, 10)"/></ccmm:date>
+            </xsl:when>
+            <!-- Year-month: 2024-01 -->
+            <xsl:when test="string-length($dateStr) >= 7 and substring($dateStr, 5, 1) = '-'">
+                <ccmm:date><xsl:value-of select="concat($dateStr, '-01')"/></ccmm:date>
+            </xsl:when>
+            <!-- Year only: 2024 -->
+            <xsl:when test="string-length($dateStr) = 4">
+                <ccmm:date><xsl:value-of select="concat($dateStr, '-01-01')"/></ccmm:date>
+            </xsl:when>
+            <!-- Fallback -->
+            <xsl:otherwise>
+                <ccmm:date><xsl:value-of select="concat(substring($dateStr, 1, 4), '-01-01')"/></ccmm:date>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -24,6 +24,7 @@
             <Format ref="uketd_dc"/>
             <Format ref="bibtex" />
             <Format ref="elg" />
+            <Format ref="ccmm" />
             <!--<Format ref="junii2" />-->
             <Description>
                 This is the default context of the DSpace OAI-PMH data provider.
@@ -102,6 +103,7 @@
             <Set ref="openaireDataSet"/>
             <Format ref="oaidc"/>
             <Format ref="oai_datacite"/>
+            <Format ref="ccmm"/>
             <Description>
                 This context exports items following the openaire data archive rules.
             </Description>
@@ -238,6 +240,16 @@
         <SchemaLocation>http://w3id.org/meta-share/meta-share/ ../Schema/ELG-SHARE.xsd</SchemaLocation>
         <Filter ref="elgFilter"/>
     </Format>
+        <!-- CCMM (Czech Common Metadata Model) 1.1.0 for NMD/NRP
+             https://github.com/techlib/CCMM
+             https://github.com/techlib/CCMM/issues/61 - metadataPrefix: ccmm-xml
+        -->
+        <Format id="ccmm">
+            <Prefix>ccmm-xml</Prefix>
+            <XSLT>metadataFormats/ccmm.xsl</XSLT>
+            <Namespace>https://schema.ccmm.cz/research-data/1.1</Namespace>
+            <SchemaLocation>https://techlib.github.io/CCMM/dataset/schema.xsd</SchemaLocation>
+        </Format>
     </Formats>
 
     <Transformers>


### PR DESCRIPTION
## Problem description
**Add CCMM 1.1.0 OAI-PMH crosswalk**

Implements export of metadata in [CCMM (Czech Common Metadata Model) 1.1.0](https://github.com/techlib/CCMM/releases/tag/1.1.0) format over OAI-PMH, as required for NMD/NRP compliance.

**Changes:**
- New XSL crosswalk (`ccmm.xsl`) mapping DSpace metadata to CCMM dataset XML (`metadataPrefix: ccmm-xml`)
- Registered in `xoai.xml` (Default Context + openaire_data Context)
- 14 unit tests + test data

**Metadata mapping:** title, identifiers (Handle/DOI), creators/contributors, publisher, publication year, dates, resource type, language, rights/license, subjects, descriptions, funding references, related resources, metadata identification with repository info.

Resolves: ufal/clarin-dspace#1145

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot