### PR TITLE
fix(ci): put PasswordAuthentication first in auth chain (unblocks vsb-tuo e2e CI)

### DIFF
--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -60,7 +60,10 @@
 
 # Authentication by Password (encrypted in DSpace's database). See authentication-password.cfg for default configuration.
 # Enabled by default (to disable, either comment out, or define a new list of AuthenticationMethod plugins in your local.cfg)
-plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.LDAPAuthentication,org.dspace.authenticate.PasswordAuthentication
+# PasswordAuthentication is FIRST so local-password accounts (incl. the e2e/demo
+# admin) log in without first blocking on the LDAP server, which is unreachable
+# from CI runners. Real LDAP users still fall through to LDAPAuthentication.
+plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication, org.dspace.authenticate.LDAPAuthentication
 
 
 #---------------------------------------------------------------#


### PR DESCRIPTION
## Problem
`customer/vsb-tuo` dspace-angular integration (Cypress e2e) CI has been red for months — every login-gated spec fails (`#sidebar-collapse-toggle not found`) while every anonymous/public spec passes.

## Root cause (verified locally with Docker)
The `customer-vsb-tuo-test` image lists **`LDAPAuthentication` first** in the authentication chain, and `authentication-ldap.cfg` points at `provider_url = ldaps://ldap.vsb.cz:636/`. That host is **unreachable from CI runners** (TCP connect blackholes; DSpace sets no JNDI connect timeout), so every admin login first **hangs on the LDAP connect**, then falls through to password.

Measured against the 29.1.2024 demo dump:

| Auth chain | Admin login (`dspacedemo+admin@gmail.com`) |
|---|---|
| `LDAPAuthentication, PasswordAuthentication` (current) | HTTP 200 but **21.4 s** (hangs on LDAP) |
| `PasswordAuthentication, LDAPAuthentication` (this PR) | HTTP 200 in **~0.4 s** |

On CI the LDAP hang is even longer (TCP SYN retries up to ~127 s), so the login POST does not return in time and breaks the e2e flow. The DB dump is **not** the problem — it is identical on all branches, and `customer/uk` already works with its own `customer-uk-test` image because that one lists `PasswordAuthentication` first.

## Fix
Reorder the chain so `PasswordAuthentication` is tried first. Local-password accounts (the e2e/demo admin) log in instantly; real VSB LDAP users have no local password, so `PasswordAuthentication` returns no-such-user and they **still fall through to `LDAPAuthentication`** exactly as before. This matches the working `customer/uk` configuration.

## Verification
Reproduced and fixed locally: started `dataquest/dspace:customer-vsb-tuo-test` + the demo dump, measured the 21 s login hang, rebuilt with the reordered chain, and confirmed login drops to ~0.4 s with a valid `Authorization` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
