### PR TITLE
[Backport dtq-dev] Issue 1360: allow to change license in workflow item, in PATCH operation (ufal#1365)

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
@@ -213,6 +213,10 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
         WorkflowItemRest wsi = findOne(context, id);
         XmlWorkflowItem source = wis.find(context, id);
 
+        if (source == null) {
+            throw new ResourceNotFoundException("WorkflowItem with id " + id + " not found");
+        }
+
         this.checkIfEditMetadataAllowedInCurrentStep(context, source);
         List<ErrorRest> errors = submissionService.uploadFileToInprogressSubmission(context, request, wsi, source,
                 file);
@@ -252,7 +256,8 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
                 submissionService.evaluatePatchToInprogressSubmission(context, request, source, wsi, section, op);
             } else {
                 throw new DSpaceBadRequestException(
-                    "Patch path operation need to starts with '" + OPERATION_PATH_SECTIONS + "'");
+                    "Patch path operation need to starts with '" +
+                            OPERATION_PATH_LICENSE_RESOURCE + "' or '" + OPERATION_PATH_SECTIONS + "'");
             }
         }
         wis.update(context, source);
@@ -325,8 +330,8 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
     }
 
     private DSpaceBadRequestException wrongValueFormatException(Operation op) {
-        return new DSpaceBadRequestException("Unsupported value type for operation: " + op.getOp()
-                + ". Expected a string or an object with a textual 'value' field.");
+        return new DSpaceBadRequestException("Unsupported value format for operation '" + op.getOp()
+                + "'. Expected a string or an object with a textual 'value' field.");
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
@@ -7,14 +7,18 @@
  */
 package org.dspace.app.rest.repository;
 
+import static org.dspace.app.rest.repository.ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE;
 import static org.dspace.xmlworkflow.state.actions.processingaction.ProcessingAction.SUBMIT_EDIT_METADATA;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.Parameter;
@@ -24,9 +28,12 @@ import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.model.WorkflowItemRest;
+import org.dspace.app.rest.model.patch.JsonValueEvaluator;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
+import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.submit.SubmissionService;
+import org.dspace.app.rest.submit.step.ClarinLicenseSubmissionUtils;
 import org.dspace.app.rest.utils.SolrOAIReindexer;
 import org.dspace.app.util.SubmissionConfigReaderException;
 import org.dspace.authorize.AuthorizeException;
@@ -200,7 +207,7 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
 
     @Override
     public WorkflowItemRest upload(HttpServletRequest request, String apiCategory, String model, Integer id,
-                                   MultipartFile file) throws SQLException {
+                                   MultipartFile file) throws SQLException, AuthorizeException {
 
         Context context = obtainContext();
         WorkflowItemRest wsi = findOne(context, id);
@@ -226,12 +233,21 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
         WorkflowItemRest wsi = findOne(context, id);
         XmlWorkflowItem source = wis.find(context, id);
 
+        if (source == null) {
+            throw new ResourceNotFoundException("WorkflowItem with id " + id + " not found");
+        }
+
         this.checkIfEditMetadataAllowedInCurrentStep(context, source);
 
         for (Operation op : operations) {
             //the value in the position 0 is a null value
             String[] path = op.getPath().substring(1).split("/", 3);
-            if (OPERATION_PATH_SECTIONS.equals(path[0])) {
+            if (OPERATION_PATH_LICENSE_RESOURCE.equals(path[0])) {
+                // Apply the CLARIN license change through the shared submission helper so the
+                // workflow `/license` path behaves the same as the submission license paths.
+                // A non-existing license surfaces as ClarinLicenseNotFoundException (404).
+                ClarinLicenseSubmissionUtils.applyLicense(context, source.getItem(), extractLicenseName(op));
+            } else if (OPERATION_PATH_SECTIONS.equals(path[0])) {
                 String section = path[1];
                 submissionService.evaluatePatchToInprogressSubmission(context, request, source, wsi, section, op);
             } else {
@@ -279,19 +295,64 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
     }
 
     /**
+     * Extract the CLARIN license name from a JSON Patch {@code replace} operation on the {@code /license}
+     * path. The value is accepted either as a plain string or as an object wrapping a textual {@code value}
+     * field; a non-replace operation or any other value shape is rejected as a bad request. A blank name is
+     * passed through (the submission helper treats it as a request to clear the current license selection).
+     * @param op the JSON Patch operation targeting the license path
+     * @return the CLARIN license name to apply
+     */
+    private String extractLicenseName(Operation op) {
+        if (!(op instanceof ReplaceOperation)) {
+            throw new DSpaceBadRequestException("The operation to update the license must be the 'replace' operation");
+        }
+        if (op.getValue() instanceof String) {
+            return (String) op.getValue();
+        }
+        if (!(op.getValue() instanceof JsonValueEvaluator)) {
+            throw wrongValueFormatException(op);
+        }
+        JsonValueEvaluator jsonValEvaluator = (JsonValueEvaluator) op.getValue();
+        if (!(jsonValEvaluator.getValueNode() instanceof ObjectNode)) {
+            throw wrongValueFormatException(op);
+        }
+        // a replace operation may wrap the value in an ObjectNode under the "value" key
+        JsonNode jsonNodeValue = jsonValEvaluator.getValueNode().get("value");
+        if (jsonNodeValue != null && jsonNodeValue.isTextual()) {
+            return jsonNodeValue.asText();
+        }
+        throw wrongValueFormatException(op);
+    }
+
+    private DSpaceBadRequestException wrongValueFormatException(Operation op) {
+        return new DSpaceBadRequestException("Unsupported value type for operation: " + op.getOp()
+                + ". Expected a string or an object with a textual 'value' field.");
+    }
+
+    /**
      * Checks if @link{SUBMIT_EDIT_METADATA} is a valid option in the workflow step this task is currently at.
      * Patching and uploading is only allowed if this is the case.
      * @param context               Context
      * @param xmlWorkflowItem       WorkflowItem of the task
      */
-    private void checkIfEditMetadataAllowedInCurrentStep(Context context, XmlWorkflowItem xmlWorkflowItem) {
+    private void checkIfEditMetadataAllowedInCurrentStep(Context context, XmlWorkflowItem xmlWorkflowItem)
+            throws AuthorizeException {
         try {
-            ClaimedTask claimedTask = claimedTaskService.findByWorkflowIdAndEPerson(context, xmlWorkflowItem,
-                context.getCurrentUser());
-            if (claimedTask == null) {
+            List<ClaimedTask> claimTasks = claimedTaskService.findByWorkflowItem(context, xmlWorkflowItem);
+            if (claimTasks.isEmpty()) {
                 throw new UnprocessableEntityException("WorkflowItem with id " + xmlWorkflowItem.getID()
-                    + " has not been claimed yet.");
+                        + " has not been claimed yet.");
             }
+
+            ClaimedTask claimedTask = claimTasks.stream()
+                    .filter(ct -> Objects.equals(ct.getOwner(), context.getCurrentUser()))
+                    .findFirst()
+                    .orElse(null);
+            if (claimedTask == null) {
+                throw new AuthorizeException("The current user hasn't claimed the workflow item with id " +
+                        xmlWorkflowItem.getID() + ", so the user cannot patch this item");
+            }
+
             Workflow workflow = workflowFactory.getWorkflow(claimedTask.getWorkflowItem().getCollection());
             Step step = workflow.getStep(claimedTask.getStepID());
             WorkflowActionConfig currentActionConfig = step.getActionConfig(claimedTask.getActionID());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
@@ -472,6 +472,10 @@ public class ClarinWorkflowItemRestRepositoryIT extends AbstractControllerIntegr
                         .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
                 .andExpect(status().isOk());
 
+        XmlWorkflowItem updatedWfItem = xmlWorkflowItemService.find(context, wfItem.getID());
+        assertThat(itemService.getMetadataFirstValue(updatedWfItem.getItem(), "dc", "rights", null, Item.ANY),
+                is("CL Name"));
+
         Map<String, String> wrappedValue = new HashMap<String, String>();
         wrappedValue.put("value", "CL Name");
         ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
@@ -15,16 +15,29 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.model.patch.AddOperation;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.model.patch.ReplaceOperation;
+import org.dspace.app.rest.repository.ClarinLicenseRestRepository;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.ClaimedTaskBuilder;
+import org.dspace.builder.ClarinLicenseBuilder;
+import org.dspace.builder.ClarinLicenseLabelBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
@@ -35,12 +48,18 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.content.clarin.ClarinLicense;
+import org.dspace.content.clarin.ClarinLicenseLabel;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.content.service.clarin.ClarinLicenseLabelService;
+import org.dspace.content.service.clarin.ClarinLicenseService;
 import org.dspace.eperson.EPerson;
 import org.dspace.license.service.CreativeCommonsService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.CollectionRoleService;
 import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
 import org.hamcrest.Matchers;
@@ -77,6 +96,11 @@ public class ClarinWorkflowItemRestRepositoryIT extends AbstractControllerIntegr
 
     @Autowired
     private ItemService itemService;
+
+    @Autowired
+    private ClarinLicenseService clarinLicenseService;
+    @Autowired
+    private ClarinLicenseLabelService clarinLicenseLabelService;
 
     Item item;
 
@@ -363,5 +387,130 @@ public class ClarinWorkflowItemRestRepositoryIT extends AbstractControllerIntegr
                 "citation", Item.ANY);
         assertFalse(mvList.isEmpty());
         assertThat(mvList.get(0).getValue(), is(CITATION_VALUE));
+    }
+
+    @Test
+    public void patchUpdateClarinLicense() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // create Clarin License Label
+        ClarinLicenseLabel clarinLicenseLabel = ClarinLicenseLabelBuilder.createClarinLicenseLabel(context).build();
+        clarinLicenseLabel.setLabel("CC");
+        clarinLicenseLabel.setExtended(false);
+        clarinLicenseLabel.setTitle("CLL Title1");
+        clarinLicenseLabelService.update(context, clarinLicenseLabel);
+
+        // create Clarin License
+        ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
+        clarinLicense.setName("CL Name");
+        clarinLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
+        clarinLicense.setDefinition("CL Definition");
+        clarinLicense.setRequiredInfo("CL Req");
+        // add clarinLicenseLabel to  clarinLicense
+        Set<ClarinLicenseLabel> clarinLicenseLabels = new HashSet<>();
+        clarinLicenseLabels.add(clarinLicenseLabel);
+        clarinLicense.setLicenseLabels(clarinLicenseLabels);
+        clarinLicenseService.update(context, clarinLicense);
+
+        // community with one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                .withWorkflowGroup("editor", eperson).build();
+
+        // create a normal user to use as submitter
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                .withEmail("submitter@example.com")
+                .withPassword("dspace")
+                .build();
+
+        // claimed task with workflow item in edit step
+        ClaimedTask claimedTask = ClaimedTaskBuilder.createClaimedTask(context, col, eperson)
+                .withTitle("Workflow Item")
+                .withIssueDate("2026-05-18")
+                .withSubject("Extra Entry")
+                .grantLicense()
+                .build();
+        claimedTask.setStepID("editstep");
+        claimedTask.setActionID("editaction");
+        XmlWorkflowItem wfItem = claimedTask.getWorkflowItem();
+
+        context.restoreAuthSystemState();
+
+        // prepare a patch targeting the clarin license resource path
+        List<Operation> ops = new ArrayList<>();
+        ops.add(new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE, "CL Name"));
+
+        String submitterToken = getAuthToken(submitter.getEmail(), "dspace");
+
+        // The submitter shouldn't be allowed to patch clarin license
+        // because the workflow item was claimed by the other user (eperson),
+        // and the submitter doesn't have permissions to edit it,
+        // so the patch request should be rejected with error 403(Forbidden)
+        getClient(submitterToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isForbidden());
+
+        String editorToken = getAuthToken(eperson.getEmail(), password);
+
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE, "Wrong CL"));
+
+        // The wrong clarin license name value should be rejected with 404 Not Found
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isNotFound());
+
+        // The valid clarin license name can be in the form of a simple string or
+        // in the form of a map with "value" key, but it should be accepted in both cases
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE, "CL Name"));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        Map<String, String> wrappedValue = new HashMap<String, String>();
+        wrappedValue.put("value", "CL Name");
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                wrappedValue));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        // The wrapped value should contain the "value" key, otherwise it is invalid
+        Map<String, String> invalidWrappedValue1 = new HashMap<String, String>();
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                invalidWrappedValue1));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isBadRequest());
+
+        // The wrapped value should be in a map, not in a list
+        List<String> invalidWrappedValue2 = new ArrayList<>();
+        invalidWrappedValue2.add("CL Name");
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                invalidWrappedValue2));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isBadRequest());
+
+        // The only accepted operation for clarin license resource is "replace",
+        // "add" operation should be rejected with 400 Bad Request even with the valid value
+        ops.set(0, new AddOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                "CL Name"));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
@@ -2893,7 +2893,7 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
         getClient(authToken).perform(patch("/api/workflow/workflowitems/" + witem.getID())
             .content(patchBody)
             .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
-            .andExpect(status().isUnprocessableEntity());
+            .andExpect(status().isForbidden());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
@@ -2879,7 +2879,8 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                  .andExpect(status().isCreated())
                  .andExpect(jsonPath("$", Matchers.allOf(hasJsonPath("$.type", is("claimedtask")))));
 
-        // try to patch a workspace item while it is in a step that does not have the edit_metadata option (review step)
+        // try to patch a workflow item by a user who does not have the edit metadata permission
+        // in the current step (review step)
         String authToken = getAuthToken(eperson.getEmail(), password);
 
         // a simple patch to update an existent metadata


### PR DESCRIPTION
Backport of ufal/clarin-dspace#1365 to `dtq-dev`. The automated port-pr cherry-pick of `40672c3241` failed; resolved manually, and **adapted to dtq-dev's existing license architecture** (see below).

## What ufal/clarin-dspace#1365 does
Lets a reviewer/editor change the CLARIN license of an item from a **workflow** item via `PATCH /api/workflow/workflowitems/{id}` with `replace /license`. It also tightens the edit-allowed gate (`checkIfEditMetadataAllowedInCurrentStep`) so it distinguishes "not claimed by anyone" (422) from "claimed by another user" (403, via `AuthorizeException`).

## Adaptation vs the literal upstream change
ufal/clarin-dspace#1365 introduced a **new** helper `ClarinLicenseUtils.updateLicenseForItem(...)` and rerouted both the workspace `/license` path and the new workflow path through it. **dtq-dev already has its own consolidated helper** `ClarinLicenseSubmissionUtils.applyLicense(context, item, name)` (used by both the legacy `/license` path and the `/sections/clarin-license/select` path). To avoid two parallel license helpers on dtq-dev, this backport:

- **Drops** the new `ClarinLicenseUtils` class entirely.
- **Leaves `WorkspaceItemRestRepository` unchanged** (dtq-dev already applies the license via `maintainLicensesForItem` → `applyLicense`).
- In `WorkflowItemRestRepository`, routes the `/license` PATCH through the existing `ClarinLicenseSubmissionUtils.applyLicense(context, source.getItem(), extractLicenseName(op))`. Because `applyLicense` resolves its services via factories, the two `@Autowired` service fields ufal/clarin-dspace#1365 added are not needed and were omitted.
- Keeps ufal/clarin-dspace#1365's `List<ClaimedTask>` gate change and the `source == null` guard verbatim.

### Status codes preserved (per the IT tests)
`extractLicenseName` deliberately mirrors ufal/clarin-dspace#1365's **strict** value validation (not dtq-dev's lenient section-step extractor), so the IT expectations hold:
- non-`replace` op or malformed value (`{}`, `["..."]`) → **400**
- non-existing license name → **404** (`ClarinLicenseNotFoundException`, which is `@ResponseStatus(NOT_FOUND)`; intentionally *not* wrapped as 422)
- valid name (string or `{value: "..."}`) → **200**
- workflow item claimed by another user → **403**

Net change: 3 files (`WorkflowItemRestRepository`, `ClarinWorkflowItemRestRepositoryIT` new tests, `TaskRestRepositoriesIT` one 422→403 expectation).

Head branch is on my fork (`kosarko/DSpace`) since I don't have push access to `dataquest-dev`. No local Maven in this env — manually audited import order/usage/braces/exception mapping; CI compiles and runs the ITs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLARIN license updates can now be applied to workflow items using patch operations

* **Bug Fixes**
  * Improved authorization checks for workflow modifications to enforce proper editing permissions
  * Better error responses when workflow items are unavailable or inaccessible

<!-- end of auto-generated comment: release notes by coderabbit.ai -->