### PR TITLE
TUL/Add warn.log appender (A4) with gzip rotation

### DIFF
--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -48,6 +48,21 @@
                 <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
             </policies>
         </Appender>
+
+        <!-- A4 is for Warns and errors -->
+        <Appender name='A4'
+                  filePattern="${log.dir}/warn.log-%d{yyyy-MM-dd}.gz"
+                  type='RollingFile'
+                  fileName='${log.dir}/warn.log'
+        >
+            <!-- NOTE: The %equals patterns are providing a default value of "unknown" if "correlationID" or
+                 "requestID" are not currently set in the ThreadContext. -->
+            <Layout type='PatternLayout'
+                    pattern='%d %-5p %equals{%X{correlationID}}{}{unknown} %equals{%X{requestID}}{}{unknown} %c @ %m%n'/>
+            <policies>
+                <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
+            </policies>
+        </Appender>
     </Appenders>
 
     <Loggers>
@@ -57,6 +72,7 @@
                 level='${loglevel.dspace}'
                 additivity='false'>
             <AppenderRef ref='A1'/>
+            <AppenderRef ref="A4" level="WARN"/>
         </Logger>
 
         <!-- The checksum checker -->
@@ -91,6 +107,7 @@
         <!-- Anything not a part of DSpace -->
         <Root level='${loglevel.other}'>
             <AppenderRef ref='A1'/>
+            <AppenderRef ref="A4" level="WARN"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## Problem description
Added A4 appender for warn.log with daily gzip rotation to match configuration from other customer branches. Added AppenderRef at WARN level to DSpace logger and Root.

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot