### PR TITLE
UFAL/Added oai bundle exclude feature

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -11,7 +11,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
@@ -107,14 +109,55 @@ public class ItemUtils {
         return e;
     }
 
+    /**
+     * Default list of bundle names that must never be exposed through OAI-PMH.
+     * These are typically derivative bundles produced by {@code dspace filter-media}
+     * (extracted plain-text for indexing, generated thumbnails) or internal bundles
+     * such as the SWORD deposit package. Exposing them leaks content that is not
+     * intended to be a first-class resource of the item (see ufal/clarin-dspace#1355).
+     * The list is overridable through the {@code oai.bundle.excluded} configuration
+     * property (comma separated list of bundle names).
+     */
+    private static final String[] DEFAULT_EXCLUDED_BUNDLES = new String[] {
+        "TEXT", "THUMBNAIL", "SWORD"
+    };
+
+    /**
+     * @return the names of the bundles that must not be exposed through OAI-PMH.
+     */
+    private static Set<String> getExcludedBundleNames() {
+        String[] configured = configurationService
+                .getArrayProperty("oai.bundle.excluded");
+        String[] effective = (configured != null && configured.length > 0)
+                ? configured
+                : DEFAULT_EXCLUDED_BUNDLES;
+        Set<String> excluded = new HashSet<>();
+        for (String name : effective) {
+            if (name != null) {
+                String trimmed = name.trim();
+                if (!trimmed.isEmpty()) {
+                    excluded.add(trimmed);
+                }
+            }
+        }
+        return excluded;
+    }
+
     private static Element createBundlesElement(Context context, Item item, AtomicBoolean restricted)
             throws SQLException {
         Element bundles = create("bundles");
 
         List<Bundle> bs;
 
+        Set<String> excludedBundleNames = getExcludedBundleNames();
+
         bs = item.getBundles();
         for (Bundle b : bs) {
+            // Skip bundles that must not be exposed via OAI-PMH (e.g. TEXT/THUMBNAIL
+            // bundles produced by `dspace filter-media`). See ufal/clarin-dspace#1355.
+            if (b.getName() != null && excludedBundleNames.contains(b.getName())) {
+                continue;
+            }
             Element bundle = create("bundle");
             bundles.getElement().add(bundle);
             bundle.getField().add(createValue("name", b.getName()));

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -110,20 +110,22 @@ public class ItemUtils {
     }
 
     /**
-     * Default list of bundle names that must never be exposed through OAI-PMH.
+     * Default list of bundle names excluded from OAI-PMH exposure.
      * These are typically derivative bundles produced by {@code dspace filter-media}
      * (extracted plain-text for indexing, generated thumbnails) or internal bundles
-     * such as the SWORD deposit package. Exposing them leaks content that is not
+     * such as the SWORD deposit package. Exposing them may leak content that is not
      * intended to be a first-class resource of the item (see ufal/clarin-dspace#1355).
-     * The list is overridable through the {@code oai.bundle.excluded} configuration
-     * property (comma separated list of bundle names).
+     * The {@code oai.bundle.excluded} configuration property, when set, overrides
+     * this default list with a comma-separated list of bundle names.
      */
     private static final String[] DEFAULT_EXCLUDED_BUNDLES = new String[] {
         "TEXT", "THUMBNAIL", "SWORD"
     };
 
     /**
-     * @return the names of the bundles that must not be exposed through OAI-PMH.
+     * @return the effective names of bundles excluded from OAI-PMH exposure,
+     * using {@code oai.bundle.excluded} when configured, or the default
+     * excluded bundle list otherwise.
      */
     private static Set<String> getExcludedBundleNames() {
         String[] configured = configurationService

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -114,7 +114,7 @@ public class ItemUtils {
      * These are typically derivative bundles produced by {@code dspace filter-media}
      * (extracted plain-text for indexing, generated thumbnails) or internal bundles
      * such as the SWORD deposit package. Exposing them may leak content that is not
-     * intended to be a first-class resource of the item (see ufal/clarin-dspace#1355).
+     * intended to be a first-class resource of the item.
      * The {@code oai.bundle.excluded} configuration property, when set, overrides
      * this default list with a comma-separated list of bundle names.
      */
@@ -156,7 +156,7 @@ public class ItemUtils {
         bs = item.getBundles();
         for (Bundle b : bs) {
             // Skip bundles that must not be exposed via OAI-PMH (e.g. TEXT/THUMBNAIL
-            // bundles produced by `dspace filter-media`). See ufal/clarin-dspace#1355.
+            // bundles produced by `dspace filter-media`).
             if (b.getName() != null && excludedBundleNames.contains(b.getName())) {
                 continue;
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIPMHBundleExposureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIPMHBundleExposureIT.java
@@ -1,0 +1,188 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.oai;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.BundleService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.xoai.util.ItemUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Integration tests that verify which bundles are exposed through the XOAI
+ * representation used by OAI-PMH crosswalks (including the CLARIN CMDI one).
+ */
+public class OAIPMHBundleExposureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    private final BitstreamService bitstreamService =
+            ContentServiceFactory.getInstance().getBitstreamService();
+    private final BundleService bundleService =
+            ContentServiceFactory.getInstance().getBundleService();
+
+    private Collection collection;
+
+    @Before
+    public void setupStructure() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context)
+                .withName("Test Community")
+                .build();
+        collection = CollectionBuilder.createCollection(context, community)
+                .withName("Test Collection")
+                .build();
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Build an item that has an ORIGINAL bitstream plus the derivative/internal
+     * bundles that {@code dspace filter-media} / SWORD typically create.
+     */
+    private Item buildItemWithDerivativeBundles() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle("Item with TEXT and THUMBNAIL bundles")
+                .withIssueDate("2026-01-01")
+                .build();
+
+        addBitstream(item, "ORIGINAL", "payload.pdf", "binary data");
+        addBitstream(item, "TEXT", "payload.pdf.txt", "extracted text from pdf");
+        addBitstream(item, "THUMBNAIL", "payload.pdf.jpg", "fake thumbnail bytes");
+        addBitstream(item, "SWORD", "sword-deposit.zip", "sword payload");
+
+        context.restoreAuthSystemState();
+        return item;
+    }
+
+    private void addBitstream(Item item, String bundleName, String name, String content)
+            throws Exception {
+        org.dspace.content.Bundle bundle;
+        List<org.dspace.content.Bundle> bundles =
+                ContentServiceFactory.getInstance().getItemService()
+                        .getBundles(item, bundleName);
+        if (bundles.isEmpty()) {
+            bundle = bundleService.create(context, item, bundleName);
+        } else {
+            bundle = bundles.get(0);
+        }
+        org.dspace.content.Bitstream bitstream = bitstreamService.create(
+                context, bundle,
+                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, name);
+        bitstreamService.update(context, bitstream);
+    }
+
+    private List<String> bundleNames(Metadata metadata) {
+        List<String> names = new ArrayList<>();
+        Element bundles = ItemUtils.getElement(metadata.getElement(), "bundles");
+        if (bundles == null) {
+            return names;
+        }
+        for (Element bundle : bundles.getElement()) {
+            for (Element.Field field : bundle.getField()) {
+                if ("name".equals(field.getName())) {
+                    names.add(field.getValue());
+                }
+            }
+        }
+        return names;
+    }
+
+    /**
+     * With the default configuration, TEXT, THUMBNAIL and SWORD bundles must be
+     * hidden from the XOAI document.
+     */
+    @Test
+    public void defaultConfiguration_hidesFilterMediaAndSwordBundles() throws Exception {
+        // Ensure we rely on the built-in default; drop any stale override.
+        configurationService.setProperty("oai.bundle.excluded", null);
+
+        Item item = buildItemWithDerivativeBundles();
+
+        Metadata metadata = ItemUtils.retrieveMetadata(context, item);
+
+        List<String> exposed = bundleNames(metadata);
+
+        assertThat("ORIGINAL bundle must always be exposed via OAI-PMH",
+                exposed, hasItem("ORIGINAL"));
+        assertThat("TEXT bundle (dspace filter-media output) must not be exposed via OAI-PMH",
+                exposed, not(hasItem("TEXT")));
+        assertThat("THUMBNAIL bundle (dspace filter-media output) must not be exposed via OAI-PMH",
+                exposed, not(hasItem("THUMBNAIL")));
+        assertThat("SWORD bundle (internal deposit package) must not be exposed via OAI-PMH",
+                exposed, not(hasItem("SWORD")));
+    }
+
+    /**
+     * The administrator may reduce the exclusion list; when only THUMBNAIL is
+     * excluded, TEXT (and others) are exposed again.
+     */
+    @Test
+    public void customExcludedBundles_allowsOverrideOfDefaults() throws Exception {
+        configurationService.setProperty("oai.bundle.excluded", "THUMBNAIL");
+        try {
+            Item item = buildItemWithDerivativeBundles();
+            Metadata metadata = ItemUtils.retrieveMetadata(context, item);
+
+            List<String> exposed = bundleNames(metadata);
+
+            assertThat("With a custom exclusion list the ORIGINAL, TEXT and SWORD "
+                       + "bundles must be exposed and only THUMBNAIL must be hidden",
+                    exposed,
+                    containsInAnyOrder("ORIGINAL", "TEXT", "SWORD"));
+        } finally {
+            configurationService.setProperty("oai.bundle.excluded", null);
+        }
+    }
+
+    /**
+     * An empty value must fall back to the built-in defaults, otherwise a
+     * mis-configuration would regress to the pre-fix behaviour.
+     */
+    @Test
+    public void emptyExcludedBundles_fallsBackToDefaults() throws Exception {
+        configurationService.setProperty("oai.bundle.excluded", "");
+        try {
+            Item item = buildItemWithDerivativeBundles();
+            Metadata metadata = ItemUtils.retrieveMetadata(context, item);
+
+            List<String> exposed = bundleNames(metadata);
+
+            assertThat(exposed, hasItem("ORIGINAL"));
+            assertThat(exposed, not(hasItem("TEXT")));
+            assertThat(exposed, not(hasItem("THUMBNAIL")));
+            assertThat(exposed, not(hasItem("SWORD")));
+        } finally {
+            configurationService.setProperty("oai.bundle.excluded", null);
+        }
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIPMHBundleExposureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIPMHBundleExposureIT.java
@@ -31,6 +31,7 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.xoai.util.ItemUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +51,7 @@ public class OAIPMHBundleExposureIT extends AbstractControllerIntegrationTest {
             ContentServiceFactory.getInstance().getBundleService();
 
     private Collection collection;
+        private String originalOaiBundleExcluded;
 
     @Before
     public void setupStructure() throws Exception {
@@ -61,6 +63,14 @@ public class OAIPMHBundleExposureIT extends AbstractControllerIntegrationTest {
                 .withName("Test Collection")
                 .build();
         context.restoreAuthSystemState();
+
+        // Preserve the loaded value so each test can safely mutate this property.
+        originalOaiBundleExcluded = configurationService.getProperty("oai.bundle.excluded");
+    }
+
+    @After
+    public void restoreOaiBundleExcludedConfiguration() {
+        configurationService.setProperty("oai.bundle.excluded", originalOaiBundleExcluded);
     }
 
     /**
@@ -149,19 +159,16 @@ public class OAIPMHBundleExposureIT extends AbstractControllerIntegrationTest {
     @Test
     public void customExcludedBundles_allowsOverrideOfDefaults() throws Exception {
         configurationService.setProperty("oai.bundle.excluded", "THUMBNAIL");
-        try {
-            Item item = buildItemWithDerivativeBundles();
-            Metadata metadata = ItemUtils.retrieveMetadata(context, item);
 
-            List<String> exposed = bundleNames(metadata);
+        Item item = buildItemWithDerivativeBundles();
+        Metadata metadata = ItemUtils.retrieveMetadata(context, item);
 
-            assertThat("With a custom exclusion list the ORIGINAL, TEXT and SWORD "
-                       + "bundles must be exposed and only THUMBNAIL must be hidden",
-                    exposed,
-                    containsInAnyOrder("ORIGINAL", "TEXT", "SWORD"));
-        } finally {
-            configurationService.setProperty("oai.bundle.excluded", null);
-        }
+        List<String> exposed = bundleNames(metadata);
+
+        assertThat("With a custom exclusion list the ORIGINAL, TEXT and SWORD "
+                   + "bundles must be exposed and only THUMBNAIL must be hidden",
+                exposed,
+                containsInAnyOrder("ORIGINAL", "TEXT", "SWORD"));
     }
 
     /**
@@ -171,18 +178,15 @@ public class OAIPMHBundleExposureIT extends AbstractControllerIntegrationTest {
     @Test
     public void emptyExcludedBundles_fallsBackToDefaults() throws Exception {
         configurationService.setProperty("oai.bundle.excluded", "");
-        try {
-            Item item = buildItemWithDerivativeBundles();
-            Metadata metadata = ItemUtils.retrieveMetadata(context, item);
 
-            List<String> exposed = bundleNames(metadata);
+        Item item = buildItemWithDerivativeBundles();
+        Metadata metadata = ItemUtils.retrieveMetadata(context, item);
 
-            assertThat(exposed, hasItem("ORIGINAL"));
-            assertThat(exposed, not(hasItem("TEXT")));
-            assertThat(exposed, not(hasItem("THUMBNAIL")));
-            assertThat(exposed, not(hasItem("SWORD")));
-        } finally {
-            configurationService.setProperty("oai.bundle.excluded", null);
-        }
+        List<String> exposed = bundleNames(metadata);
+
+        assertThat(exposed, hasItem("ORIGINAL"));
+        assertThat(exposed, not(hasItem("TEXT")));
+        assertThat(exposed, not(hasItem("THUMBNAIL")));
+        assertThat(exposed, not(hasItem("SWORD")));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIPMHBundleExposureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIPMHBundleExposureIT.java
@@ -51,7 +51,7 @@ public class OAIPMHBundleExposureIT extends AbstractControllerIntegrationTest {
             ContentServiceFactory.getInstance().getBundleService();
 
     private Collection collection;
-        private String originalOaiBundleExcluded;
+    private String originalOaiBundleExcluded;
 
     @Before
     public void setupStructure() throws Exception {

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -38,13 +38,15 @@ oai.solr.url=${solr.server}/${solr.multicorePrefix}oai
 # Base url for bitstreams
 oai.bitstream.baseUrl = ${dspace.ui.url}
 
-# Bundles whose bitstreams must NEVER be exposed through OAI-PMH.
+# Default / recommended list of bundles whose bitstreams are excluded from
+# exposure through OAI-PMH.
 # Comma separated list of bundle names. Typical candidates are the bundles
 # produced by `dspace filter-media` (TEXT plain-text extracts, THUMBNAIL
 # thumbnails) and the internal SWORD deposit bundle. These are derivative /
 # internal artifacts and should not appear in harvested records, e.g. in the
 # lindat CMDI crosswalk.
 # If this property is not set, the default value is: TEXT, THUMBNAIL, SWORD.
+# Changing this property changes which bundles are exposed through OAI-PMH.
 oai.bundle.excluded = TEXT, THUMBNAIL, SWORD
 
 # Base Configuration Directory

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -38,6 +38,15 @@ oai.solr.url=${solr.server}/${solr.multicorePrefix}oai
 # Base url for bitstreams
 oai.bitstream.baseUrl = ${dspace.ui.url}
 
+# Bundles whose bitstreams must NEVER be exposed through OAI-PMH.
+# Comma separated list of bundle names. Typical candidates are the bundles
+# produced by `dspace filter-media` (TEXT plain-text extracts, THUMBNAIL
+# thumbnails) and the internal SWORD deposit bundle. These are derivative /
+# internal artifacts and should not appear in harvested records, e.g. in the
+# lindat CMDI crosswalk.
+# If this property is not set, the default value is: TEXT, THUMBNAIL, SWORD.
+oai.bundle.excluded = TEXT, THUMBNAIL, SWORD
+
 # Base Configuration Directory
 oai.config.dir = ${dspace.dir}/config/crosswalks/oai
 


### PR DESCRIPTION
This PR prevents unintended OAI-PMH exposure of derivative/internal bitstreams
created by media processing (for example files in `TEXT`, `THUMBNAIL`, and
`SWORD` bundles).

### What changed

- Added bundle filtering in XOAI serialization in
  `dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java`.
- `createBundlesElement` now skips bundles configured in
  `oai.bundle.excluded`.
- Added OAI config property in `dspace/config/modules/oai.cfg`:
  `oai.bundle.excluded = TEXT, THUMBNAIL, SWORD`.
- Added integration tests in
  `dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIPMHBundleExposureIT.java`
  covering:
  - default behavior (TEXT/THUMBNAIL/SWORD excluded),
  - custom override behavior,
  - empty config fallback to defaults.

### Why

Without this change, OAI output can include derivative files that are not
intended as primary published content, especially in crosswalks that iterate
over all XOAI bitstreams (for example CMDI).

### Validation

- Targeted OAI integration tests pass (`OAIPMHBundleExposureIT`).
- Checkstyle passes for touched modules.