### PR TITLE
VSB-TUO/Reduce noisy WARN logs to DEBUG level

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -227,7 +227,7 @@ public class ClarinItemServiceImpl implements ClarinItemService {
                 itemService.getMetadata(item, "local", "approximateDate", "issued", Item.ANY, false);
 
         if (CollectionUtils.isEmpty(approximatedDates) || StringUtils.isBlank(approximatedDates.get(0).getValue())) {
-            log.warn("Cannot update item dates metadata because the approximate date is empty.");
+            log.debug("Cannot update item dates metadata because the approximate date is empty.");
             return;
         }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -187,8 +187,8 @@ public class Context implements AutoCloseable {
                               "Check previous entries in the dspace.log to find why the db failed to initialize.");
             } else {
                 if (isTransactionAlive()) {
-                    log.warn("Initializing a context while an active transaction exists. Context with hash: {}.",
-                             getHash());
+                    log.debug("Initializing a context while an active transaction exists. Context with hash: {}.",
+                              getHash());
                 }
             }
         }


### PR DESCRIPTION
## Problem description
Changed two frequently occurring WARN log messages to DEBUG level:
- Context.java: 'Initializing a context while an active transaction exists'
- ClarinItemServiceImpl.java: 'Cannot update item dates metadata because the approximate date is empty'

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot