### PR TITLE
ZCU-DATA/Reduce noisy WARN logs to DEBUG level

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -245,6 +245,7 @@ public class ClarinItemServiceImpl implements ClarinItemService {
                 itemService.getMetadata(item, "local", "approximateDate", "issued", Item.ANY, false);
 
         if (CollectionUtils.isEmpty(approximatedDates) || StringUtils.isBlank(approximatedDates.get(0).getValue())) {
+            log.debug("Cannot update item dates metadata because the approximate date is empty.");
             return null;
         }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -181,6 +181,11 @@ public class Context implements AutoCloseable {
             if (dbConnection == null) {
                 log.fatal("Cannot obtain the bean which provides a database connection. " +
                               "Check previous entries in the dspace.log to find why the db failed to initialize.");
+            } else {
+                if (isTransactionAlive()) {
+                    log.debug("Initializing a context while an active transaction exists. Context with hash: {}.",
+                              getHash());
+                }
             }
         }
 


### PR DESCRIPTION
Cherry-pick of PR #1263 into customer/zcu-data.

## Problem description

Changed two frequently occurring WARN log messages to DEBUG level:

- Context.java: 'Initializing a context while an active transaction exists'
- ClarinItemServiceImpl.java: 'Cannot update item dates metadata because the approximate date is empty'

Original PR: https://github.com/dataquest-dev/DSpace/pull/1263