### PR TITLE
TUL/Reduce noisy WARN logs to DEBUG level

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -176,11 +176,16 @@ public class Context implements AutoCloseable {
             if (dbConnection == null) {
                 log.fatal("Cannot obtain the bean which provides a database connection. " +
                               "Check previous entries in the dspace.log to find why the db failed to initialize.");
-            }
-        }
-
-        currentUser = null;
-        currentLocale = I18nUtil.getDefaultLocale();
+<<<<<<< HEAD
+=======
+            } else {
+                if (isTransactionAlive()) {
+                    log.debug("Initializing a context while an active transaction exists. Context with hash: {}.",
+            } else {
+                if (isTransactionAlive()) {
+                    log.debug("Initializing a context while an active transaction exists. Context with hash: {}.",
+                              getHash());
+                }
         extraLogInfo = "";
         ignoreAuth = false;
 


### PR DESCRIPTION
Cherry-pick of PR #1263 into customer/TUL.

## Problem description

Changed one frequently occurring WARN log message to DEBUG level:

- Context.java: 'Initializing a context while an active transaction exists'

Note: ClarinItemServiceImpl.java has a minimal version in this branch without the relevant method, so only Context.java change is applied.

Original PR: https://github.com/dataquest-dev/DSpace/pull/1263