### PR TITLE
MENDELU/Reduce noisy WARN logs to DEBUG level

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -181,6 +181,11 @@ public class Context implements AutoCloseable {
             if (dbConnection == null) {
                 log.fatal("Cannot obtain the bean which provides a database connection. " +
                               "Check previous entries in the dspace.log to find why the db failed to initialize.");
+            } else {
+                if (isTransactionAlive()) {
+                    log.debug("Initializing a context while an active transaction exists. Context with hash: {}.",
+                              getHash());
+                }
             }
         }
 


### PR DESCRIPTION
Cherry-pick of PR #1263 into customer/mendelu.

## Problem description

Changed one frequently occurring WARN log message to DEBUG level:

- Context.java: 'Initializing a context while an active transaction exists'

Note: ClarinItemServiceImpl.java does not exist in this branch, so only Context.java change is applied.

Original PR: https://github.com/dataquest-dev/DSpace/pull/1263