### PR TITLE
mendelu/Docker build fails with permission denied when creating /install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
-# Run as root to create /install (base image may default to non-root dspace user)
+# Run as root to create /install
 USER root
 RUN mkdir /install \
     && chown -Rv dspace: /install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
+# Run as root to create /install (base image may default to non-root dspace user)
+USER root
 RUN mkdir /install \
     && chown -Rv dspace: /install \
     && chown -Rv dspace: /app


### PR DESCRIPTION
## Problem
During the Docker build process, the following error occurs:
```
mkdir: cannot create directory ‘/install’: Permission denied
```
This happens in the build stage when running:
```
RUN mkdir /install \
    && chown -Rv dspace: /install \
    && chown -Rv dspace: /app
```

## Root Cause

The base image dspace/dspace-dependencies:dspace-9_x now runs as a non-root user (dspace) by default.
Because of this change, the container no longer has permission to create directories in the root filesystem (/), which causes the build to fail when attempting to create /install.

## Fix

The issue was resolved by explicitly switching to the root user before creating the directory:
```
USER root
RUN mkdir /install \
    && chown -Rv dspace: /install \
    && chown -Rv dspace: /app
USER dspace
```
This allows the directory to be created with sufficient permissions, after which ownership is assigned back to the dspace user and the build continues securely as a non-root user.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot