### PR TITLE
ZCU-PUB/Config for redirecting author

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -826,12 +826,6 @@ event.consumer.orcidqueue.filters = Item+Install|Modify|Modify_Metadata|Delete|R
 event.consumer.submissionconfig.class = org.dspace.submit.consumer.SubmissionConfigConsumer
 event.consumer.submissionconfig.filters = Collection+Modify_Metadata
 
-#### Author/ORCID link behavior ####
-# Target of the link rendered for an author whose authority value is an ORCID iD.
-# browse - clicking the author name navigates to the browse-by-author page (default);
-# orcid - clicking the author name navigates directly to the ORCID profile.
-item.author.orcid.link-target = browse
-
 # ...set to true to enable testConsumer messages to standard output
 #testConsumer.verbose = true
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -826,6 +826,12 @@ event.consumer.orcidqueue.filters = Item+Install|Modify|Modify_Metadata|Delete|R
 event.consumer.submissionconfig.class = org.dspace.submit.consumer.SubmissionConfigConsumer
 event.consumer.submissionconfig.filters = Collection+Modify_Metadata
 
+#### Author/ORCID link behavior ####
+# Target of the link rendered for an author whose authority value is an ORCID iD.
+# browse - clicking the author name navigates to the browse-by-author page (default);
+# orcid - clicking the author name navigates directly to the ORCID profile.
+item.author.orcid.link-target = browse
+
 # ...set to true to enable testConsumer messages to standard output
 #testConsumer.verbose = true
 

--- a/dspace/config/modules/orcid.cfg
+++ b/dspace/config/modules/orcid.cfg
@@ -162,3 +162,9 @@ orcid.external-data.mapping.publication.external-ids = dc.identifier.scopus::eid
 orcid.external-data.mapping.publication.external-ids = dc.identifier.pmid::pmid
 orcid.external-data.mapping.publication.external-ids = dc.identifier.isi::wosuid
 orcid.external-data.mapping.publication.external-ids = dc.identifier.issn::issn
+
+#### Author/ORCID link behavior ####
+# Target of the link rendered for an author whose authority value is an ORCID iD.
+# browse - clicking the author name navigates to the browse-by-author page (default);
+# orcid - clicking the author name navigates directly to the ORCID profile.
+orcid.author.link-target = browse

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -82,6 +82,7 @@ rest.properties.exposed = statistics.cache-server.uri
 rest.properties.exposed = citace.pro.url
 rest.properties.exposed = citace.pro.university
 rest.properties.exposed = citace.pro.allowed
+rest.properties.exposed = item.author.orcid.link-target
 
 
 #---------------------------------------------------------------#

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -82,7 +82,7 @@ rest.properties.exposed = statistics.cache-server.uri
 rest.properties.exposed = citace.pro.url
 rest.properties.exposed = citace.pro.university
 rest.properties.exposed = citace.pro.allowed
-rest.properties.exposed = item.author.orcid.link-target
+rest.properties.exposed = orcid.author.link-target
 
 
 #---------------------------------------------------------------#


### PR DESCRIPTION
## Problem description
Authors with ORCID have icon next to name (redirect to orcid url). When clicking on author name, you can configure if it will redirect to orcid url or default browse as it was before

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot