### PR TITLE
[Port to dtq-dev] Issue 1339: fixed NPE when hidden item metadata are checked for the item with deleted submitter

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
@@ -21,6 +21,7 @@ import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -117,10 +118,12 @@ public class MetadataExposureServiceImpl implements MetadataExposureService {
         }
 
         // The user is not administrator, but he could be a submitter
-        if (hidden && Objects.nonNull(context) && Objects.nonNull(item) &&
-                this.submitterShouldSee(schema, element, qualifier)) {
-            // the submitters override
-            hidden = !item.getSubmitter().equals(context.getCurrentUser());
+        if (hidden && Objects.nonNull(context) && Objects.nonNull(item)) {
+            EPerson submitter = item.getSubmitter();
+            if (Objects.nonNull(submitter) && this.submitterShouldSee(schema, element, qualifier)) {
+                // the submitters override
+                hidden = !submitter.equals(context.getCurrentUser());
+            }
         }
 
         return hidden;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -5102,6 +5102,19 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
                 .andExpect(jsonPath("$", existNoteLocalMetadataMatcher))
                 .andExpect(jsonPath("$", existDescriptionProvenanceMetadataMatcher));
+
+        // After the submitter is deleted, the response for the request made using the previously issued submitter
+        // token (which now authenticates as anonymous) should not contain
+        // `local.submission.note` and `dc.description.provenance` metadata
+        context.turnOffAuthorisationSystem();
+        EPersonBuilder.deleteEPerson(submitter.getID());
+        context.restoreAuthSystemState();
+
+        getClient(submitterToken).perform(get("/api/core/items/" + publicItem.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
+                .andExpect(jsonPath("$", notExistNoteLocalMetadataMatcher))
+                .andExpect(jsonPath("$", notExistDescriptionProvenanceMetadataMatcher));
     }
 
     /**


### PR DESCRIPTION
Port of ufal/clarin-dspace#1344 by @kuchtiak-ufal to `dtq-dev`.