### PR TITLE
MENDELU/fix: unvalid openaire4 OAI-PMH endpoint

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
@@ -10,6 +10,7 @@ package org.dspace.xoai.util;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,12 +35,8 @@ public class DateUtils {
      * @return UTC date string
      */
     public static String format(Instant date) {
-        // NOTE: OAI-PMH REQUIRES that all dates be expressed in UTC format
-        // as YYYY-MM-DDThh:mm:ssZ  For more details, see
-        // http://www.openarchives.org/OAI/openarchivesprotocol.html#DatestampsResponses
-
-        // toString returns the correct format
-        return date.toString();
+        Instant truncated = date.truncatedTo(ChronoUnit.SECONDS);
+        return DateTimeFormatter.ISO_INSTANT.format(truncated);
     }
 
     /**

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -87,6 +87,7 @@
             <!-- Openaire filter -->
             <Filter ref="openaire4Filter"/>
             <!-- Metadata Formats -->
+            <Format ref="oaidc"/>
             <Format ref="oaiopenaire"/>
             <Description>
                 This contexts complies with Openaire Guidelines for Literature Repositories v4.0.


### PR DESCRIPTION
## Problem description
DSpace 9.1 fails OAI-PMH validation at Open Archives (openarchives.org) with:

> `FAIL Bad responseDate of 2025-08-02T21:13:43.801369Z, the date is a UTC DateTime but includes decimal seconds which are not allowed by the specification, must be YYYY-MM-DDThh:mm:ssZ format.`

Root cause: `DateUtils.format(Instant)` calls `Instant.toString()` which includes nanoseconds when they are non-zero. The OAI-PMH spec requires `YYYY-MM-DDThh:mm:ssZ` without fractional seconds.

Additionally, the `openaire4` context in `xoai.xml` is missing the `oai_dc` metadata format, which is the only format required by the OAI-PMH spec for every endpoint.

## Changes

1. **`DateUtils.format(Instant)`** — truncate to seconds and format via `DateTimeFormatter.ISO_INSTANT` instead of `Instant.toString()` (port of [DSpace#11438](https://github.com/DSpace/DSpace/pull/11438))
2. **`DateUtilsTest`** — unit test verifying nanoseconds are stripped
3. **`xoai.xml`** — add `<Format ref="oaidc"/>` to the `openaire4` context

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot