### PR TITLE
ZCU-DATA/Reduce ClarinItemServiceImpl approximate date log from WARN to DEBUG

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -220,7 +220,7 @@ public class ClarinItemServiceImpl implements ClarinItemService {
 
         String derivedDate = deriveDateIssuedFromApproximateDate(item);
         if (derivedDate == null) {
-            log.warn("Cannot update item dates metadata because the approximate date is empty.");
+            log.debug("Cannot update item dates metadata because the approximate date is empty.");
             return;
         }
 


### PR DESCRIPTION
## Problem description
Changed 'Cannot update item dates metadata because the approximate date is empty' from WARN to DEBUG level to reduce log noise.

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot