### PR TITLE
ZCU-PUB: fix slow /browse/subject (~5s→~0.2s) — backport #10057 metadata-browse json.facet/numBuckets

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -422,9 +422,6 @@ public class BrowseEngine {
                 }
             }
 
-            // this is the total number of results in answer to the query
-            int total = getTotalResults(true);
-
             // set the ordering field (there is only one option)
             dao.setOrderField("sort_value");
 
@@ -443,6 +440,9 @@ public class BrowseEngine {
             // assemble the offset and limit
             dao.setOffset(offset);
             dao.setLimit(scope.getResultsPerPage());
+
+            // this is the total number of results in answer to the query
+            int total = getTotalResults(true);
 
             // Holder for the results
             List<String[]> results = null;
@@ -680,32 +680,8 @@ public class BrowseEngine {
         // tell the browse query whether we are distinct
         dao.setDistinct(distinct);
 
-        // ensure that the select is set to "*"
-        String[] select = {"*"};
-        dao.setCountValues(select);
-
-        // FIXME: it would be nice to have a good way of doing this in the DAO
-        // now reset all of the fields that we don't want to have constraining
-        // our count, storing them locally to reinstate later
-        String focusField = dao.getJumpToField();
-        String focusValue = dao.getJumpToValue();
-        int limit = dao.getLimit();
-        int offset = dao.getOffset();
-
-        dao.setJumpToField(null);
-        dao.setJumpToValue(null);
-        dao.setLimit(-1);
-        dao.setOffset(-1);
-
         // perform the query and get the result
         int count = dao.doCountQuery();
-
-        // now put back the values we removed for this method
-        dao.setJumpToField(focusField);
-        dao.setJumpToValue(focusValue);
-        dao.setLimit(limit);
-        dao.setOffset(offset);
-        dao.setCountValues(null);
 
         log.debug(LogHelper.getHeader(context, "get_total_results_return", "return=" + count));
 

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.util.ClientUtils;
@@ -180,18 +182,33 @@ public class SolrBrowseDAO implements BrowseDAO {
             addDefaultFilterQueries(query);
             if (distinct) {
                 DiscoverFacetField dff;
+
+                // To get the number of distinct values we use the next "json.facet" query param
+                // {"entries_count": {"type":"terms","field": "<fieldName>_filter", "limit":0, "numBuckets":true}}"
+                ObjectNode jsonFacet = JsonNodeFactory.instance.objectNode();
+                ObjectNode entriesCount = JsonNodeFactory.instance.objectNode();
+                entriesCount.put("type", "terms");
+                entriesCount.put("field", facetField + "_filter");
+                entriesCount.put("limit", 0);
+                entriesCount.put("numBuckets", true);
+                jsonFacet.set("entries_count", entriesCount);
+
                 if (StringUtils.isNotBlank(startsWith)) {
                     dff = new DiscoverFacetField(facetField,
-                        DiscoveryConfigurationParameters.TYPE_TEXT, -1,
-                        DiscoveryConfigurationParameters.SORT.VALUE, startsWith);
+                        DiscoveryConfigurationParameters.TYPE_TEXT, limit,
+                        DiscoveryConfigurationParameters.SORT.VALUE, startsWith, offset);
+
+                    // Add the prefix to the json facet query
+                    entriesCount.put("prefix", startsWith);
                 } else {
                     dff = new DiscoverFacetField(facetField,
-                        DiscoveryConfigurationParameters.TYPE_TEXT, -1,
-                        DiscoveryConfigurationParameters.SORT.VALUE);
+                        DiscoveryConfigurationParameters.TYPE_TEXT, limit,
+                        DiscoveryConfigurationParameters.SORT.VALUE, offset);
                 }
                 query.addFacetField(dff);
                 query.setFacetMinCount(1);
                 query.setMaxResults(0);
+                query.addProperty("json.facet", jsonFacet.toString());
             } else {
                 query.setMaxResults(limit/* > 0 ? limit : 20*/);
                 if (offset > 0) {
@@ -248,8 +265,7 @@ public class SolrBrowseDAO implements BrowseDAO {
         DiscoverResult resp = getSolrResponse();
         int count = 0;
         if (distinct) {
-            List<FacetResult> facetResults = resp.getFacetResult(facetField);
-            count = facetResults.size();
+            count = (int) resp.getTotalEntries();
         } else {
             // we need to cast to int to respect the BrowseDAO contract...
             count = (int) resp.getTotalSearchResults();
@@ -266,8 +282,8 @@ public class SolrBrowseDAO implements BrowseDAO {
         DiscoverResult resp = getSolrResponse();
         List<FacetResult> facet = resp.getFacetResult(facetField);
         int count = doCountQuery();
-        int start = offset > 0 ? offset : 0;
-        int max = limit > 0 ? limit : count; //if negative, return everything
+        int start = 0;
+        int max = facet.size();
         List<String[]> result = new ArrayList<>();
         if (ascending) {
             for (int i = start; i < (start + max) && i < count; i++) {

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -23,7 +23,6 @@ import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.dspace.discovery.DiscoverFacetField;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.DiscoverQuery.SORT_ORDER;
 import org.dspace.discovery.DiscoverResult;
@@ -34,7 +33,6 @@ import org.dspace.discovery.SearchService;
 import org.dspace.discovery.SearchServiceException;
 import org.dspace.discovery.SearchUtils;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
-import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
 import org.dspace.discovery.indexobject.IndexableItem;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -181,32 +179,28 @@ public class SolrBrowseDAO implements BrowseDAO {
             addLocationScopeFilter(query);
             addDefaultFilterQueries(query);
             if (distinct) {
-                DiscoverFacetField dff;
-
-                // To get the number of distinct values we use the next "json.facet" query param
-                // {"entries_count": {"type":"terms","field": "<fieldName>_filter", "limit":0, "numBuckets":true}}"
+                // We use a json.facet query for metadata browsing because it allows us to limit the results
+                // while obtaining the total number of facet values with numBuckets:true and sort in reverse order
+                // Example of json.facet query:
+                // {"<fieldName>": {"type":"terms","field": "<fieldName>_filter", "limit":0, "offset":0,
+                // "sort":"index desc", "numBuckets":true, "prefix":"<startsWith>"}}
                 ObjectNode jsonFacet = JsonNodeFactory.instance.objectNode();
-                ObjectNode entriesCount = JsonNodeFactory.instance.objectNode();
-                entriesCount.put("type", "terms");
-                entriesCount.put("field", facetField + "_filter");
-                entriesCount.put("limit", 0);
-                entriesCount.put("numBuckets", true);
-                jsonFacet.set("entries_count", entriesCount);
-
-                if (StringUtils.isNotBlank(startsWith)) {
-                    dff = new DiscoverFacetField(facetField,
-                        DiscoveryConfigurationParameters.TYPE_TEXT, limit,
-                        DiscoveryConfigurationParameters.SORT.VALUE, startsWith, offset);
-
-                    // Add the prefix to the json facet query
-                    entriesCount.put("prefix", startsWith);
+                ObjectNode entriesFacet = JsonNodeFactory.instance.objectNode();
+                entriesFacet.put("type", "terms");
+                entriesFacet.put("field", facetField + "_filter");
+                entriesFacet.put("limit", limit);
+                entriesFacet.put("offset", offset);
+                entriesFacet.put("numBuckets", true);
+                if (ascending) {
+                    entriesFacet.put("sort", "index");
                 } else {
-                    dff = new DiscoverFacetField(facetField,
-                        DiscoveryConfigurationParameters.TYPE_TEXT, limit,
-                        DiscoveryConfigurationParameters.SORT.VALUE, offset);
+                    entriesFacet.put("sort", "index desc");
                 }
-                query.addFacetField(dff);
-                query.setFacetMinCount(1);
+                if (StringUtils.isNotBlank(startsWith)) {
+                    // Add the prefix to the json facet query
+                    entriesFacet.put("prefix", startsWith);
+                }
+                jsonFacet.set(facetField, entriesFacet);
                 query.setMaxResults(0);
                 query.addProperty("json.facet", jsonFacet.toString());
             } else {
@@ -282,26 +276,15 @@ public class SolrBrowseDAO implements BrowseDAO {
         DiscoverResult resp = getSolrResponse();
         List<FacetResult> facet = resp.getFacetResult(facetField);
         int count = doCountQuery();
-        int start = 0;
         int max = facet.size();
         List<String[]> result = new ArrayList<>();
-        if (ascending) {
-            for (int i = start; i < (start + max) && i < count; i++) {
-                FacetResult c = facet.get(i);
-                String freq = showFrequencies ? String.valueOf(c.getCount())
-                    : "";
-                result.add(new String[] {c.getDisplayedValue(),
-                    c.getAuthorityKey(), freq});
-            }
-        } else {
-            for (int i = count - start - 1; i >= count - (start + max)
-                && i >= 0; i--) {
-                FacetResult c = facet.get(i);
-                String freq = showFrequencies ? String.valueOf(c.getCount())
-                    : "";
-                result.add(new String[] {c.getDisplayedValue(),
-                    c.getAuthorityKey(), freq});
-            }
+
+        for (int i = 0; i < max && i < count; i++) {
+            FacetResult c = facet.get(i);
+            String freq = showFrequencies ? String.valueOf(c.getCount())
+                : "";
+            result.add(new String[] {c.getDisplayedValue(),
+                c.getAuthorityKey(), freq});
         }
 
         return result;

--- a/dspace-api/src/main/java/org/dspace/discovery/DiscoverResult.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/DiscoverResult.java
@@ -32,6 +32,9 @@ public class DiscoverResult {
     private List<IndexableObject> indexableObjects;
     private Map<String, List<FacetResult>> facetResults;
 
+    // Total count of facet entries calculated for a metadata browsing query
+    private long totalEntries;
+
     /**
      * A map that contains all the documents sougth after, the key is a string representation of the Indexable Object
      */
@@ -62,6 +65,14 @@ public class DiscoverResult {
 
     public void setTotalSearchResults(long totalSearchResults) {
         this.totalSearchResults = totalSearchResults;
+    }
+
+    public long getTotalEntries() {
+        return totalEntries;
+    }
+
+    public void setTotalEntries(long totalEntries) {
+        this.totalEntries = totalEntries;
     }
 
     public int getStart() {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1062,6 +1062,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
                 //Resolve our facet field values
                 resolveFacetFields(context, query, result, skipLoadingResponse, solrQueryResponse);
+                //Add total entries count for metadata browsing
+                resolveEntriesCount(result, solrQueryResponse);
             }
             // If any stale entries are found in the current page of results,
             // we remove those stale entries and rerun the same query again.
@@ -1087,7 +1089,39 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         return result;
     }
 
+    /**
+     * Stores the total count of entries for metadata index browsing. The count is calculated by the
+     * <code>json.facet</code> parameter with the following value:
+     *
+     * <pre><code>
+     * {
+     *     "entries_count": {
+     *         "type": "terms",
+     *         "field": "facetNameField_filter",
+     *         "limit": 0,
+     *         "prefix": "prefix_value",
+     *         "numBuckets": true
+     *     }
+     * }
+     * </code></pre>
+     *
+     * This value is returned in the <code>facets</code> field of the Solr response.
+     *
+     * @param result DiscoverResult object where the total entries count will be stored
+     * @param solrQueryResponse QueryResponse object containing the solr response
+     */
+    private void resolveEntriesCount(DiscoverResult result, QueryResponse solrQueryResponse) {
 
+        Object facetsObj = solrQueryResponse.getResponse().get("facets");
+        if (facetsObj instanceof NamedList) {
+            NamedList<Object> facets = (NamedList<Object>) facetsObj;
+            Object bucketsInfoObj = facets.get("entries_count");
+            if (bucketsInfoObj instanceof NamedList) {
+                NamedList<Object> bucketsInfo = (NamedList<Object>) bucketsInfoObj;
+                result.setTotalEntries((int) bucketsInfo.get("numBuckets"));
+            }
+        }
+    }
 
     private void resolveFacetFields(Context context, DiscoverQuery query, DiscoverResult result,
             boolean skipLoadingResponse, QueryResponse solrQueryResponse) throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -41,6 +41,9 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.FacetField;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.json.BucketBasedJsonFacet;
+import org.apache.solr.client.solrj.response.json.BucketJsonFacet;
+import org.apache.solr.client.solrj.response.json.NestableJsonFacet;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
@@ -1062,8 +1065,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
                 //Resolve our facet field values
                 resolveFacetFields(context, query, result, skipLoadingResponse, solrQueryResponse);
-                //Add total entries count for metadata browsing
-                resolveEntriesCount(result, solrQueryResponse);
+                //Resolve our json facet field values used for metadata browsing
+                resolveJsonFacetFields(context, result, solrQueryResponse);
             }
             // If any stale entries are found in the current page of results,
             // we remove those stale entries and rerun the same query again.
@@ -1090,35 +1093,38 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     }
 
     /**
-     * Stores the total count of entries for metadata index browsing. The count is calculated by the
-     * <code>json.facet</code> parameter with the following value:
+     * Process the 'json.facet' response, which is currently only used for metadata browsing
      *
-     * <pre><code>
-     * {
-     *     "entries_count": {
-     *         "type": "terms",
-     *         "field": "facetNameField_filter",
-     *         "limit": 0,
-     *         "prefix": "prefix_value",
-     *         "numBuckets": true
-     *     }
-     * }
-     * </code></pre>
-     *
-     * This value is returned in the <code>facets</code> field of the Solr response.
-     *
-     * @param result DiscoverResult object where the total entries count will be stored
-     * @param solrQueryResponse QueryResponse object containing the solr response
+     * @param context context object
+     * @param result the result object to add the facet results to
+     * @param solrQueryResponse the solr query response
+     * @throws SQLException if database error
      */
-    private void resolveEntriesCount(DiscoverResult result, QueryResponse solrQueryResponse) {
+    private void resolveJsonFacetFields(Context context, DiscoverResult result, QueryResponse solrQueryResponse)
+        throws SQLException {
 
-        Object facetsObj = solrQueryResponse.getResponse().get("facets");
-        if (facetsObj instanceof NamedList) {
-            NamedList<Object> facets = (NamedList<Object>) facetsObj;
-            Object bucketsInfoObj = facets.get("entries_count");
-            if (bucketsInfoObj instanceof NamedList) {
-                NamedList<Object> bucketsInfo = (NamedList<Object>) bucketsInfoObj;
-                result.setTotalEntries((int) bucketsInfo.get("numBuckets"));
+        NestableJsonFacet response = solrQueryResponse.getJsonFacetingResponse();
+        if (response != null && response.getBucketBasedFacetNames() != null) {
+            for (String facetName : response.getBucketBasedFacetNames()) {
+                BucketBasedJsonFacet facet = response.getBucketBasedFacets(facetName);
+                if (facet != null) {
+                    result.setTotalEntries(facet.getNumBucketsCount());
+                    for (BucketJsonFacet bucket : facet.getBuckets()) {
+                        String facetValue = bucket.getVal() != null ? bucket.getVal().toString() : "";
+                        String field = facetName + "_filter";
+                        String displayedValue = transformDisplayedValue(context, field, facetValue);
+                        String authorityValue = transformAuthorityValue(context, field, facetValue);
+                        String sortValue = transformSortValue(context, field, facetValue);
+                        String filterValue = displayedValue;
+                        if (StringUtils.isNotBlank(authorityValue)) {
+                            filterValue = authorityValue;
+                        }
+                        result.addFacetResult(facetName,
+                            new DiscoverResult.FacetResult(filterValue, displayedValue,
+                                authorityValue, sortValue, bucket.getCount(),
+                                DiscoveryConfigurationParameters.TYPE_TEXT));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## What & why

Fixes the slow `/browse/subject` (and any metadata `valueList` browse: subject/author/language) on **ZCU-PUB**. Root cause is upstream **[DSpace #9244](https://github.com/DSpace/DSpace/issues/9244)**: the pre-7.6.3 `SolrBrowseDAO` requests the Solr facet with `limit = -1`, so Solr returns **every** distinct value on every page request and the code discards all but the page. Cost ≈ O(distinct values).

ZCU-PUB has **254,531 distinct subjects**, so subject browse measured **~5.25 s mean (peak 11 s)** against `naos-be.zcu.cz`. This backports the upstream fix ([PR #10057](https://github.com/DSpace/DSpace/pull/10057)) — a `json.facet` terms query with server-side `limit`/`offset`/`numBuckets` — which returns only the requested page plus the exact total.

Full investigation, measurements and reproduction: **dataquest-dev/dspace-customers#668**.

## Changes

Cherry-pick of the two upstream 7.6.x backport commits (clean for the core fix; one trivial import/method conflict in `SolrServiceImpl.java` resolved to the refactored form):

- `fcc650e1a6` — *Add limit, offset, and a total-entry-count parameter to the metadata-navigation Solr query* (the core fix; touches `SolrBrowseDAO`, `SolrServiceImpl`, `DiscoverResult`, `BrowseEngine`).
- `d6ff41d9f5` — *Refactor browse entries facet query to use JSON facet query*.

`SolrBrowseDAO` now builds a `json.facet` terms facet on `<field>_filter` with `limit`/`offset`/`numBuckets:true`; `DiscoverResult.getTotalEntries()` is populated from `numBuckets`. No change to the date/item (`flatBrowse`) path.

## Notes

- **No Solr reindex required** — query-side change only; the `<field>_filter` fields already exist in the 7.6 schema (used by discovery facets).
- ZCU-PUB carries a browse customization (`ZCU-PUB/partial-word-match-browsing-using-api`); this branch is cut from current `customer/zcu-pub` `HEAD`, so that work (if merged) is preserved — please sanity-check partial-word browse after deploy.
- Same bug affects **TUL** (~2.37 s, 130k subjects); separate PR against `customer/TUL`. **ZCU-DATA** runs the same code but is unaffected (40 subjects) — no change needed there.

## Verification

- Local `mvn -pl dspace-api -am test-compile checkstyle:check` → **BUILD SUCCESS** (compiles + checkstyle clean).
- These commits are already merged upstream (shipped in dspace-7.6.3 / 10.0) and passed upstream CI incl. browse integration tests.

**Post-deploy acceptance** (re-run against `https://naos-be.zcu.cz/server/api`):
- `GET /discover/browses/subject/entries?page=0&size=20` mean **< 500 ms** (expect ~100–300 ms), and `page=0` ≈ `page=5`.
- `page.totalElements` unchanged (**254,531**) — proves the `numBuckets` total wiring is correct.
