### PR TITLE
MENDELU/Update OAI-PMH to fix CitacePRO composing

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -132,8 +132,8 @@
 					</xsl:if>
 					<xsl:text>, s. </xsl:text>
 					<xsl:choose>
-						<xsl:when test="$formatValue">
-							<xsl:value-of select="$formatValue" />
+						<xsl:when test="normalize-space($formatValue) != ''">
+							<xsl:value-of select="normalize-space($formatValue)" />
 						</xsl:when>
 						<xsl:otherwise>0</xsl:otherwise>
 					</xsl:choose>

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -132,8 +132,8 @@
 					</xsl:if>
 					<xsl:text>, s. </xsl:text>
 					<xsl:choose>
-						<xsl:when test="normalize-space($formatValue) != ''">
-							<xsl:value-of select="normalize-space($formatValue)" />
+						<xsl:when test="$formatValue != ''">
+							<xsl:value-of select="$formatValue" />
 						</xsl:when>
 						<xsl:otherwise>0</xsl:otherwise>
 					</xsl:choose>

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -118,15 +118,26 @@
 			<!-- dc.identifier - formatted with additional metadata -->
 			<xsl:if test="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value'] or doc:metadata/doc:element[@name='local']/doc:element[@name='volume']/doc:element/doc:field[@name='value'] or doc:metadata/doc:element[@name='local']/doc:element[@name='number']/doc:element/doc:field[@name='value']">
 				<dc:identifier>
+					<xsl:variable name="isConferenceObject" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field[@name='value'][normalize-space(.)='conferenceObject']" />
+					<xsl:variable name="isBookPart" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field[@name='value'][normalize-space(.)='bookPart']" />
+					<xsl:variable name="formatValue" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:field[@name='value'][1]" />
 					<xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element[@name='ispartof']/doc:element/doc:field[@name='value']" />
 					<xsl:text>. </xsl:text>
 					<xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']" />
-					<xsl:text>, vol. </xsl:text>
-					<xsl:value-of select="doc:metadata/doc:element[@name='local']/doc:element[@name='volume']/doc:element/doc:field[@name='value']" />
-					<xsl:text>, č. </xsl:text>
-					<xsl:value-of select="doc:metadata/doc:element[@name='local']/doc:element[@name='number']/doc:element/doc:field[@name='value']" />
-					<!-- We do not have any information about pages, so it is `s. 0` by default -->
-					<xsl:text>, s. 0.</xsl:text>
+					<xsl:if test="not($isConferenceObject or $isBookPart)">
+						<xsl:text>, vol. </xsl:text>
+						<xsl:value-of select="doc:metadata/doc:element[@name='local']/doc:element[@name='volume']/doc:element/doc:field[@name='value']" />
+						<xsl:text>, č. </xsl:text>
+						<xsl:value-of select="doc:metadata/doc:element[@name='local']/doc:element[@name='number']/doc:element/doc:field[@name='value']" />
+					</xsl:if>
+					<xsl:text>, s. </xsl:text>
+					<xsl:choose>
+						<xsl:when test="$formatValue">
+							<xsl:value-of select="$formatValue" />
+						</xsl:when>
+						<xsl:otherwise>0</xsl:otherwise>
+					</xsl:choose>
+					<xsl:text>.</xsl:text>
 				</dc:identifier>
 			</xsl:if>
 			<!-- dc.identifier.* -->


### PR DESCRIPTION
## Summary
This PR updates OAI-PMH `oai_dc` identifier formatting to better match citation requirements used by CitacePRO.

## What Changed
- Updated the composed `dc:identifier` output in the OAI DC XSL transformation.
- Replaced the fixed pages suffix (`s. 0.`) with dynamic page data from metadata (`dc.format`) when available.
- Added conditional formatting for `conferenceObject` records:
  - skips `vol.` and issue (`č.`) parts for this type
  - keeps page output in the identifier

## Scope
- 1 file changed
- 17 additions, 6 deletions
- No API or database changes

## Why
The previous output used a hardcoded page placeholder and did not handle `conferenceObject` citation formatting correctly.  
This change improves metadata quality during OAI-PMH exposure and aligns output with expected citation structure.

## Testing
- Verified OAI DC transformation output for:
  - regular records (volume/issue/pages)
  - `conferenceObject` records (without volume/issue)
  - missing pages fallback behavior