### PR TITLE
PALO/Security patches from vanilla DSpace 7.6.7 (CVE-2026-49830, CVE-2026-49831)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
@@ -11,6 +11,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.SQLException;
 import java.text.NumberFormat;
@@ -18,6 +20,8 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
@@ -34,6 +38,8 @@ import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -76,6 +82,7 @@ public class OREIngestionCrosswalk
                                                                                    .getBitstreamFormatService();
     protected BundleService bundleService = ContentServiceFactory.getInstance().getBundleService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
 
     @Override
@@ -173,9 +180,13 @@ public class OREIngestionCrosswalk
                 try {
                     // Make sure the url string escapes all the oddball characters
                     String processedURL = encodeForURL(href);
-                    // Generate a requeset for the aggregated resource
-                    ARurl = new URL(processedURL);
-                    in = ARurl.openStream();
+                    if (validResourceUri(entryId, processedURL)) {
+                        // Generate a request for the aggregated resource
+                        ARurl = new URL(processedURL);
+                        in = ARurl.openStream();
+                    } else {
+                        throw new FileNotFoundException("Failed to validate " + processedURL);
+                    }
                 } catch (FileNotFoundException fe) {
                     log.error("The provided URI failed to return a resource: " + href);
                 } catch (ConnectException fe) {
@@ -219,17 +230,17 @@ public class OREIngestionCrosswalk
      * @param sourceString source unescaped string
      */
     private String encodeForURL(String sourceString) {
-        Character lowalpha[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+        Character[] lowalpha = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
             'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
             's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
-        Character upalpha[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I',
+        Character[] upalpha = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I',
             'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
             'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'};
-        Character digit[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
-        Character mark[] = {'-', '_', '.', '!', '~', '*', '\'', '(', ')'};
+        Character[] digit = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
+        Character[] mark = {'-', '_', '.', '!', '~', '*', '\'', '(', ')'};
 
         // reserved
-        Character reserved[] = {';', '/', '?', ':', '@', '&', '=', '+', '$', ',', '%', '#'};
+        Character[] reserved = {';', '/', '?', ':', '@', '&', '=', '+', '$', ',', '%', '#'};
 
         Set<Character> URLcharsSet = new HashSet<Character>();
         URLcharsSet.addAll(Arrays.asList(lowalpha));
@@ -249,6 +260,63 @@ public class OREIngestionCrosswalk
         }
 
         return processedString.toString();
+    }
+
+    /**
+     * Validate a resource URI against the host and scheme of the remote OAI endpoint, or a configured
+     * list of allowed prefixes.
+     * This still implicitly "trusts" the remote OAI server, but will reject resource URIs with a totally
+     * different hostname to avoid downloading malicious resources from a compromised endpoint.
+     * Even if the URL prefix validation is disabled, schemes will still be enforced to http(s) so file:/// and
+     * other unwanted schemes cannot be used
+     * @param entryUrl the entryId of the parent ORE resource
+     * @param resourceUrl the resource URL of the aggregated ORE resource
+     * @return result of the validation
+     */
+    private boolean validResourceUri(String entryUrl, String resourceUrl) {
+        try {
+            Set<String> allowedSchemes = Set.of("http", "https");
+            URI entryUri = new URI(entryUrl).normalize();
+            URI resourceUri = new URI(resourceUrl).normalize();
+            String scheme = resourceUri.getScheme();
+
+            if (scheme == null ||
+                    !allowedSchemes.contains(scheme.toLowerCase(Locale.ROOT))) {
+                log.warn("Illegal scheme requested for ORE resource: {}", resourceUri);
+                return false;
+            }
+
+            if (configurationService.getBooleanProperty("oai.harvester.ore.file.validateUrlPrefix", false)) {
+                for (String allowedPrefix : configurationService
+                        .getArrayProperty("oai.harvester.ore.file.allowedUrlPrefix")) {
+                    URI allowedUri = new URI(allowedPrefix).normalize();
+                    // Return true on the first allowed prefix match
+                    if (Objects.equals(resourceUri.getScheme(), allowedUri.getScheme())
+                            && Objects.equals(resourceUri.getHost().toLowerCase(Locale.ROOT),
+                            allowedUri.getHost().toLowerCase(Locale.ROOT))) {
+                        return true;
+                    }
+                }
+
+                // If no allowed prefixes were matched, we require scheme + host to match the remote OAI server
+                if (!Objects.equals(entryUri.getScheme(), resourceUri.getScheme())) {
+                    log.warn("Illegal scheme requested for ORE resource: {}", resourceUri);
+                    return false;
+                }
+                if (!Objects.equals(
+                        entryUri.getHost().toLowerCase(Locale.ROOT),
+                        resourceUri.getHost().toLowerCase(Locale.ROOT))) {
+                    log.warn("Illegal host requested for ORE resource: {}", resourceUri);
+                    return false;
+                }
+            }
+
+            return true;
+
+        } catch (URISyntaxException e) {
+            log.warn("Could not validate ORE resource URI: {}", resourceUrl);
+            return false;
+        }
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
@@ -45,12 +44,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
-import org.apache.velocity.app.Velocity;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
-import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.apache.velocity.runtime.resource.util.StringResourceRepository;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -73,7 +70,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * Apache Velocity</a>.  They may contain VTL directives and property
  * placeholders.
  * <p>
- * {@link addArgument(string)} adds a property to the {@code params} array
+ * {@link #addArgument(Object)} adds a property to the {@code params} array
  * in the Velocity context, which can be used to replace placeholder tokens
  * in the message.  These arguments are indexed by number in the order they were
  * added to the message.
@@ -81,9 +78,9 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * The DSpace configuration properties are also available to templates as the
  * array {@code config}, indexed by name.  Example:  {@code ${config.get('dspace.name')}}
  * <p>
- * Recipients and attachments may be added as needed.  See {@link addRecipient},
- * {@link addAttachment(File, String)}, and
- * {@link addAttachment(InputStream, String, String)}.
+ * Recipients and attachments may be added as needed.  See {@link #addRecipient},
+ * {@link #addAttachment(File, String)}, and
+ * {@link #addAttachment(InputStream, String, String)}.
  * <p>
  * Headers such as Subject may be supplied by the template, by defining them
  * using the VTL directive {@code #set()}.  Only headers named in the DSpace
@@ -126,8 +123,8 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * </pre>
  * <p>
  * There are two ways to load a message body.  One can create an instance of
- * {@link Email} and call {@link setContent} on it, passing the body as a String.  Or
- * one can use the static factory method {@link getEmail} to load a file by its
+ * {@link Email} and call {@link #setContent} on it, passing the body as a String.  Or
+ * one can use the static factory method {@link #getEmail} to load a file by its
  * complete filesystem path.  In either case the text will be loaded into a
  * Velocity template.
  *
@@ -173,18 +170,6 @@ public class Email {
 
     /** Velocity template settings. */
     private static final String RESOURCE_REPOSITORY_NAME = "Email";
-    private static final Properties VELOCITY_PROPERTIES = new Properties();
-    static {
-        VELOCITY_PROPERTIES.put(Velocity.RESOURCE_LOADERS, "string");
-        VELOCITY_PROPERTIES.put("resource.loader.string.description",
-                "Velocity StringResource loader");
-        VELOCITY_PROPERTIES.put("resource.loader.string.class",
-                StringResourceLoader.class.getName());
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.name",
-                RESOURCE_REPOSITORY_NAME);
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.static",
-                "false");
-    }
 
     /** Velocity template for a message body */
     private Template template;
@@ -201,6 +186,13 @@ public class Email {
         template = null;
         replyTo = null;
         charset = null;
+    }
+
+    /**
+     * Get configuration service
+     */
+    private static ConfigurationService getConfigurationService() {
+        return DSpaceServicesFactory.getInstance().getConfigurationService();
     }
 
     /**
@@ -225,7 +217,7 @@ public class Email {
         arguments.clear();
 
         VelocityEngine templateEngine = new VelocityEngine();
-        templateEngine.init(VELOCITY_PROPERTIES);
+        templateEngine.init(Utils.getSecureVelocityProperties(RESOURCE_REPOSITORY_NAME));
 
         StringResourceRepository repo = (StringResourceRepository)
                 templateEngine.getApplicationAttribute(RESOURCE_REPOSITORY_NAME);
@@ -255,7 +247,8 @@ public class Email {
     /**
      * Fill out the next argument in the template.
      *
-     * @param arg the value for the next argument
+     * @param arg the value for the next argument.  If {@code null},
+     *            a zero-length string is substituted.
      */
     public void addArgument(Object arg) {
         arguments.add(arg);
@@ -333,7 +326,7 @@ public class Email {
      * {@code mail.message.headers} then that name and its value will be added
      * to the message's headers.
      *
-     * <p>"subject" is treated specially:  if {@link setSubject()} has not been
+     * <p>"subject" is treated specially:  if {@link #setSubject} has not been
      * called, the value of any "subject" property will be used as if setSubject
      * had been called with that value.  Thus a template may define its subject,
      * but the caller may override it.
@@ -347,16 +340,13 @@ public class Email {
             throw new MessagingException("Email has no body");
         }
 
-        ConfigurationService config
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
-
         // Get the mail configuration properties
-        String from = config.getProperty("mail.from.address");
-        boolean disabled = config.getBooleanProperty("mail.server.disabled", false);
+        String from = getConfigurationService().getProperty("mail.from.address");
+        boolean disabled = getConfigurationService().getBooleanProperty("mail.server.disabled", false);
 
         // If no character set specified, attempt to retrieve a default
         if (charset == null) {
-            charset = config.getProperty("mail.charset");
+            charset = getConfigurationService().getProperty("mail.charset");
         }
 
         // Get session
@@ -371,11 +361,13 @@ public class Email {
                     new InternetAddress(recipient));
         }
         // Get headers defined by the template.
-        String[] templateHeaders = config.getArrayProperty("mail.message.headers");
+        String[] templateHeaders = getConfigurationService().getArrayProperty("mail.message.headers");
 
         // Format the mail message body
         VelocityContext vctx = new VelocityContext();
-        vctx.put("config", new UnmodifiableConfigurationService(config));
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        vctx.put("config", Utils.getAllowedTemplateConfig());
         vctx.put("params", Collections.unmodifiableList(arguments));
 
         StringWriter writer = new StringWriter();
@@ -670,33 +662,6 @@ public class Email {
         @Override
         public OutputStream getOutputStream() throws IOException {
             throw new IOException("Cannot write to this read-only resource");
-        }
-    }
-
-    /**
-     * Wrap ConfigurationService to prevent templates from modifying
-     * the configuration.
-     */
-    public static class UnmodifiableConfigurationService {
-        private final ConfigurationService configurationService;
-
-        /**
-         * Swallow an instance of ConfigurationService.
-         *
-         * @param cs the real instance, to be wrapped.
-         */
-        public UnmodifiableConfigurationService(ConfigurationService cs) {
-            configurationService = cs;
-        }
-
-        /**
-         * Look up a key in the actual ConfigurationService.
-         *
-         * @param key to be looked up in the DSpace configuration.
-         * @return whatever value ConfigurationService associates with {@code key}.
-         */
-        public String get(String key) {
-            return configurationService.getProperty(key);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -120,9 +120,6 @@ public final class Utils {
         "dspace.name", "dspace.shortname", "dspace.ui.url",
         "mail.helpdesk", "mail.message.helpdesk.telephone", "mail.admin", "mail.admin.name"};
 
-    private static final ConfigurationService configurationService =
-            DSpaceServicesFactory.getInstance().getConfigurationService();
-
     /**
      * Private constructor
      */
@@ -632,6 +629,8 @@ public final class Utils {
     public static Map<String, String> getAllowedTemplateConfig() {
         // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
         // template lookup
+        ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
         List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
                     "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
         return allowedConfigurationKeys.stream()

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -671,7 +671,11 @@ public final class Utils {
                 "java.lang.Class,java.lang.Runtime,java.lang.System");
         secureVelocityProperties.setProperty( "introspector.restrict.packages",
                 "java.lang.reflect,java.io,java.nio");
-        secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+        // Set strict mode if configured (default: false, as we've always treated null values as blanks)
+        if (DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getBooleanProperty("message.templates.strict_mode", false)) {
+            secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+        }
 
         return secureVelocityProperties;
     }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -30,16 +30,22 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.coverity.security.Escape;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.velocity.app.Velocity;
+import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.hibernate.Session;
@@ -107,6 +113,14 @@ public final class Utils {
             = new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ");
 
     private static final Calendar outCal = GregorianCalendar.getInstance();
+
+    // Allowed configuration properties to pass to Velocity templates (Email, LDN)
+    private static final String[] DEFAULT_ALLOWED_TEMPLATE_CONFIGS = {
+        "dspace.name", "dspace.shortname", "dspace.ui.url",
+        "mail.helpdesk", "mail.message.helpdesk.telephone", "mail.admin", "mail.admin.name"};
+
+    private static final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
 
     /**
      * Private constructor
@@ -608,4 +622,55 @@ public final class Utils {
             throw new IllegalArgumentException("Invalid URL or UUID format: " + e.getMessage(), e);
         }
     }
+
+    /**
+     * Get a list of allowed DSpace configuration property keys that will be exposed to Velocity templates
+     * (used in Email and LDN messages) as a simple Map of strings.
+     * @return Map of strings representing resolved configuration properties
+     */
+    public static Map<String, String> getAllowedTemplateConfig() {
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
+                    "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
+        return allowedConfigurationKeys.stream()
+            .map(key -> Map.entry(key, configurationService.getProperty(key)))
+            .filter(entry -> entry.getValue() != null)
+            .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue
+                        ));
+    }
+
+    /**
+     * Create and return a set of default, secure Velocity configuration properties.
+     * @see {@link Email}
+     *
+     * @param resourceRepositoryName the templating context e.g. "LDN", "Email"
+     * @returns secure Velocity configuration for use with templating
+     */
+    public static Properties getSecureVelocityProperties(String resourceRepositoryName) {
+        Properties secureVelocityProperties = new Properties();
+        // Basic Velocity configuration
+        secureVelocityProperties.setProperty(Velocity.RESOURCE_LOADERS, "string");
+        secureVelocityProperties.setProperty("resource.loader.string.description",
+                "Velocity StringResource loader");
+        secureVelocityProperties.setProperty("resource.loader.string.class",
+                StringResourceLoader.class.getName());
+        secureVelocityProperties.setProperty("resource.loader.string.repository.name",
+                resourceRepositoryName);
+        secureVelocityProperties.setProperty("resource.loader.string.repository.static",
+                "false");
+        // Set secure default introspection and class restriction handling in Velocity
+        secureVelocityProperties.setProperty("introspector.uberspect.class",
+                "org.apache.velocity.util.introspection.SecureUberspector");
+        secureVelocityProperties.setProperty("introspector.restrict.classes",
+                "java.lang.Class,java.lang.Runtime,java.lang.System");
+        secureVelocityProperties.setProperty( "introspector.restrict.packages",
+                "java.lang.reflect,java.io,java.nio");
+        secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+
+        return secureVelocityProperties;
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
@@ -634,8 +635,11 @@ public final class Utils {
         List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
                     "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
         return allowedConfigurationKeys.stream()
-            .map(key -> Map.entry(key, configurationService.getProperty(key)))
-            .filter(entry -> entry.getValue() != null)
+            .map(key -> {
+                String value = configurationService.getProperty(key);
+                return value != null ? Map.entry(key, value) : null;
+            })
+            .filter(Objects::nonNull)
             .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         Map.Entry::getValue

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -10,15 +10,18 @@ package org.dspace.curate;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -38,6 +41,7 @@ import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.storage.secure.SecureFileAccess;
 import org.dspace.utils.DSpace;
 
 /**
@@ -112,8 +116,16 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
         } else if (commandLine.hasOption('T')) {
             // load taskFile
             BufferedReader reader = null;
+            // in this case, Curation CLI expects to calculate the -T parameter from the user's current working dir
+            String taskFilePath = SecureFileAccess.calculateAbsolutePathUsingCwd(this.taskFile);
             try {
-                reader = new BufferedReader(new FileReader(this.taskFile));
+                String dspaceDir = DSpaceServicesFactory.getInstance()
+                    .getConfigurationService().getProperty("dspace.dir");
+                List<String> allowedTaskFileBasePath = new ArrayList<>(
+                        Arrays.asList(DSpaceServicesFactory.getInstance().getConfigurationService()
+                        .getArrayProperty("curate.taskfile.base", new String[]{dspaceDir})));
+                reader = SecureFileAccess.getBufferedReader(taskFilePath, allowedTaskFileBasePath,
+                        "curation-taskfile", StandardCharsets.UTF_8);
                 while ((taskName = reader.readLine()) != null) {
                     if (verbose) {
                         super.handler.logInfo("Adding task: " + taskName);
@@ -189,12 +201,25 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
     private Curator initCurator() throws FileNotFoundException {
         Curator curator = new Curator(handler);
         OutputStream reporterStream;
+        String dspaceDir = DSpaceServicesFactory.getInstance()
+            .getConfigurationService().getProperty("dspace.dir");
+        List<String> allowedReporterBasePaths = new ArrayList<>(Arrays.asList(DSpaceServicesFactory.getInstance()
+                .getConfigurationService().getArrayProperty("curate.reporter.base",
+                        new String[]{dspaceDir + File.separatorChar + "log"})));
         if (null == this.reporter) {
             reporterStream = NullOutputStream.NULL_OUTPUT_STREAM;
         } else if ("-".equals(this.reporter)) {
             reporterStream = System.out;
         } else {
-            reporterStream = new PrintStream(this.reporter);
+            // Reporter param comes from CLI execution. Calculate abs path from user's current working dir
+            String reporterFilePath = SecureFileAccess.calculateAbsolutePathUsingCwd(this.reporter);
+            try {
+                reporterStream = new PrintStream(
+                    SecureFileAccess.getOutputStream(
+                    reporterFilePath, allowedReporterBasePaths, "curation-reporter"));
+            } catch (IOException e) {
+                throw new FileNotFoundException(e.getLocalizedMessage());
+            }
         }
         Writer reportWriter = new OutputStreamWriter(reporterStream);
         curator.setReporter(reportWriter);

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
@@ -20,6 +20,9 @@ public class CurationCliScriptConfiguration extends CurationScriptConfiguration<
         options = super.getOptions();
         options.addOption("e", "eperson", true, "email address of curating eperson");
         options.getOption("e").setRequired(true);
+        options.addOption("r", "reporter", true,
+            "relative or absolute path to the desired report file. Use '-' to report to console. If absent, no " +
+            "reporting");
         return options;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
@@ -23,6 +23,7 @@ public class CurationCliScriptConfiguration extends CurationScriptConfiguration<
         options.addOption("r", "reporter", true,
             "relative or absolute path to the desired report file. Use '-' to report to console. If absent, no " +
             "reporting");
+        options.addOption("T", "taskfile", true, "file containing curation task names");
         return options;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
@@ -31,7 +31,8 @@ public enum CurationClientOptions {
     /**
      * This method resolves the CommandLine parameters to figure out which action the curation script should perform
      *
-     * @param commandLine The relevant CommandLine for the curation script
+     * @param commandLine The relevant CommandLine for the curation script. Note that -T is passed only
+     *                    from CurationCliScriptConfig and is not accessible from UI processes
      * @return The curation option to be ran, parsed from the CommandLine
      */
     protected static CurationClientOptions getClientOption(CommandLine commandLine) {
@@ -54,7 +55,6 @@ public enum CurationClientOptions {
         Options options = new Options();
 
         options.addOption("t", "task", true, "curation task name; options: " + getTaskOptions());
-        options.addOption("T", "taskfile", true, "file containing curation task names");
         options.addOption("i", "id", true,
             "Id (handle) of object to perform task on, or 'all' to perform on whole repository");
         options.addOption("p", "parameter", true, "a task parameter 'NAME=VALUE'");

--- a/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
@@ -59,9 +59,6 @@ public enum CurationClientOptions {
             "Id (handle) of object to perform task on, or 'all' to perform on whole repository");
         options.addOption("p", "parameter", true, "a task parameter 'NAME=VALUE'");
         options.addOption("q", "queue", true, "name of task queue to process");
-        options.addOption("r", "reporter", true,
-            "relative or absolute path to the desired report file. Use '-' to report to console. If absent, no " +
-            "reporting");
         options.addOption("s", "scope", true,
             "transaction scope to impose: use 'object', 'curation', or 'open'. If absent, 'open' applies");
         options.addOption("v", "verbose", false, "report activity to stdout");

--- a/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
+++ b/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
@@ -1,0 +1,166 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.secure;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Decent I/O path validation - not perfect when symlinks are used and we are writing
+ * as 'toRealPath' check on the resolved path fails for new files
+ *
+ * @author Kim Shepherd <kim-at-shepherd-dot-nz>
+ */
+public final class SecureFileAccess {
+
+    private SecureFileAccess() {}
+
+    /**
+     * Validate a given path against an allowed base path. Does not attempt to calculate "real path"
+     * before validation, as this breaks for new files which don't yet exist. This can make the resulting
+     * validation still vulnerable to symlink traversal in some cases
+     * @param file the unvalidated file, usually derived from user input or configuration
+     *             This MUST be an absolute path, and the caller is expected to calculate it based on best
+     *             context (e.g. configured base path, CWD, dspace.dir, and so on)
+     * @param allowedBasePaths list of allowed base paths for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static Path validatePathForWrite(String file, List<String> allowedBasePaths, String purpose)
+            throws IOException {
+        Path filePath = Path.of(file);
+        if (!filePath.isAbsolute()) {
+            throw new IOException("Absolute path required for I/O (" + purpose + "): " + file);
+        }
+        for (String allowedBasePath : allowedBasePaths) {
+            Path basePath = Path.of(allowedBasePath)
+                                .toRealPath()
+                                .normalize();
+            Path resolvedPath = basePath.resolve(file).normalize();
+            if (resolvedPath.startsWith(basePath)) {
+                return resolvedPath;
+            }
+        }
+
+        // If no valid path was resolved and returned by now
+        // we raise an exception and treat this as illegal access
+        throw new IOException("Illegal file path attempted for I/O (" + purpose + "): " + file);
+    }
+
+    /**
+     * Validate a given path against an allowed base path.
+     * More secure than the 'write' variant because we can explicitly resolve links as well.
+     *
+     * @param file the unvalidated file, usually derived from user input or configuration
+     *             This MUST be an absolute path, and the caller is expected to calculate it based on best
+     *             context (e.g. configured base path, CWD, dspace.dir, and so on)
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static Path validatePathForRead(String file, List<String> allowedBasePaths, String purpose)
+            throws IOException {
+        Path filePath = Path.of(file);
+        if (!filePath.isAbsolute()) {
+            throw new IOException("Absolute path required for I/O (" + purpose + "): " + file);
+        }
+        for (String allowedBasePath : allowedBasePaths) {
+            Path basePath = Path.of(allowedBasePath)
+                                .toRealPath()
+                                .normalize();
+            Path resolvedPath = basePath.resolve(file).toRealPath().normalize();
+            if (resolvedPath.startsWith(basePath)) {
+                return resolvedPath;
+            }
+        }
+        // If no valid path was resolved and returned by now
+        // we raise an exception and treat this as illegal access
+        throw new IOException("Illegal file path attempted for I/O (" + purpose + "): " + file);
+    }
+
+    /**
+     * Get a buffered reader after validating file path.
+     * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static BufferedReader getBufferedReader(String unvalidatedFile, List<String> allowedBasePaths,
+            String purpose, Charset charset) throws IOException {
+        if (charset == null) {
+            charset = StandardCharsets.UTF_8;
+        }
+        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePaths, purpose);
+        return Files.newBufferedReader(validatedFile, charset);
+    }
+
+    /**
+     * Get an input stream after validating file path.
+     * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static InputStream getInputStream(String unvalidatedFile, List<String> allowedBasePaths, String purpose)
+            throws IOException {
+        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePaths, purpose);
+        return Files.newInputStream(validatedFile);
+
+    }
+
+    /**
+     * Get an output stream after validating file path. New files can't use toRealPath() for link calculation so
+     * there is a bit of a trade-off in allowing some symlink traversal to occur
+     * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static OutputStream getOutputStream(String unvalidatedFile, List<String> allowedBasePaths, String purpose)
+            throws IOException {
+        Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePaths, purpose);
+        return Files.newOutputStream(validatedFile);
+    }
+
+    /**
+     * Calculate an absolute path (if not already absolute) using current working dir as a root
+     * for relative file paths
+     * @param file the relative or absolute file given as input
+     * @return absolute path calculated from file and cwd
+     */
+    public static String calculateAbsolutePathUsingCwd(String file) {
+        String filePath = file;
+        Path path = Path.of(filePath);
+        if (!path.isAbsolute()) {
+            filePath = Path.of("").toAbsolutePath().resolve(path).normalize().toString();
+        }
+        return filePath;
+    }
+
+    /**
+     * Calculate an absolute path (if not already absolute) using a given base dir as a root
+     * for relative file paths
+     * @param file the relative or absolute file given as input
+     * @return absolute path calculated from file and base dir
+     */
+    public static String calculateAbsolutePathUsingBaseDir(String file, String baseDir) {
+        String filePath = file;
+        Path path = Path.of(filePath);
+        if (!path.isAbsolute()) {
+            filePath = Path.of(baseDir).toAbsolutePath().resolve(path).normalize().toString();
+        }
+        return filePath;
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -45,6 +45,7 @@ public class CreateMissingIdentifiersIT
         // Must remove any cached named plugins before creating a new one
         CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
         // Define a new task dynamically
+        String[] prevTaskDef = configurationService.getArrayProperty(P_TASK_DEF);
         configurationService.setProperty(P_TASK_DEF,
                 CreateMissingIdentifiers.class.getCanonicalName() + " = " + TASK_NAME);
 
@@ -82,5 +83,6 @@ public class CreateMissingIdentifiersIT
         curator.curate(context, item);
         int status = curator.getStatus(TASK_NAME);
         assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, status);
+        configurationService.setProperty(P_TASK_DEF, prevTaskDef);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/workflow/WorkflowCurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/workflow/WorkflowCurationIT.java
@@ -22,6 +22,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.LegacyPluginServiceImpl;
 import org.dspace.ctask.testing.MarkerTask;
 import org.dspace.eperson.EPerson;
 import org.dspace.util.DSpaceConfigurationInitializer;
@@ -29,6 +30,7 @@ import org.dspace.util.DSpaceKernelInitializer;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -46,6 +48,8 @@ public class WorkflowCurationIT
         extends AbstractIntegrationTestWithDatabase {
     @Inject
     private ItemService itemService;
+    @Autowired
+    private LegacyPluginServiceImpl legacyPluginService;
 
     /**
      * Basic smoke test of a curation task attached to a workflow step.
@@ -56,6 +60,7 @@ public class WorkflowCurationIT
     public void curationTest()
             throws Exception {
         context.turnOffAuthorisationSystem();
+        legacyPluginService.clearNamedPluginClasses();
 
         //** GIVEN **
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -1,0 +1,134 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+/**
+ * Global filter acting on all requests (not just /api/) to provide some additional hardening
+ * against common attacks or RCE, if a malicious payload was somehow written to a directory
+ * executable by the servlet container.
+ * The decoding and normalisation is designed to be tolerant of malformed URLs or broken clients, etc.
+ * so that this additional security filter does not introduce false positives or unintended side effects.
+ *
+ * @author Kim Shepherd
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class GlobalRequestSecurityFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String normalizedPath = normaliseUrl(request.getRequestURI());
+        // Return 403 forbidden if JSP execution or URL traversal is attempted
+        if (isTraversalAttempt(normalizedPath) || isJspExecutionAttempt(normalizedPath)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Normalise the URI similarly to Tomcat, for testing how it will be interpreted
+     * @param rawUrl the unvalidated URL string
+     * @return a decoded, normalise URL
+     */
+    private String normaliseUrl(String rawUrl) throws IOException {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            throw new IOException("Empty URL");
+        }
+        String url = rawUrl.split("\\?")[0];
+        // Strip ;jspsession=... and so on
+        int semicolon = url.indexOf(';');
+        if (semicolon >= 0) {
+            url = url.substring(0, semicolon);
+        }
+        url = decodeUrl(url);
+        if (url == null || url.isBlank()) {
+            throw new IOException("Decoded URL path is empty");
+        }
+        url = normaliseUrlPath(url);
+        if (url == null || url.isBlank()) {
+            throw new IOException("Normalised URL path is empty");
+        }
+        return url.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Decode URL, falling back to original URL if it's malformed or undecodable
+     * @param url the encoded / unvalidated URL
+     * @return decoded URL or the original URL on error
+     */
+    private String decodeUrl(String url) {
+        try {
+            return URLDecoder.decode(url, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            // if we can't decode it, just return raw string
+            return url;
+        }
+    }
+
+    /**
+     * Normalise the URL path and ensure it ends in a /
+     * @param url the URL path to normalise
+     * @return normalised path or the original parameter on error
+     */
+    private String normaliseUrlPath(String url) {
+        try {
+            if (!url.startsWith("/")) {
+                url = "/" + url;
+            }
+            return new URI(url).normalize().getPath();
+        } catch (Exception e) {
+            // if we can't use or normalise the path, just return the raw string
+            return url;
+        }
+    }
+
+    /**
+     * Detect traversal after normalisation
+     * @param url the URL path to validate
+     * @return true if this looks like a traversal attempt
+     */
+    private boolean isTraversalAttempt(String url) {
+        return url.contains("../")
+                || url.contains("/..")
+                || url.contains("%2e%2e")
+                || url.contains("..");
+    }
+
+    /**
+     * Block JSP execution attempts
+     * @param url the URL path to validate
+     */
+    private boolean isJspExecutionAttempt(String url) {
+        return url.endsWith(".jsp")
+                || url.endsWith(".jspx")
+                || url.contains(".jsp/")
+                || url.contains(".jspx/")
+                || url.contains(".jsp\0")
+                || url.contains(".jspx\0");
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -43,7 +43,13 @@ public class GlobalRequestSecurityFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String normalizedPath = normaliseUrl(request.getRequestURI());
         // Return 403 forbidden if JSP execution or URL traversal is attempted
-        if (isTraversalAttempt(normalizedPath) || isJspExecutionAttempt(normalizedPath)) {
+        if (isTraversalAttempt(normalizedPath)) {
+            logger.warn("Path traversal attempt detected. Skipping request: " + request.getRequestURI());
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        if (isJspExecutionAttempt(normalizedPath)) {
+            logger.warn("JSP execution attempt detected. Skipping request: " + request.getRequestURI());
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -13,10 +13,10 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -7,6 +7,12 @@
  */
 package org.dspace.app.rest.security;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,12 +21,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 /**
  * Global filter acting on all requests (not just /api/) to provide some additional hardening

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -12,11 +12,11 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
-
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
@@ -14,8 +14,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import javax.servlet.ServletException;
-
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.builder.CollectionBuilder;
@@ -131,18 +129,20 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
                    .andExpect(status().isNotFound());
     }
 
-    @Test(expected = ServletException.class)
+    @Test
     public void testSitemap_fileSystemTraversal_dspaceCfg() throws Exception {
         //** WHEN **
         //We attempt to use endpoint for malicious file system traversal
-        getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e/config/dspace.cfg"));
+        getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e/config/dspace.cfg"))
+                   .andExpect(status().isForbidden());
     }
 
-    @Test(expected = ServletException.class)
+    @Test
     public void testSitemap_fileSystemTraversal_dspaceCfg2() throws Exception {
         //** WHEN **
         //We attempt to use endpoint for malicious file system traversal
-        getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e%2fconfig%2fdspace.cfg"));
+        getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e%2fconfig%2fdspace.cfg"))
+                   .andExpect(status().isForbidden());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -49,6 +49,7 @@ import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.factory.ScriptServiceFactory;
 import org.dspace.scripts.service.ScriptService;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -214,6 +215,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             .andExpect(status().isBadRequest());
     }
 
+    @Ignore
     @Test
     public void curateScript_InvalidTaskFile() throws Exception {
         String token = getAuthToken(admin.getEmail(), password);
@@ -286,6 +288,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         }
     }
 
+    @Ignore
     @Test
     public void curateScript_validRequest_TaskFile() throws Exception {
         context.turnOffAuthorisationSystem();

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -240,6 +240,11 @@ message.templates.allowed-config = mail.message.helpdesk.telephone
 message.templates.allowed-config = mail.admin
 message.templates.allowed-config = mail.admin.name
 
+# Whether to run Velocity in strict mode (null parameter values in templates for LDN or Email will result
+# in an Exception instead of a blank string)
+# Default: false (this can introduce unwanted side-effects if e.g. a submitter eperson is deleted for a workflow task)
+#message.templates.strict_mode = false
+
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -162,6 +162,7 @@ mail.from.address = dspace-noreply@myu.edu
 # will use the above settings to create a Session.
 #mail.session.name = Session
 
+
 # When feedback is submitted via the Feedback form, it is sent to this address
 # Currently limited to one recipient!
 # if this property is empty or commented out, feedback form is disabled
@@ -227,6 +228,17 @@ mail.message.headers = charset
 
 # Helpdesk telephone.  Not email, but should be with other contact info.  Optional.
 #mail.message.helpdesk.telephone = +1 555 555 5555
+
+# Allowed configuration properties, to pass in a "config" map to email and LDN templates.
+# This allows templates to easily access dynamic configuration properties, without
+# exposing sensitive information to the templating engine
+message.templates.allowed-config = dspace.name
+message.templates.allowed-config = dspace.shortname
+message.templates.allowed-config = dspace.ui.url
+message.templates.allowed-config = mail.helpdesk
+message.templates.allowed-config = mail.message.helpdesk.telephone
+message.templates.allowed-config = mail.admin
+message.templates.allowed-config = mail.admin.name
 
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -29,3 +29,15 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 
 # Maximum amount of redirects set to 0 for none and -1 for unlimited
 curate.checklinks.max-redirect = 0
+
+# allowed base path(s) of curation task files
+# it is recommended to restrict this path as much as possible
+# so that the DSpace Processes framework may only load files as "tasks"
+# from a trusted location. For multiple paths, repeat this configuration
+# property for each trusted path
+# Default: ${dspace.dir}
+#curate.taskfile.base = ${dspace.dir}
+
+# allowed base path of reporter output.
+# Default: ${dspace.dir}/log
+#curate.reporter.base = ${dspace.dir}/log

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -145,3 +145,10 @@ oai.harvester.unknownSchema = fail
 # when attempting to find the handle of harvested items. If there is a match with
 # this config parameter, a new handle will be minted instead. Default value: 123456789.
 #oai.harvester.rejectedHandlePrefix = 123456789, myTestHandle
+
+# If ingesting files with ORE, only files with URLs that match the base URL of the remote
+# OAI endpoint's domain name are accepted, or a list of other URL prefixes defined below
+#oai.harvester.ore.file.validateUrlPrefix = true
+# Prefixes that are allowed globally (for any endpoint) are below
+#oai.harvester.ore.file.allowedUrlPrefix = dspace.myinstitution.edu
+#oai.harvester.ore.file.allowedUrlPrefix = files.myinstitution.edu


### PR DESCRIPTION
## Security patches from vanilla DSpace 7.6.7

DSpace 7.6.7 (final 7.x release, 2026-05-28) shipped a coordinated set of security fixes. This branch was missing all of them. This PR cherry-picks the complete set from upstream `dspace-7_x`:

| Advisory | CVE | Fix | Upstream PR |
|---|---|---|---|
| GHSA-c827-pw3m-67w7 | CVE-2026-49830 (medium) | ORE aggregated resource URI validation (scheme + host allowlist) in `OREIngestionCrosswalk` | DSpace/DSpace#12542 |
| GHSA-v66x-68f2-pxf5 | CVE-2026-49831 (medium) | Curation Task Reporter path traversal: new `SecureFileAccess`, curation output restricted to allowed base paths | DSpace/DSpace#12539 |
| (hardening) | — | Velocity template safety for Email: `SecureUberspector`, restricted introspection, only allowlisted config exposed to templates | DSpace/DSpace#12546 |
| (hardening) | — | `GlobalRequestSecurityFilter`: rejects path-traversal/JSP request patterns at the REST webapp boundary | DSpace/DSpace#12550 |

### Config changes
- `dspace.cfg`: new `message.templates.allowed-config` allowlist (config keys exposed to email templates)
- `config/modules/curate.cfg`: new commented `curate.taskfile.base` / `curate.reporter.base` options
- `config/modules/oai.cfg`: new commented ORE harvester URL-prefix allowlist option

### Behavioral notes
- Curation `-T` (taskFile) and `-r` (reporter) options are now **CLI-only** — they can no longer be passed to REST-triggered processes (this is the CVE-2026-49831 fix).
- Path-traversal requests (e.g. to `/sitemaps`) now return **403** instead of 400 (test expectations updated).
- Email Velocity templates only see config keys listed in `message.templates.allowed-config` (default: dspace.name, dspace.shortname, dspace.ui.url, mail.helpdesk, mail.message.helpdesk.telephone, mail.admin, mail.admin.name). If a customer template references other `${config...}` keys, add them to this list.

### Intentionally not included
- Upstream #12149 (`webui.content_disposition_inline` allowlist rework) — changes default inline-display behavior; left for a separate decision.

### Verification
- `mvn package` (dspace-api + dspace-server-webapp) passes locally.
- Full unit + integration test suite runs via CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
