### PR TITLE
[Port to dtq-dev] fix failing Curation tests (ufal/clarin-dspace#1353)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/iiif/consumer/IIIFCacheEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/consumer/IIIFCacheEventConsumer.java
@@ -124,6 +124,10 @@ public class IIIFCacheEventConsumer implements Consumer {
     }
 
     private void addToCacheEviction(DSpaceObject subject, DSpaceObject subject2, int type) {
+        if (subject == null) {
+            log.warn("IIIF event consumer cannot evict from cache when subject is null.");
+            return;
+        }
         if (type == Constants.BITSTREAM) {
             toEvictFromCanvasCache.add(subject2);
         }

--- a/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
@@ -32,6 +32,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.identifier.factory.IdentifierServiceFactory;
 import org.dspace.identifier.service.IdentifierService;
 import org.dspace.services.ConfigurationService;
@@ -80,6 +81,7 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
         try {
             //we have to create a new community in the database
             context.turnOffAuthorisationSystem();

--- a/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
@@ -29,6 +29,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.identifier.factory.IdentifierServiceFactory;
 import org.dspace.identifier.service.IdentifierService;
 import org.junit.After;
@@ -96,6 +97,8 @@ public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testPerform() throws IOException {
+        CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
+
         Curator curator = new Curator();
         curator.addTask(TASK_NAME);
         CuratorReportTest.ListReporter reporter = new CuratorReportTest.ListReporter();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
@@ -27,11 +27,13 @@ import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.PreviewContentBuilder;
 import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.PreviewContent;
+import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.PreviewContentService;
 import org.dspace.util.FileInfo;
 import org.junit.After;
@@ -44,6 +46,8 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
 
     @Autowired
     PreviewContentService previewContentService;
+    @Autowired
+    BitstreamFormatService bitstreamFormatService;
 
     PreviewContent previewContent0;
     PreviewContent previewContent1;
@@ -229,13 +233,20 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
         PreviewContentBuilder.deletePreviewContent(previewContent3.getID());
 
         BitstreamBuilder.deleteBitstream(tarGzFile.getID());
+
+        BitstreamFormat customMimeTypeFormat = tarXGzipFile.getFormat(context);
         BitstreamBuilder.deleteBitstream(tarXGzipFile.getID());
+        if (customMimeTypeFormat != null) {
+            bitstreamFormatService.delete(context, customMimeTypeFormat);
+        }
+
         BitstreamBuilder.deleteBitstream(tgzFile.getID());
         BitstreamBuilder.deleteBitstream(gzFile.getID());
         BitstreamBuilder.deleteBitstream(tarXzFile.getID());
         BitstreamBuilder.deleteBitstream(xzFile.getID());
         BitstreamBuilder.deleteBitstream(tarGzFileWithWrongExtension.getID());
         BitstreamBuilder.deleteBitstream(tarXzFileWithIncorrectMimeType.getID());
+
         super.destroy();
     }
 


### PR DESCRIPTION
port of ufal/clarin-dspace#1353

**NOTE**: This is without the `dspace-api/src/test/java/org/dspace/curate/ItemMetadataQACheckerIT.java` change. Will add that one into https://github.com/dataquest-dev/DSpace/pull/1237

### Copilot review
- [x] Requested review from Copilot