### PR TITLE
MENDELU/Security patches from vanilla DSpace 9.3 (CVE-2026-49830..49833 incl. LDN RCE)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
@@ -11,6 +11,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.SQLException;
 import java.text.NumberFormat;
@@ -18,6 +20,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
@@ -34,6 +38,8 @@ import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -76,6 +82,7 @@ public class OREIngestionCrosswalk
                                                                                    .getBitstreamFormatService();
     protected BundleService bundleService = ContentServiceFactory.getInstance().getBundleService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
 
     @Override
@@ -173,9 +180,13 @@ public class OREIngestionCrosswalk
                 try {
                     // Make sure the url string escapes all the oddball characters
                     String processedURL = encodeForURL(href);
-                    // Generate a request for the aggregated resource
-                    ARurl = new URL(processedURL);
-                    in = ARurl.openStream();
+                    if (validResourceUri(entryId, processedURL)) {
+                        // Generate a request for the aggregated resource
+                        ARurl = new URL(processedURL);
+                        in = ARurl.openStream();
+                    } else {
+                        throw new FileNotFoundException("Failed to validate " + processedURL);
+                    }
                 } catch (FileNotFoundException fe) {
                     log.error("The provided URI failed to return a resource: " + href);
                 } catch (ConnectException fe) {
@@ -250,6 +261,63 @@ public class OREIngestionCrosswalk
         }
 
         return processedString.toString();
+    }
+
+    /**
+     * Validate a resource URI against the host and scheme of the remote OAI endpoint, or a configured
+     * list of allowed prefixes.
+     * This still implicitly "trusts" the remote OAI server, but will reject resource URIs with a totally
+     * different hostname to avoid downloading malicious resources from a compromised endpoint.
+     * Even if the URL prefix validation is disabled, schemes will still be enforced to http(s) so file:/// and
+     * other unwanted schemes cannot be used
+     * @param entryUrl the entryId of the parent ORE resource
+     * @param resourceUrl the resource URL of the aggregated ORE resource
+     * @return result of the validation
+     */
+    private boolean validResourceUri(String entryUrl, String resourceUrl) {
+        try {
+            Set<String> allowedSchemes = Set.of("http", "https");
+            URI entryUri = new URI(entryUrl).normalize();
+            URI resourceUri = new URI(resourceUrl).normalize();
+            String scheme = resourceUri.getScheme();
+
+            if (scheme == null ||
+                    !allowedSchemes.contains(scheme.toLowerCase(Locale.ROOT))) {
+                log.warn("Illegal scheme requested for ORE resource: {}", resourceUri);
+                return false;
+            }
+
+            if (configurationService.getBooleanProperty("oai.harvester.ore.file.validateUrlPrefix", false)) {
+                for (String allowedPrefix : configurationService
+                        .getArrayProperty("oai.harvester.ore.file.allowedUrlPrefix")) {
+                    URI allowedUri = new URI(allowedPrefix).normalize();
+                    // Return true on the first allowed prefix match
+                    if (Objects.equals(resourceUri.getScheme(), allowedUri.getScheme())
+                            && Objects.equals(resourceUri.getHost().toLowerCase(Locale.ROOT),
+                            allowedUri.getHost().toLowerCase(Locale.ROOT))) {
+                        return true;
+                    }
+                }
+
+                // If no allowed prefixes were matched, we require scheme + host to match the remote OAI server
+                if (!Objects.equals(entryUri.getScheme(), resourceUri.getScheme())) {
+                    log.warn("Illegal scheme requested for ORE resource: {}", resourceUri);
+                    return false;
+                }
+                if (!Objects.equals(
+                        entryUri.getHost().toLowerCase(Locale.ROOT),
+                        resourceUri.getHost().toLowerCase(Locale.ROOT))) {
+                    log.warn("Illegal host requested for ORE resource: {}", resourceUri);
+                    return false;
+                }
+            }
+
+            return true;
+
+        } catch (URISyntaxException e) {
+            log.warn("Could not validate ORE resource URI: {}", resourceUrl);
+            return false;
+        }
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -596,7 +596,7 @@ public class Email {
             System.out.println(" - To: " + to);
             System.out.println(" - Subject: " + subject);
             System.out.println(" - Server: " + server);
-            boolean disabled = configurationService.getBooleanProperty("mail.server.disabled", false);
+            boolean disabled = getConfigurationService().getBooleanProperty("mail.server.disabled", false);
             if (disabled) {
                 System.err.println("\nError sending email:");
                 System.err.println(" - Error: cannot test email because mail.server.disabled is set to true");

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Properties;
 
 import jakarta.activation.DataHandler;
 import jakarta.activation.DataSource;
@@ -44,18 +43,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
-import org.apache.velocity.app.Velocity;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
-import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.apache.velocity.runtime.resource.util.StringResourceRepository;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
- * Builder representing an e-mail message.  The {@link send} method causes the
+ * Builder representing an e-mail message.  The {@link #send} method causes the
  * assembled message to be formatted and sent.
  * <p>
  * Typical use:
@@ -72,7 +69,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * Apache Velocity</a>.  They may contain VTL directives and property
  * placeholders.
  * <p>
- * {@link addArgument(string)} adds a property to the {@code params} array
+ * {@link #addArgument(Object)} adds a property to the {@code params} array
  * in the Velocity context, which can be used to replace placeholder tokens
  * in the message.  These arguments are indexed by number in the order they were
  * added to the message.
@@ -80,9 +77,9 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * The DSpace configuration properties are also available to templates as the
  * array {@code config}, indexed by name.  Example:  {@code ${config.get('dspace.name')}}
  * <p>
- * Recipients and attachments may be added as needed.  See {@link addRecipient},
- * {@link addAttachment(File, String)}, and
- * {@link addAttachment(InputStream, String, String)}.
+ * Recipients and attachments may be added as needed.  See {@link #addRecipient},
+ * {@link #addAttachment(File, String)}, and
+ * {@link #addAttachment(InputStream, String, String)}.
  * <p>
  * Headers such as Subject may be supplied by the template, by defining them
  * using the VTL directive {@code #set()}.  Only headers named in the DSpace
@@ -125,8 +122,8 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * </pre>
  * <p>
  * There are two ways to load a message body.  One can create an instance of
- * {@link Email} and call {@link setContent} on it, passing the body as a String.  Or
- * one can use the static factory method {@link getEmail} to load a file by its
+ * {@link Email} and call {@link #setContent} on it, passing the body as a String.  Or
+ * one can use the static factory method {@link #getEmail} to load a file by its
  * complete filesystem path.  In either case the text will be loaded into a
  * Velocity template.
  *
@@ -173,20 +170,11 @@ public class Email {
 
     private static final Logger LOG = LogManager.getLogger();
 
+    private static final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+
     /** Velocity template settings. */
     private static final String RESOURCE_REPOSITORY_NAME = "Email";
-    private static final Properties VELOCITY_PROPERTIES = new Properties();
-    static {
-        VELOCITY_PROPERTIES.put(Velocity.RESOURCE_LOADERS, "string");
-        VELOCITY_PROPERTIES.put("resource.loader.string.description",
-                "Velocity StringResource loader");
-        VELOCITY_PROPERTIES.put("resource.loader.string.class",
-                StringResourceLoader.class.getName());
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.name",
-                RESOURCE_REPOSITORY_NAME);
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.static",
-                "false");
-    }
 
     /** Velocity template for a message body */
     private Template template;
@@ -230,7 +218,7 @@ public class Email {
         arguments.clear();
 
         VelocityEngine templateEngine = new VelocityEngine();
-        templateEngine.init(VELOCITY_PROPERTIES);
+        templateEngine.init(Utils.getSecureVelocityProperties(RESOURCE_REPOSITORY_NAME));
 
         StringResourceRepository repo = (StringResourceRepository)
                 templateEngine.getApplicationAttribute(RESOURCE_REPOSITORY_NAME);
@@ -364,7 +352,7 @@ public class Email {
      * {@code mail.message.headers} then that name and its value will be added
      * to the message's headers.
      *
-     * <p>"subject" is treated specially:  if {@link setSubject()} has not been
+     * <p>"subject" is treated specially:  if {@link #setSubject} has not been
      * called, the value of any "subject" property will be used as if setSubject
      * had been called with that value.  Thus a template may define its subject,
      * but the caller may override it.
@@ -383,11 +371,11 @@ public class Email {
                 = DSpaceServicesFactory.getInstance().getConfigurationService();
 
         // Get the mail configuration properties
-        String from = config.getProperty("mail.from.address");
+        String from = configurationService.getProperty("mail.from.address");
 
         // If no character set specified, attempt to retrieve a default
         if (charset == null) {
-            charset = config.getProperty("mail.charset");
+            charset = configurationService.getProperty("mail.charset");
         }
 
         // Get session
@@ -402,11 +390,13 @@ public class Email {
                     new InternetAddress(recipient));
         }
         // Get headers defined by the template.
-        String[] templateHeaders = config.getArrayProperty("mail.message.headers");
+        String[] templateHeaders = configurationService.getArrayProperty("mail.message.headers");
 
         // Format the mail message body
         VelocityContext vctx = new VelocityContext();
-        vctx.put("config", new UnmodifiableConfigurationService(config));
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        vctx.put("config", Utils.getAllowedTemplateConfig());
         vctx.put("params", Collections.unmodifiableList(arguments));
 
         StringWriter writer = new StringWriter();
@@ -607,7 +597,7 @@ public class Email {
             System.out.println(" - To: " + to);
             System.out.println(" - Subject: " + subject);
             System.out.println(" - Server: " + server);
-            boolean disabled = config.getBooleanProperty("mail.server.disabled", false);
+            boolean disabled = configurationService.getBooleanProperty("mail.server.disabled", false);
             if (disabled) {
                 System.err.println("\nError sending email:");
                 System.err.println(" - Error: cannot test email because mail.server.disabled is set to true");
@@ -707,33 +697,6 @@ public class Email {
         @Override
         public OutputStream getOutputStream() throws IOException {
             throw new IOException("Cannot write to this read-only resource");
-        }
-    }
-
-    /**
-     * Wrap ConfigurationService to prevent templates from modifying
-     * the configuration.
-     */
-    public static class UnmodifiableConfigurationService {
-        private final ConfigurationService configurationService;
-
-        /**
-         * Swallow an instance of ConfigurationService.
-         *
-         * @param cs the real instance, to be wrapped.
-         */
-        public UnmodifiableConfigurationService(ConfigurationService cs) {
-            configurationService = cs;
-        }
-
-        /**
-         * Look up a key in the actual ConfigurationService.
-         *
-         * @param key to be looked up in the DSpace configuration.
-         * @return whatever value ConfigurationService associates with {@code key}.
-         */
-        public String get(String key) {
-            return configurationService.getProperty(key);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -170,9 +170,6 @@ public class Email {
 
     private static final Logger LOG = LogManager.getLogger();
 
-    private static final ConfigurationService configurationService =
-            DSpaceServicesFactory.getInstance().getConfigurationService();
-
     /** Velocity template settings. */
     private static final String RESOURCE_REPOSITORY_NAME = "Email";
 
@@ -194,6 +191,13 @@ public class Email {
         template = null;
         replyTo = null;
         charset = null;
+    }
+
+    /**
+     * Get configuration service
+     */
+    private static ConfigurationService getConfigurationService() {
+        return DSpaceServicesFactory.getInstance().getConfigurationService();
     }
 
     /**
@@ -336,9 +340,7 @@ public class Email {
     public void send() throws MessagingException, IOException {
         build();
 
-        ConfigurationService config
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
-        boolean disabled = config.getBooleanProperty("mail.server.disabled", false);
+        boolean disabled = getConfigurationService().getBooleanProperty("mail.server.disabled", false);
         if (disabled) {
             LOG.info(format(message, body));
         } else {
@@ -367,15 +369,12 @@ public class Email {
             throw new MessagingException("Email has no body");
         }
 
-        ConfigurationService config
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
-
         // Get the mail configuration properties
-        String from = configurationService.getProperty("mail.from.address");
+        String from = getConfigurationService().getProperty("mail.from.address");
 
         // If no character set specified, attempt to retrieve a default
         if (charset == null) {
-            charset = configurationService.getProperty("mail.charset");
+            charset = getConfigurationService().getProperty("mail.charset");
         }
 
         // Get session
@@ -390,7 +389,7 @@ public class Email {
                     new InternetAddress(recipient));
         }
         // Get headers defined by the template.
-        String[] templateHeaders = configurationService.getArrayProperty("mail.message.headers");
+        String[] templateHeaders = getConfigurationService().getArrayProperty("mail.message.headers");
 
         // Format the mail message body
         VelocityContext vctx = new VelocityContext();

--- a/dspace-api/src/main/java/org/dspace/core/LDN.java
+++ b/dspace-api/src/main/java/org/dspace/core/LDN.java
@@ -155,10 +155,16 @@ public class LDN {
     public static LDN getLDNMessage(String ldnMessageFile)
         throws IOException {
         StringBuilder contentBuffer = new StringBuilder();
-        List<String> allowedBasePaths = Arrays.stream(configurationService
-                .getArrayProperty("ldn.template.path", DEFAULT_TEMPLATE_PATHS)).toList();
+        List<String> allowedBasePaths = List.of(
+                Arrays.stream(configurationService
+                                .getArrayProperty("ldn.template.path", DEFAULT_TEMPLATE_PATHS))
+                        .findFirst()
+                        .orElseThrow(() -> new IOException("No LDN template path configured"))
+        );
+        String ldnFilePath = SecureFileAccess.calculateAbsolutePathUsingBaseDir(ldnMessageFile,
+                allowedBasePaths.get(0));
         try (
-            InputStream is = SecureFileAccess.getInputStream(ldnMessageFile, allowedBasePaths, "ldn");
+            InputStream is = SecureFileAccess.getInputStream(ldnFilePath, allowedBasePaths, "ldn");
             InputStreamReader ir = new InputStreamReader(is, "UTF-8");
             BufferedReader reader = new BufferedReader(ir);
             ) {

--- a/dspace-api/src/main/java/org/dspace/core/LDN.java
+++ b/dspace-api/src/main/java/org/dspace/core/LDN.java
@@ -11,14 +11,12 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,6 +31,9 @@ import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import org.apache.velocity.runtime.resource.util.StringResourceRepository;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.storage.secure.SecureFileAccess;
 
 /**
  * Class representing an LDN message json
@@ -63,9 +64,8 @@ public class LDN {
     private static final ConfigurationService configurationService =
         DSpaceServicesFactory.getInstance().getConfigurationService();
     private static final String dspaceDir = configurationService.getProperty("dspace.dir", "/dspace");
-    private static final Path allowedTemplateBasePath = Paths.get(
-            configurationService.getProperty( "ldn.template.path", dspaceDir + File.separatorChar
-                    + "config" + File.separatorChar + "ldn"));
+    private static final String[] DEFAULT_TEMPLATE_PATHS = new String[]{
+        dspaceDir + File.separatorChar + "config" + File.separatorChar + "ldn"};
 
     /**
      * Create a new ldn message.
@@ -155,14 +155,10 @@ public class LDN {
     public static LDN getLDNMessage(String ldnMessageFile)
         throws IOException {
         StringBuilder contentBuffer = new StringBuilder();
-        Path ldnMessagePath = new File(ldnMessageFile).toPath().normalize();
-        Path realLdnMessagePath = allowedTemplateBasePath.resolve(ldnMessagePath).normalize();
-        if (!realLdnMessagePath.startsWith(allowedTemplateBasePath)) {
-            throw new IOException("Illegal LDN message path: '" + ldnMessagePath + "'");
-        }
-
+        List<String> allowedBasePaths = Arrays.stream(configurationService
+                .getArrayProperty("ldn.template.path", DEFAULT_TEMPLATE_PATHS)).toList();
         try (
-            InputStream is = new FileInputStream(realLdnMessagePath.toFile());
+            InputStream is = SecureFileAccess.getInputStream(ldnMessageFile, allowedBasePaths, "ldn");
             InputStreamReader ir = new InputStreamReader(is, "UTF-8");
             BufferedReader reader = new BufferedReader(ir);
             ) {

--- a/dspace-api/src/main/java/org/dspace/core/LDN.java
+++ b/dspace-api/src/main/java/org/dspace/core/LDN.java
@@ -10,11 +10,14 @@ package org.dspace.core;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,6 +58,14 @@ public class LDN {
 
     /** Velocity template for the message*/
     private Template template;
+
+    /** Allowed base directory for LDN messages / templates **/
+    private static final ConfigurationService configurationService =
+        DSpaceServicesFactory.getInstance().getConfigurationService();
+    private static final String dspaceDir = configurationService.getProperty("dspace.dir", "/dspace");
+    private static final Path allowedTemplateBasePath = Paths.get(
+            configurationService.getProperty( "ldn.template.path", dspaceDir + File.separatorChar
+                    + "config" + File.separatorChar + "ldn"));
 
     /**
      * Create a new ldn message.
@@ -144,8 +155,14 @@ public class LDN {
     public static LDN getLDNMessage(String ldnMessageFile)
         throws IOException {
         StringBuilder contentBuffer = new StringBuilder();
+        Path ldnMessagePath = new File(ldnMessageFile).toPath().normalize();
+        Path realLdnMessagePath = allowedTemplateBasePath.resolve(ldnMessagePath).normalize();
+        if (!realLdnMessagePath.startsWith(allowedTemplateBasePath)) {
+            throw new IOException("Illegal LDN message path: '" + ldnMessagePath + "'");
+        }
+
         try (
-            InputStream is = new FileInputStream(ldnMessageFile);
+            InputStream is = new FileInputStream(realLdnMessagePath.toFile());
             InputStreamReader ir = new InputStreamReader(is, "UTF-8");
             BufferedReader reader = new BufferedReader(ir);
             ) {

--- a/dspace-api/src/main/java/org/dspace/core/LDN.java
+++ b/dspace-api/src/main/java/org/dspace/core/LDN.java
@@ -18,7 +18,6 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 import jakarta.mail.MessagingException;
 import org.apache.commons.lang3.StringUtils;
@@ -26,15 +25,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
-import org.apache.velocity.app.Velocity;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
-import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.apache.velocity.runtime.resource.util.StringResourceRepository;
-import org.dspace.services.ConfigurationService;
-import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Class representing an LDN message json
@@ -57,18 +52,6 @@ public class LDN {
 
     /** Velocity template settings. */
     private static final String RESOURCE_REPOSITORY_NAME = "LDN";
-    private static final Properties VELOCITY_PROPERTIES = new Properties();
-    static {
-        VELOCITY_PROPERTIES.put(Velocity.RESOURCE_LOADERS, "string");
-        VELOCITY_PROPERTIES.put("resource.loader.string.description",
-                "Velocity StringResource loader");
-        VELOCITY_PROPERTIES.put("resource.loader.string.class",
-                StringResourceLoader.class.getName());
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.name",
-                RESOURCE_REPOSITORY_NAME);
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.static",
-                "false");
-    }
 
     /** Velocity template for the message*/
     private Template template;
@@ -112,14 +95,13 @@ public class LDN {
      * @throws IOException        if IO error
      */
     public String generateLDNMessage() {
-        ConfigurationService config
-            = DSpaceServicesFactory.getInstance().getConfigurationService();
-
         VelocityEngine templateEngine = new VelocityEngine();
-        templateEngine.init(VELOCITY_PROPERTIES);
+        templateEngine.init(Utils.getSecureVelocityProperties(RESOURCE_REPOSITORY_NAME));
 
         VelocityContext vctx = new VelocityContext();
-        vctx.put("config", new LDN.UnmodifiableConfigurationService(config));
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        vctx.put("config", Utils.getAllowedTemplateConfig());
         vctx.put("params", Collections.unmodifiableList(arguments));
 
         if (null == template) {
@@ -181,32 +163,5 @@ public class LDN {
         LDN ldn = new LDN();
         ldn.setContent(ldnMessageFile, contentBuffer.toString());
         return ldn;
-    }
-
-    /**
-     * Wrap ConfigurationService to prevent templates from modifying
-     * the configuration.
-     */
-    public static class UnmodifiableConfigurationService {
-        private final ConfigurationService configurationService;
-
-        /**
-         * Swallow an instance of ConfigurationService.
-         *
-         * @param cs the real instance, to be wrapped.
-         */
-        public UnmodifiableConfigurationService(ConfigurationService cs) {
-            configurationService = cs;
-        }
-
-        /**
-         * Look up a key in the actual ConfigurationService.
-         *
-         * @param key to be looked up in the DSpace configuration.
-         * @return whatever value ConfigurationService associates with {@code key}.
-         */
-        public String get(String key) {
-            return configurationService.getProperty(key);
-        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -31,16 +31,22 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.coverity.security.Escape;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.velocity.app.Velocity;
+import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -98,6 +104,14 @@ public final class Utils {
     // for formatISO8601Date
     // output canonical format
     private static final DateTimeFormatter outFmt = DateTimeFormatter.ISO_INSTANT;
+
+    // Allowed configuration properties to pass to Velocity templates (Email, LDN)
+    private static final String[] DEFAULT_ALLOWED_TEMPLATE_CONFIGS = {
+        "dspace.name", "dspace.shortname", "dspace.ui.url",
+        "mail.helpdesk", "mail.message.helpdesk.telephone", "mail.admin", "mail.admin.name"};
+
+    private static final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
 
     /**
      * Private constructor
@@ -499,6 +513,56 @@ public final class Utils {
     public static Instant getMinTimestamp() {
         return LocalDateTime.of(-4713, 11, 12, 0, 0, 0)
                 .toInstant(ZoneOffset.UTC);
+    }
+
+    /**
+     * Get a list of allowed DSpace configuration property keys that will be exposed to Velocity templates
+     * (used in Email and LDN messages) as a simple Map of strings.
+     * @return Map of strings representing resolved configuration properties
+     */
+    public static Map<String, String> getAllowedTemplateConfig() {
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
+                    "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
+        return allowedConfigurationKeys.stream()
+            .map(key -> Map.entry(key, configurationService.getProperty(key)))
+            .filter(entry -> entry.getValue() != null)
+            .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue
+                        ));
+    }
+
+    /**
+     * Create and return a set of default, secure Velocity configuration properties.
+     * @see {@link LDN}, {@link Email}
+     *
+     * @param resourceRepositoryName the templating context e.g. "LDN", "Email"
+     * @returns secure Velocity configuration for use with templating
+     */
+    public static Properties getSecureVelocityProperties(String resourceRepositoryName) {
+        Properties secureVelocityProperties = new Properties();
+        // Basic Velocity configuration
+        secureVelocityProperties.setProperty(Velocity.RESOURCE_LOADERS, "string");
+        secureVelocityProperties.setProperty("resource.loader.string.description",
+                "Velocity StringResource loader");
+        secureVelocityProperties.setProperty("resource.loader.string.class",
+                StringResourceLoader.class.getName());
+        secureVelocityProperties.setProperty("resource.loader.string.repository.name",
+                resourceRepositoryName);
+        secureVelocityProperties.setProperty("resource.loader.string.repository.static",
+                "false");
+        // Set secure default introspection and class restriction handling in Velocity
+        secureVelocityProperties.setProperty("introspector.uberspect.class",
+                "org.apache.velocity.util.introspection.SecureUberspector");
+        secureVelocityProperties.setProperty("introspector.restrict.classes",
+                "java.lang.Class,java.lang.Runtime,java.lang.System");
+        secureVelocityProperties.setProperty( "introspector.restrict.packages",
+                "java.lang.reflect,java.io,java.nio");
+        secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+
+        return secureVelocityProperties;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
@@ -526,8 +527,11 @@ public final class Utils {
         List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
                     "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
         return allowedConfigurationKeys.stream()
-            .map(key -> Map.entry(key, configurationService.getProperty(key)))
-            .filter(entry -> entry.getValue() != null)
+            .map(key -> {
+                String value = configurationService.getProperty(key);
+                return value != null ? Map.entry(key, value) : null;
+            })
+            .filter(Objects::nonNull)
             .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         Map.Entry::getValue

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -563,7 +563,11 @@ public final class Utils {
                 "java.lang.Class,java.lang.Runtime,java.lang.System");
         secureVelocityProperties.setProperty( "introspector.restrict.packages",
                 "java.lang.reflect,java.io,java.nio");
-        secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+        // Set strict mode if configured (default: false, as we've always treated null values as blanks)
+        if (DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getBooleanProperty("message.templates.strict_mode", false)) {
+            secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+        }
 
         return secureVelocityProperties;
     }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -111,9 +111,6 @@ public final class Utils {
         "dspace.name", "dspace.shortname", "dspace.ui.url",
         "mail.helpdesk", "mail.message.helpdesk.telephone", "mail.admin", "mail.admin.name"};
 
-    private static final ConfigurationService configurationService =
-            DSpaceServicesFactory.getInstance().getConfigurationService();
-
     /**
      * Private constructor
      */
@@ -524,6 +521,8 @@ public final class Utils {
     public static Map<String, String> getAllowedTemplateConfig() {
         // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
         // template lookup
+        ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
         List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
                     "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
         return allowedConfigurationKeys.stream()

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -18,8 +18,10 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -117,8 +119,10 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
             try {
                 String dspaceDir = DSpaceServicesFactory.getInstance()
                     .getConfigurationService().getProperty("dspace.dir");
-                String allowedTaskFileBasePath = DSpaceServicesFactory.getInstance()
-                    .getConfigurationService().getProperty("curate.taskfile.base", dspaceDir);
+                List<String> allowedTaskFileBasePath = Arrays.stream(
+                        DSpaceServicesFactory.getInstance().getConfigurationService()
+                        .getArrayProperty("curate.taskfile.base", new String[]{dspaceDir})
+                        ).toList();
                 reader = SecureFileAccess.getBufferedReader(this.taskFile, allowedTaskFileBasePath,
                         "curation-taskfile", StandardCharsets.UTF_8);
                 while ((taskName = reader.readLine()) != null) {
@@ -198,9 +202,10 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
         OutputStream reporterStream;
         String dspaceDir = DSpaceServicesFactory.getInstance()
             .getConfigurationService().getProperty("dspace.dir");
-        String allowedReporterBasePath = DSpaceServicesFactory.getInstance()
-            .getConfigurationService().getProperty("curate.reporter.base",
-                    dspaceDir + File.separatorChar + "log");
+        List<String> allowedReporterBasePaths = Arrays.stream(
+            DSpaceServicesFactory.getInstance()
+            .getConfigurationService().getArrayProperty("curate.reporter.base",
+                    new String[]{dspaceDir + File.separatorChar + "log"})).toList();
         if (null == this.reporter) {
             reporterStream = NullOutputStream.INSTANCE;
         } else if ("-".equals(this.reporter)) {
@@ -209,7 +214,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
             try {
                 reporterStream = new PrintStream(
                     SecureFileAccess.getOutputStream(
-                    this.reporter, allowedReporterBasePath, "curation-reporter"));
+                    this.reporter, allowedReporterBasePaths, "curation-reporter"));
             } catch (IOException e) {
                 throw new FileNotFoundException(e.getLocalizedMessage());
             }

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -10,12 +10,12 @@ package org.dspace.curate;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.HashMap;
@@ -39,6 +39,7 @@ import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.storage.secure.SecureFileAccess;
 import org.dspace.utils.DSpace;
 
 /**
@@ -114,7 +115,12 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
             // load taskFile
             BufferedReader reader = null;
             try {
-                reader = new BufferedReader(new FileReader(this.taskFile));
+                String dspaceDir = DSpaceServicesFactory.getInstance()
+                    .getConfigurationService().getProperty("dspace.dir");
+                String allowedTaskFileBasePath = DSpaceServicesFactory.getInstance()
+                    .getConfigurationService().getProperty("curate.taskfile.base", dspaceDir);
+                reader = SecureFileAccess.getBufferedReader(this.taskFile, allowedTaskFileBasePath,
+                        "curation-taskfile", StandardCharsets.UTF_8);
                 while ((taskName = reader.readLine()) != null) {
                     if (verbose) {
                         super.handler.logInfo("Adding task: " + taskName);
@@ -190,12 +196,23 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
     private Curator initCurator() throws FileNotFoundException {
         Curator curator = new Curator(handler);
         OutputStream reporterStream;
+        String dspaceDir = DSpaceServicesFactory.getInstance()
+            .getConfigurationService().getProperty("dspace.dir");
+        String allowedReporterBasePath = DSpaceServicesFactory.getInstance()
+            .getConfigurationService().getProperty("curate.reporter.base",
+                    dspaceDir + File.separatorChar + "log");
         if (null == this.reporter) {
-            reporterStream = NullOutputStream.NULL_OUTPUT_STREAM;
+            reporterStream = NullOutputStream.INSTANCE;
         } else if ("-".equals(this.reporter)) {
             reporterStream = System.out;
         } else {
-            reporterStream = new PrintStream(this.reporter);
+            try {
+                reporterStream = new PrintStream(
+                    SecureFileAccess.getOutputStream(
+                    this.reporter, allowedReporterBasePath, "curation-reporter"));
+            } catch (IOException e) {
+                throw new FileNotFoundException(e.getLocalizedMessage());
+            }
         }
         Writer reportWriter = new OutputStreamWriter(reporterStream);
         curator.setReporter(reportWriter);

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -116,6 +116,8 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
         } else if (commandLine.hasOption('T')) {
             // load taskFile
             BufferedReader reader = null;
+            // in this case, Curation CLI expects to calculate the -T parameter from the user's current working dir
+            String taskFilePath = SecureFileAccess.calculateAbsolutePathUsingCwd(this.taskFile);
             try {
                 String dspaceDir = DSpaceServicesFactory.getInstance()
                     .getConfigurationService().getProperty("dspace.dir");
@@ -123,7 +125,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
                         DSpaceServicesFactory.getInstance().getConfigurationService()
                         .getArrayProperty("curate.taskfile.base", new String[]{dspaceDir})
                         ).toList();
-                reader = SecureFileAccess.getBufferedReader(this.taskFile, allowedTaskFileBasePath,
+                reader = SecureFileAccess.getBufferedReader(taskFilePath, allowedTaskFileBasePath,
                         "curation-taskfile", StandardCharsets.UTF_8);
                 while ((taskName = reader.readLine()) != null) {
                     if (verbose) {
@@ -211,10 +213,12 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
         } else if ("-".equals(this.reporter)) {
             reporterStream = System.out;
         } else {
+            // Reporter param comes from CLI execution. Calculate abs path from user's current working dir
+            String reporterFilePath = SecureFileAccess.calculateAbsolutePathUsingCwd(this.reporter);
             try {
                 reporterStream = new PrintStream(
                     SecureFileAccess.getOutputStream(
-                    this.reporter, allowedReporterBasePaths, "curation-reporter"));
+                    reporterFilePath, allowedReporterBasePaths, "curation-reporter"));
             } catch (IOException e) {
                 throw new FileNotFoundException(e.getLocalizedMessage());
             }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
@@ -20,6 +20,9 @@ public class CurationCliScriptConfiguration extends CurationScriptConfiguration<
         options = super.getOptions();
         options.addOption("e", "eperson", true, "email address of curating eperson");
         options.getOption("e").setRequired(true);
+        options.addOption("r", "reporter", true,
+            "relative or absolute path to the desired report file. Use '-' to report to console. If absent, no " +
+            "reporting");
         return options;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
@@ -23,6 +23,7 @@ public class CurationCliScriptConfiguration extends CurationScriptConfiguration<
         options.addOption("r", "reporter", true,
             "relative or absolute path to the desired report file. Use '-' to report to console. If absent, no " +
             "reporting");
+        options.addOption("T", "taskfile", true, "file containing curation task names");
         return options;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
@@ -31,7 +31,8 @@ public enum CurationClientOptions {
     /**
      * This method resolves the CommandLine parameters to figure out which action the curation script should perform
      *
-     * @param commandLine The relevant CommandLine for the curation script
+     * @param commandLine The relevant CommandLine for the curation script. Note that -T is passed only
+     *                    from CurationCliScriptConfig and is not accessible from UI processes
      * @return The curation option to be ran, parsed from the CommandLine
      */
     protected static CurationClientOptions getClientOption(CommandLine commandLine) {
@@ -54,7 +55,6 @@ public enum CurationClientOptions {
         Options options = new Options();
 
         options.addOption("t", "task", true, "curation task name; options: " + getTaskOptions());
-        options.addOption("T", "taskfile", true, "file containing curation task names");
         options.addOption("i", "id", true,
             "Id (handle) of object to perform task on, or 'all' to perform on whole repository");
         options.addOption("p", "parameter", true, "a task parameter 'NAME=VALUE'");

--- a/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
@@ -59,9 +59,6 @@ public enum CurationClientOptions {
             "Id (handle) of object to perform task on, or 'all' to perform on whole repository");
         options.addOption("p", "parameter", true, "a task parameter 'NAME=VALUE'");
         options.addOption("q", "queue", true, "name of task queue to process");
-        options.addOption("r", "reporter", true,
-            "relative or absolute path to the desired report file. Use '-' to report to console. If absent, no " +
-            "reporting");
         options.addOption("s", "scope", true,
             "transaction scope to impose: use 'object', 'curation', or 'open'. If absent, 'open' applies");
         options.addOption("v", "verbose", false, "report activity to stdout");

--- a/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
+++ b/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
@@ -32,12 +32,18 @@ public final class SecureFileAccess {
      * before validation, as this breaks for new files which don't yet exist. This can make the resulting
      * validation still vulnerable to symlink traversal in some cases
      * @param file the unvalidated file, usually derived from user input or configuration
+     *             This MUST be an absolute path, and the caller is expected to calculate it based on best
+     *             context (e.g. configured base path, CWD, dspace.dir, and so on)
      * @param allowedBasePaths list of allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
     public static Path validatePathForWrite(String file, List<String> allowedBasePaths, String purpose)
             throws IOException {
+        Path filePath = Path.of(file);
+        if (!filePath.isAbsolute()) {
+            throw new IOException("Absolute path required for I/O (%s): %s".formatted(purpose, file));
+        }
         for (String allowedBasePath : allowedBasePaths) {
             Path basePath = Path.of(allowedBasePath)
                                 .toRealPath()
@@ -50,7 +56,7 @@ public final class SecureFileAccess {
                 return resolvedPath;
             }
         }
-        
+
         // If no valid path was resolved and returned by now
         // we raise an exception and treat this as illegal access
         throw new IOException("Illegal file path attempted for I/O (%s): %s".formatted(purpose, file));
@@ -61,12 +67,18 @@ public final class SecureFileAccess {
      * More secure than the 'write' variant because we can explicitly resolve links as well.
      *
      * @param file the unvalidated file, usually derived from user input or configuration
+     *             This MUST be an absolute path, and the caller is expected to calculate it based on best
+     *             context (e.g. configured base path, CWD, dspace.dir, and so on)
      * @param allowedBasePaths the allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
     public static Path validatePathForRead(String file, List<String> allowedBasePaths, String purpose)
             throws IOException {
+        Path filePath = Path.of(file);
+        if (!filePath.isAbsolute()) {
+            throw new IOException("Absolute path required for I/O (%s): %s".formatted(purpose, file));
+        }
         for (String allowedBasePath : allowedBasePaths) {
             Path basePath = Path.of(allowedBasePath)
                                 .toRealPath()
@@ -123,5 +135,35 @@ public final class SecureFileAccess {
             throws IOException {
         Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePaths, purpose);
         return Files.newOutputStream(validatedFile);
+    }
+
+    /**
+     * Calculate an absolute path (if not already absolute) using current working dir as a root
+     * for relative file paths
+     * @param file the relative or absolute file given as input
+     * @return absolute path calculated from file and cwd
+     */
+    public static String calculateAbsolutePathUsingCwd(String file) {
+        String filePath = file;
+        Path path = Path.of(filePath);
+        if (!path.isAbsolute()) {
+            filePath = Path.of("").toAbsolutePath().resolve(path).normalize().toString();
+        }
+        return filePath;
+    }
+
+    /**
+     * Calculate an absolute path (if not already absolute) using a given base dir as a root
+     * for relative file paths
+     * @param file the relative or absolute file given as input
+     * @return absolute path calculated from file and base dir
+     */
+    public static String calculateAbsolutePathUsingBaseDir(String file, String baseDir) {
+        String filePath = file;
+        Path path = Path.of(filePath);
+        if (!path.isAbsolute()) {
+            filePath = Path.of(baseDir).toAbsolutePath().resolve(path).normalize().toString();
+        }
+        return filePath;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
+++ b/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Decent I/O path validation - not perfect when symlinks are used and we are writing
@@ -32,23 +33,28 @@ public final class SecureFileAccess {
      * before validation, as this breaks for new files which don't yet exist. This can make the resulting
      * validation still vulnerable to symlink traversal in some cases
      * @param file the unvalidated file, usually derived from user input or configuration
-     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param allowedBasePaths list of allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
-    public static Path validatePathForWrite(String file, String allowedBasePath, String purpose)
+    public static Path validatePathForWrite(String file, List<String> allowedBasePaths, String purpose)
             throws IOException {
-        Path basePath = Path.of(allowedBasePath)
-                            .toRealPath()
-                            .normalize();
-        if (basePath == null) {
-            throw new IOException("Null base path can not be provided for validation");
+        for (String allowedBasePath : allowedBasePaths) {
+            Path basePath = Path.of(allowedBasePath)
+                                .toRealPath()
+                                .normalize();
+            if (basePath == null) {
+                throw new IOException("Null base path can not be provided for validation");
+            }
+            Path resolvedPath = basePath.resolve(file).normalize();
+            if (resolvedPath.startsWith(basePath)) {
+                return resolvedPath;
+            }
         }
-        Path resolvedPath = basePath.resolve(file).normalize();
-        if (!resolvedPath.startsWith(basePath)) {
-            throw new IOException("Illegal file path attempted for I/O (%s): %s".formatted(purpose, file));
-        }
-        return resolvedPath;
+        
+        // If no valid path was resolved and returned by now
+        // we raise an exception and treat this as illegal access
+        throw new IOException("Illegal file path attempted for I/O (%s): %s".formatted(purpose, file));
     }
 
     /**
@@ -60,47 +66,51 @@ public final class SecureFileAccess {
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
-    public static Path validatePathForRead(String file, String allowedBasePath, String purpose)
+    public static Path validatePathForRead(String file, List<String> allowedBasePaths, String purpose)
             throws IOException {
-        Path basePath = Path.of(allowedBasePath)
-                            .toRealPath()
-                            .normalize();
-        if (basePath == null) {
-            throw new IOException("Null base path can not be provided for validation");
+        for (String allowedBasePath : allowedBasePaths) {
+            Path basePath = Path.of(allowedBasePath)
+                                .toRealPath()
+                                .normalize();
+            if (basePath == null) {
+                throw new IOException("Null base path can not be provided for validation");
+            }
+            Path resolvedPath = basePath.resolve(file).toRealPath().normalize();
+            if (resolvedPath.startsWith(basePath)) {
+                return resolvedPath;
+            }
         }
-        Path resolvedPath = basePath.resolve(file).toRealPath().normalize();
-        if (!resolvedPath.startsWith(basePath)) {
-            throw new IOException("Illegal file path attempted for I/O (%s): %s".formatted(purpose, file));
-        }
-        return resolvedPath;
+        // If no valid path was resolved and returned by now
+        // we raise an exception and treat this as illegal access
+        throw new IOException("Illegal file path attempted for I/O (%s): %s".formatted(purpose, file));
     }
 
     /**
      * Get a buffered reader after validating file path.
      * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
-     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
-    public static BufferedReader getBufferedReader(String unvalidatedFile, String allowedBasePath,
+    public static BufferedReader getBufferedReader(String unvalidatedFile, List<String> allowedBasePaths,
             String purpose, Charset charset) throws IOException {
         if (charset == null) {
             charset = StandardCharsets.UTF_8;
         }
-        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePath, purpose);
+        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePaths, purpose);
         return Files.newBufferedReader(validatedFile, charset);
     }
 
     /**
      * Get an input stream after validating file path.
      * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
-     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
-    public static InputStream getInputStream(String unvalidatedFile, String allowedBasePath, String purpose)
+    public static InputStream getInputStream(String unvalidatedFile, List<String> allowedBasePaths, String purpose)
             throws IOException {
-        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePath, purpose);
+        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePaths, purpose);
         return Files.newInputStream(validatedFile);
 
     }
@@ -109,13 +119,13 @@ public final class SecureFileAccess {
      * Get an input stream after validating file path. Adds NOFOLLOW_LINKS link option to
      * help ensure some extra safety since new files can't use toRealPath() for link calculation
      * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
-     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
-    public static OutputStream getOutputStream(String unvalidatedFile, String allowedBasePath, String purpose)
+    public static OutputStream getOutputStream(String unvalidatedFile, List<String> allowedBasePaths, String purpose)
             throws IOException {
-        Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePath, purpose);
+        Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePaths, purpose);
         return Files.newOutputStream(validatedFile, LinkOption.NOFOLLOW_LINKS);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
+++ b/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
@@ -14,7 +14,6 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -62,7 +61,7 @@ public final class SecureFileAccess {
      * More secure than the 'write' variant because we can explicitly resolve links as well.
      *
      * @param file the unvalidated file, usually derived from user input or configuration
-     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
      * @throws IOException on validation failure
      */
@@ -72,9 +71,6 @@ public final class SecureFileAccess {
             Path basePath = Path.of(allowedBasePath)
                                 .toRealPath()
                                 .normalize();
-            if (basePath == null) {
-                throw new IOException("Null base path can not be provided for validation");
-            }
             Path resolvedPath = basePath.resolve(file).toRealPath().normalize();
             if (resolvedPath.startsWith(basePath)) {
                 return resolvedPath;
@@ -116,8 +112,8 @@ public final class SecureFileAccess {
     }
 
     /**
-     * Get an input stream after validating file path. Adds NOFOLLOW_LINKS link option to
-     * help ensure some extra safety since new files can't use toRealPath() for link calculation
+     * Get an output stream after validating file path. New files can't use toRealPath() for link calculation so
+     * there is a bit of a trade-off in allowing some symlink traversal to occur
      * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
      * @param allowedBasePaths the allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
@@ -126,6 +122,6 @@ public final class SecureFileAccess {
     public static OutputStream getOutputStream(String unvalidatedFile, List<String> allowedBasePaths, String purpose)
             throws IOException {
         Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePaths, purpose);
-        return Files.newOutputStream(validatedFile, LinkOption.NOFOLLOW_LINKS);
+        return Files.newOutputStream(validatedFile);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
+++ b/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
@@ -1,0 +1,121 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.secure;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+/**
+ * Decent I/O path validation - not perfect when symlinks are used and we are writing
+ * as 'toRealPath' check on the resolved path fails for new files
+ *
+ * @author Kim Shepherd <kim-at-shepherd-dot-nz>
+ */
+public final class SecureFileAccess {
+
+    private SecureFileAccess() {}
+
+    /**
+     * Validate a given path against an allowed base path. Does not attempt to calculate "real path"
+     * before validation, as this breaks for new files which don't yet exist. This can make the resulting
+     * validation still vulnerable to symlink traversal in some cases
+     * @param file the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static Path validatePathForWrite(String file, String allowedBasePath, String purpose)
+            throws IOException {
+        Path basePath = Path.of(allowedBasePath)
+                            .toRealPath()
+                            .normalize();
+        if (basePath == null) {
+            throw new IOException("Null base path can not be provided for validation");
+        }
+        Path resolvedPath = basePath.resolve(file).normalize();
+        if (!resolvedPath.startsWith(basePath)) {
+            throw new IOException("Illegal file path attempted for I/O (%s): %s".formatted(purpose, file));
+        }
+        return resolvedPath;
+    }
+
+    /**
+     * Validate a given path against an allowed base path.
+     * More secure than the 'write' variant because we can explicitly resolve links as well.
+     *
+     * @param file the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static Path validatePathForRead(String file, String allowedBasePath, String purpose)
+            throws IOException {
+        Path basePath = Path.of(allowedBasePath)
+                            .toRealPath()
+                            .normalize();
+        if (basePath == null) {
+            throw new IOException("Null base path can not be provided for validation");
+        }
+        Path resolvedPath = basePath.resolve(file).toRealPath().normalize();
+        if (!resolvedPath.startsWith(basePath)) {
+            throw new IOException("Illegal file path attempted for I/O (%s): %s".formatted(purpose, file));
+        }
+        return resolvedPath;
+    }
+
+    /**
+     * Get a buffered reader after validating file path.
+     * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static BufferedReader getBufferedReader(String unvalidatedFile, String allowedBasePath,
+            String purpose, Charset charset) throws IOException {
+        if (charset == null) {
+            charset = StandardCharsets.UTF_8;
+        }
+        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePath, purpose);
+        return Files.newBufferedReader(validatedFile, charset);
+    }
+
+    /**
+     * Get an input stream after validating file path.
+     * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static InputStream getInputStream(String unvalidatedFile, String allowedBasePath, String purpose)
+            throws IOException {
+        Path validatedFile = validatePathForRead(unvalidatedFile, allowedBasePath, purpose);
+        return Files.newInputStream(validatedFile);
+
+    }
+
+    /**
+     * Get an input stream after validating file path. Adds NOFOLLOW_LINKS link option to
+     * help ensure some extra safety since new files can't use toRealPath() for link calculation
+     * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePath the allowed base path for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @throws IOException on validation failure
+     */
+    public static OutputStream getOutputStream(String unvalidatedFile, String allowedBasePath, String purpose)
+            throws IOException {
+        Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePath, purpose);
+        return Files.newOutputStream(validatedFile, LinkOption.NOFOLLOW_LINKS);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/ldn/action/SendLDNMessageActionIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/ldn/action/SendLDNMessageActionIT.java
@@ -255,7 +255,7 @@ public class SendLDNMessageActionIT extends AbstractIntegrationTestWithDatabase 
             LDN.getLDNMessage("../modules/dspace.cfg");
             fail("IOException should have been thrown for illegal template path");
         } catch (IOException e) {
-            assertTrue(e.getMessage().contains("Illegal LDN message path:"));
+            assertTrue(e.getMessage().contains("Illegal file path attempted for I/O (ldn):"));
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/app/ldn/action/SendLDNMessageActionIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/ldn/action/SendLDNMessageActionIT.java
@@ -10,10 +10,14 @@ package org.dspace.app.ldn.action;
 import static org.dspace.app.ldn.action.LDNActionStatus.ABORT;
 import static org.dspace.app.ldn.action.LDNActionStatus.CONTINUE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
@@ -40,6 +44,7 @@ import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.core.LDN;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -230,6 +235,28 @@ public class SendLDNMessageActionIT extends AbstractIntegrationTestWithDatabase 
         assertEquals(sendLDNMessageAction.execute(context, notification, item), ABORT);
         mockedClient.close();
         response.close();
+    }
+
+    @Test
+    public void testLDNLegalPath() throws Exception {
+        try {
+            // Path traversal will be calculated properly
+            // but this still ends up at a legal base
+            LDN message = LDN.getLDNMessage("../../config/ldn/request-review");
+            assertNotNull(message);
+        } catch (IOException e) {
+            fail("IOException should NOT have been thrown for legal template path: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testLDNIllegalPath() throws Exception {
+        try {
+            LDN.getLDNMessage("../modules/dspace.cfg");
+            fail("IOException should have been thrown for illegal template path");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Illegal LDN message path:"));
+        }
     }
 
     @Override

--- a/dspace-api/src/test/java/org/dspace/app/ldn/action/SendLDNMessageActionIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/ldn/action/SendLDNMessageActionIT.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -252,7 +253,11 @@ public class SendLDNMessageActionIT extends AbstractIntegrationTestWithDatabase 
     @Test
     public void testLDNIllegalPath() throws Exception {
         try {
-            LDN.getLDNMessage("../modules/dspace.cfg");
+            String badAbsolutePath = Path.of(configurationService.getProperty("dspace.dir"))
+                .resolve("config/dspace.cfg")
+                .toAbsolutePath()
+                .toString();
+            LDN.getLDNMessage(badAbsolutePath);
             fail("IOException should have been thrown for illegal template path");
         } catch (IOException e) {
             assertTrue(e.getMessage().contains("Illegal file path attempted for I/O (ldn):"));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -1,0 +1,134 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+/**
+ * Global filter acting on all requests (not just /api/) to provide some additional hardening
+ * against common attacks or RCE, if a malicious payload was somehow written to a directory
+ * executable by the servlet container.
+ * The decoding and normalisation is designed to be tolerant of malformed URLs or broken clients, etc.
+ * so that this additional security filter does not introduce false positives or unintended side effects.
+ *
+ * @author Kim Shepherd
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class GlobalRequestSecurityFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String normalizedPath = normaliseUrl(request.getRequestURI());
+        // Return 403 forbidden if JSP execution or URL traversal is attempted
+        if (isTraversalAttempt(normalizedPath) || isJspExecutionAttempt(normalizedPath)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Normalise the URI similarly to Tomcat, for testing how it will be interpreted
+     * @param rawUrl the unvalidated URL string
+     * @return a decoded, normalise URL
+     */
+    private String normaliseUrl(String rawUrl) throws IOException {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            throw new IOException("Empty URL");
+        }
+        String url = rawUrl.split("\\?")[0];
+        // Strip ;jspsession=... and so on
+        int semicolon = url.indexOf(';');
+        if (semicolon >= 0) {
+            url = url.substring(0, semicolon);
+        }
+        url = decodeUrl(url);
+        if (url == null || url.isBlank()) {
+            throw new IOException("Decoded URL path is empty");
+        }
+        url = normaliseUrlPath(url);
+        if (url == null || url.isBlank()) {
+            throw new IOException("Normalised URL path is empty");
+        }
+        return url.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Decode URL, falling back to original URL if it's malformed or undecodable
+     * @param url the encoded / unvalidated URL
+     * @return decoded URL or the original URL on error
+     */
+    private String decodeUrl(String url) {
+        try {
+            return URLDecoder.decode(url, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            // if we can't decode it, just return raw string
+            return url;
+        }
+    }
+
+    /**
+     * Normalise the URL path and ensure it ends in a /
+     * @param url the URL path to normalise
+     * @return normalised path or the original parameter on error
+     */
+    private String normaliseUrlPath(String url) {
+        try {
+            if (!url.startsWith("/")) {
+                url = "/" + url;
+            }
+            return new URI(url).normalize().getPath();
+        } catch (Exception e) {
+            // if we can't use or normalise the path, just return the raw string
+            return url;
+        }
+    }
+
+    /**
+     * Detect traversal after normalisation
+     * @param url the URL path to validate
+     * @return true if this looks like a traversal attempt
+     */
+    private boolean isTraversalAttempt(String url) {
+        return url.contains("../")
+                || url.contains("/..")
+                || url.contains("%2e%2e")
+                || url.contains("..");
+    }
+
+    /**
+     * Block JSP execution attempts
+     * @param url the URL path to validate
+     */
+    private boolean isJspExecutionAttempt(String url) {
+        return url.endsWith(".jsp")
+                || url.endsWith(".jspx")
+                || url.contains(".jsp/")
+                || url.contains(".jspx/")
+                || url.contains(".jsp\0")
+                || url.contains(".jspx\0");
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -43,7 +43,13 @@ public class GlobalRequestSecurityFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String normalizedPath = normaliseUrl(request.getRequestURI());
         // Return 403 forbidden if JSP execution or URL traversal is attempted
-        if (isTraversalAttempt(normalizedPath) || isJspExecutionAttempt(normalizedPath)) {
+        if (isTraversalAttempt(normalizedPath)) {
+            logger.warn("Path traversal attempt detected. Skipping request: " + request.getRequestURI());
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        if (isJspExecutionAttempt(normalizedPath)) {
+            logger.warn("JSP execution attempt detected. Skipping request: " + request.getRequestURI());
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -7,6 +7,12 @@
  */
 package org.dspace.app.rest.security;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,12 +21,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 /**
  * Global filter acting on all requests (not just /api/) to provide some additional hardening

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
@@ -134,7 +134,7 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
         //** WHEN **
         //We attempt to use endpoint for malicious file system traversal
         getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e/config/dspace.cfg"))
-                   .andExpect(status().isBadRequest());
+                   .andExpect(status().isForbidden());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
         //** WHEN **
         //We attempt to use endpoint for malicious file system traversal
         getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e%2fconfig%2fdspace.cfg"))
-                   .andExpect(status().isBadRequest());
+                   .andExpect(status().isForbidden());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -49,6 +49,7 @@ import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.factory.ScriptServiceFactory;
 import org.dspace.scripts.service.ScriptService;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -217,6 +218,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             .andExpect(status().isBadRequest());
     }
 
+    @Ignore
     @Test
     public void curateScript_InvalidTaskFile() throws Exception {
         String token = getAuthToken(admin.getEmail(), password);
@@ -289,6 +291,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         }
     }
 
+    @Ignore
     @Test
     public void curateScript_validRequest_TaskFile() throws Exception {
         context.turnOffAuthorisationSystem();

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -240,6 +240,11 @@ message.templates.allowed-config = mail.message.helpdesk.telephone
 message.templates.allowed-config = mail.admin
 message.templates.allowed-config = mail.admin.name
 
+# Whether to run Velocity in strict mode (null parameter values in templates for LDN or Email will result
+# in an Exception instead of a blank string)
+# Default: false (this can introduce unwanted side-effects if e.g. a submitter eperson is deleted for a workflow task)
+#message.templates.strict_mode = false
+
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -162,6 +162,7 @@ mail.from.address = repozitar@mendelu.cz
 # will use the above settings to create a Session.
 #mail.session.name = Session
 
+
 # When feedback is submitted via the Feedback form, it is sent to this address
 # Currently limited to one recipient!
 # if this property is empty or commented out, feedback form is disabled
@@ -227,6 +228,17 @@ mail.message.headers = charset
 
 # Helpdesk telephone.  Not email, but should be with other contact info.  Optional.
 #mail.message.helpdesk.telephone = +1 555 555 5555
+
+# Allowed configuration properties, to pass in a "config" map to email and LDN templates.
+# This allows templates to easily access dynamic configuration properties, without
+# exposing sensitive information to the templating engine
+message.templates.allowed-config = dspace.name
+message.templates.allowed-config = dspace.shortname
+message.templates.allowed-config = dspace.ui.url
+message.templates.allowed-config = mail.helpdesk
+message.templates.allowed-config = mail.message.helpdesk.telephone
+message.templates.allowed-config = mail.admin
+message.templates.allowed-config = mail.admin.name
 
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -30,10 +30,11 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 # Maximum amount of redirects set to 0 for none and -1 for unlimited
 curate.checklinks.max-redirect = 0
 
-# allowed base path of curation task files
+# allowed base path(s) of curation task files
 # it is recommended to restrict this path as much as possible
 # so that the DSpace Processes framework may only load files as "tasks"
-# from a trusted location
+# from a trusted location. For multiple paths, repeat this configuration
+# property for each trusted path
 curate.taskfile.base = ${dspace.dir}
 
 # allowed base path of reporter output.

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -29,3 +29,12 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 
 # Maximum amount of redirects set to 0 for none and -1 for unlimited
 curate.checklinks.max-redirect = 0
+
+# allowed base path of curation task files
+# it is recommended to restrict this path as much as possible
+# so that the DSpace Processes framework may only load files as "tasks"
+# from a trusted location
+curate.taskfile.base = ${dspace.dir}
+
+# allowed base path of reporter output.
+curate.reporter.base = ${dspace.dir}/log

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -35,7 +35,9 @@ curate.checklinks.max-redirect = 0
 # so that the DSpace Processes framework may only load files as "tasks"
 # from a trusted location. For multiple paths, repeat this configuration
 # property for each trusted path
-curate.taskfile.base = ${dspace.dir}
+# Default: ${dspace.dir}
+#curate.taskfile.base = ${dspace.dir}
 
 # allowed base path of reporter output.
-curate.reporter.base = ${dspace.dir}/log
+# Default: ${dspace.dir}/log
+#curate.reporter.base = ${dspace.dir}/log

--- a/dspace/config/modules/ldn.cfg
+++ b/dspace/config/modules/ldn.cfg
@@ -42,6 +42,7 @@ ldn.notify.inbox.block-untrusted-ip = true
 
 # Allowed base path of LDN templates. Apache Velocity will only
 # load templates that begin with this base path.
+# You can repeat this parameter to allow multiple base paths.
 # Default is ${dspace.dir}/config/ldn
 #ldn.template.path = ${dspace.dir}/config/ldn
 

--- a/dspace/config/modules/ldn.cfg
+++ b/dspace/config/modules/ldn.cfg
@@ -40,6 +40,11 @@ ldn.notify.inbox.block-untrusted-ip = true
 # this is the medatada used to retrieve the relation with external items when sending relationship requests
 #ldn.notify.relation.metadata = dc.relation
 
+# Allowed base path of LDN templates. Apache Velocity will only
+# load templates that begin with this base path.
+# Default is ${dspace.dir}/config/ldn
+#ldn.template.path = ${dspace.dir}/config/ldn
+
 
 # EMAIL CONFIGURATION
 # Supported values for actionSendFilter are:

--- a/dspace/config/modules/ldn.cfg
+++ b/dspace/config/modules/ldn.cfg
@@ -40,12 +40,11 @@ ldn.notify.inbox.block-untrusted-ip = true
 # this is the medatada used to retrieve the relation with external items when sending relationship requests
 #ldn.notify.relation.metadata = dc.relation
 
-# Allowed base path of LDN templates. Apache Velocity will only
-# load templates that begin with this base path.
-# You can repeat this parameter to allow multiple base paths.
+# Base path of LDN templates. Apache Velocity will only
+# load templates that begin with this base path, and relative paths will use this as a base when
+# calculating the absolute path. This is not repeatable, multiple paths will be ignored beyond the first.
 # Default is ${dspace.dir}/config/ldn
 #ldn.template.path = ${dspace.dir}/config/ldn
-
 
 # EMAIL CONFIGURATION
 # Supported values for actionSendFilter are:

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -132,3 +132,10 @@ oai.harvester.unknownSchema = fail
 # when attempting to find the handle of harvested items. If there is a match with
 # this config parameter, a new handle will be minted instead. Default value: 123456789.
 #oai.harvester.rejectedHandlePrefix = 123456789, myTestHandle
+
+# If ingesting files with ORE, only files with URLs that match the base URL of the remote
+# OAI endpoint's domain name are accepted, or a list of other URL prefixes defined below
+#oai.harvester.ore.file.validateUrlPrefix = true
+# Prefixes that are allowed globally (for any endpoint) are below
+#oai.harvester.ore.file.allowedUrlPrefix = dspace.myinstitution.edu
+#oai.harvester.ore.file.allowedUrlPrefix = files.myinstitution.edu


### PR DESCRIPTION
## Security patches from vanilla DSpace 9.3

This branch is based on **DSpace 9.1**, which is affected by all four security advisories fixed in DSpace 9.3 (2026-05-28). This PR cherry-picks the complete security set from upstream `dspace-9_x`:

| Advisory | CVE | Severity | Fix | Upstream PR |
|---|---|---|---|---|
| GHSA-9x82-rm84-c6x7 | CVE-2026-49832 | **HIGH** | RCE via Velocity templates used by LDN: secure Velocity engine (`SecureUberspector`, restricted introspection), only allowlisted config exposed to Email/LDN templates | DSpace/DSpace#12548 |
| GHSA-9qm4-rh6w-pq5x | CVE-2026-49833 | medium | Path traversal in LDN message generation: LDN templates restricted to configured path via new `SecureFileAccess` validator | DSpace/DSpace#12552 |
| GHSA-c827-pw3m-67w7 | CVE-2026-49830 | medium | ORE aggregated resource URI validation (scheme + host allowlist) | DSpace/DSpace#12541 |
| GHSA-v66x-68f2-pxf5 | CVE-2026-49831 | medium | Curation Task Reporter path traversal: curation I/O via `SecureFileAccess`, allowed base paths, `-T`/`-r` CLI-only | DSpace/DSpace#12552 |
| (hardening) | — | — | `GlobalRequestSecurityFilter` rejecting path-traversal/JSP request patterns | DSpace/DSpace#12545 |

### Config changes
- `dspace.cfg`: new `message.templates.allowed-config` allowlist (config keys exposed to Email/LDN Velocity templates)
- `config/modules/curate.cfg`: commented `curate.taskfile.base` / `curate.reporter.base` defaults
- `config/modules/oai.cfg`: commented ORE harvester URL-prefix allowlist
- `config/modules/ldn.cfg` area: LDN template path restrictions

### Behavioral notes
- Email/LDN Velocity templates only see allowlisted config keys — extend `message.templates.allowed-config` if custom templates reference other `${config...}` values.
- Curation `-T` (taskFile) / `-r` (reporter) options are CLI-only now.
- Path-traversal requests return 403 (sitemap test expectations updated).

### Note
The rest of the dataquest customer branches are DSpace 7.6.x and received the equivalent 7.6.7 patch set in separate PRs. This branch needed the **9_x** variants (jakarta-based + the LDN fixes which only exist in DSpace 8+).

### Verification
- `mvn package` (dspace-api + dspace-server-webapp) passes locally.
- Full unit + integration test suite runs via CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
