### PR TITLE
MENDELU/Reduce warn logs noise - 404 dedicated logger

### DIFF
--- a/dspace-api/src/test/java/org/dspace/workflow/WorkflowCurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/workflow/WorkflowCurationIT.java
@@ -22,6 +22,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.LegacyPluginServiceImpl;
 import org.dspace.ctask.testing.MarkerTask;
 import org.dspace.eperson.EPerson;
 import org.dspace.util.DSpaceConfigurationInitializer;
@@ -29,6 +30,7 @@ import org.dspace.util.DSpaceKernelInitializer;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -46,6 +48,8 @@ public class WorkflowCurationIT
         extends AbstractIntegrationTestWithDatabase {
     @Inject
     private ItemService itemService;
+    @Autowired
+    private LegacyPluginServiceImpl legacyPluginService;
 
     /**
      * Basic smoke test of a curation task attached to a workflow step.
@@ -56,6 +60,11 @@ public class WorkflowCurationIT
     public void curationTest()
             throws Exception {
         context.turnOffAuthorisationSystem();
+
+        // Reset the named plugin cache to avoid pollution from other tests
+        // (e.g. CreateMissingIdentifiersIT) that may have run before this one.
+        // See https://github.com/DSpace/DSpace/issues/8533
+        legacyPluginService.clearNamedPluginClasses();
 
         //** GIVEN **
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -62,6 +62,14 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     private static final Logger log = LogManager.getLogger();
 
     /**
+     * Dedicated logger for 404 NOT_FOUND responses. Configured at OFF level by default
+     * so that expected 404s don't flood production logs.
+     * Set to WARN in log4j2.xml to see 404 responses in logs.
+     */
+    private static final Logger notFoundLog =
+            LogManager.getLogger("org.dspace.app.rest.exception.DSpaceApiExceptionControllerAdvice.NotFound");
+
+    /**
      * Default collection of HTTP error codes to log as ERROR with full stack trace.
      */
     private static final String[] LOG_AS_ERROR_DEFAULT = { "422" };
@@ -277,7 +285,6 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
             // Log the full error and status code
             log.error("{} (status:{})", message, statusCode, ex);
         } else if (HttpStatus.valueOf(statusCode).is4xxClientError()) {
-            // Log the error as a single-line WARN
             String location;
             String exceptionMessage;
             if (null == ex) {
@@ -288,12 +295,27 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                 StackTraceElement[] trace = ex.getStackTrace();
                 location = trace.length <= 0 ? "unknown" : trace[0].toString();
             }
-            log.warn("{} (status:{} exception: {} at: {})", message, statusCode,
-                    exceptionMessage, location);
+            logClientError(statusCode, message, exceptionMessage, location);
         }
 
         //Exception properties will be set by org.springframework.boot.web.support.ErrorPageFilter
         response.sendError(statusCode, message);
+    }
+
+    /**
+     * Log a 4xx client error. 404 NOT_FOUND is sent to a dedicated logger ({@link #notFoundLog})
+     * at WARN level, but the logger is set to OFF by default in log4j2.xml (suppressed).
+     * Set logger to WARN in log4j2.xml to see 404 responses in logs.
+     */
+    private void logClientError(int statusCode, String message,
+                                String exceptionMessage, String location) {
+        if (statusCode == HttpServletResponse.SC_NOT_FOUND) {
+            notFoundLog.warn("{} (status:{} exception: {} at: {})",
+                    message, statusCode, exceptionMessage, location);
+        } else {
+            log.warn("{} (status:{} exception: {} at: {})",
+                    message, statusCode, exceptionMessage, location);
+        }
     }
 
 }

--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -88,6 +88,13 @@
             <AppenderRef ref='A1'/>
         </Logger>
 
+        <!-- NotFound logger for 404 responses - set to WARN to enable 404 logging -->
+        <Logger name='org.dspace.app.rest.exception.DSpaceApiExceptionControllerAdvice.NotFound'
+                level='OFF'
+                additivity='false'>
+            <AppenderRef ref='A1'/>
+        </Logger>
+
         <!-- Block services logging except on exceptions -->
         <Logger name='org.dspace.kernel'
                 level='ERROR'/>


### PR DESCRIPTION
Cherry-pick of commits 1dc5339 and db67645 into customer/mendelu.

## Problem description

- Log 404 responses via dedicated Log4j2 logger (org.dspace.app.rest.exception.DSpaceApiExceptionControllerAdvice.NotFound) set to OFF by default
- Extract getStatusCodesLoggedAsErrors() and logClientError() helper methods
- Add sendErrorResponseFromException() for 4xx errors
- Fix row length to be less than 120 chars

Original commits:
- https://github.com/dataquest-dev/DSpace/commit/1dc5339b785c5710aef2bfe57952f20ae1768724
- https://github.com/dataquest-dev/DSpace/commit/db676459229010c1c6e2be8468134c31ef8ab11b