### PR TITLE
[Port to dtq-dev] Issue 1364: tgz file preview fix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
@@ -369,7 +369,7 @@ public class PreviewContentServiceImpl implements PreviewContentService {
         if (fileName == null) {
             logBitstreamNameIsNull();
         } else {
-            if (fileName.toLowerCase().endsWith("tar.gz")) {
+            if (fileName.toLowerCase().endsWith(".tar.gz") || fileName.toLowerCase().endsWith(".tgz")) {
                 processTarGzipFile(filePaths, file, bitstream);
             } else {
                 try (InputStream is = new GzipCompressorInputStream(new FileInputStream(file))) {

--- a/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreview.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreview.java
@@ -16,12 +16,10 @@ import javax.naming.AuthenticationException;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
-import org.dspace.authenticate.AuthenticationMethod;
-import org.dspace.authenticate.factory.AuthenticateServiceFactory;
-import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
+import org.dspace.content.PreviewContent;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.PreviewContentService;
@@ -46,13 +44,12 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
             ContentServiceFactory.getInstance().getPreviewContentService();
     private EPersonService ePersonService = EPersonServiceFactory.getInstance()
             .getEPersonService();
-    private AuthenticationService authenticateService = AuthenticateServiceFactory.getInstance()
-            .getAuthenticationService();
 
     /**
      * `-i`: Info, show help information.
      */
     private boolean info = false;
+    private boolean force = false;
 
     /**
      * `-u`: UUID of the Item for which to create a preview of its bitstreams.
@@ -60,7 +57,6 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
     private String specificItemUUID = null;
 
     private String epersonMail = null;
-    private String epersonPassword = null;
 
     @Override
     public FilePreviewConfiguration getScriptConfiguration() {
@@ -84,11 +80,14 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                     specificItemUUID);
         }
 
-        epersonMail = commandLine.getOptionValue('e');
-        epersonPassword = commandLine.getOptionValue('p');
+        if (commandLine.hasOption('f')) {
+            force = true;
+        }
 
-        if (getEpersonIdentifier() == null && (epersonMail == null || epersonPassword == null)) {
-            throw new ParseException("Provide both -e/--email and -p/--password when no eperson is supplied.");
+        epersonMail = commandLine.getOptionValue('e');
+
+        if (getEpersonIdentifier() == null && epersonMail == null) {
+            throw new ParseException("Provide -e/--email when no eperson is supplied.");
         }
     }
 
@@ -101,7 +100,7 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
 
         Context context = new Context();
         try {
-            context.setCurrentUser(getAuthenticatedEperson((context)));
+            context.setCurrentUser(getEperson(context));
             handler.logInfo("Authentication by user: " + context.getCurrentUser().getEmail());
             if (StringUtils.isNotBlank(specificItemUUID)) {
                 // Generate the preview only for a specific item
@@ -152,7 +151,17 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                 }
                 // Generate new content if we didn't find any
                 if (previewContentService.hasPreview(context, bitstream)) {
-                    continue;
+                    if (force) {
+                        List<PreviewContent> previewContents = previewContentService
+                                .findByBitstream(context, bitstream.getID());
+                        for (PreviewContent content : previewContents) {
+                            handler.logInfo("Deleting existing preview content: '" + content.getName() +
+                                    "', for bitstream: '" + bitstream.getName() + "'");
+                            previewContentService.delete(context, content);
+                        }
+                    } else {
+                        continue;
+                    }
                 }
 
                 List<FileInfo> fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
@@ -162,6 +171,7 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                     continue;
                 }
 
+                handler.logInfo("Generating file preview for bitstream: " + bitstream.getName());
                 for (FileInfo fi : fileInfos) {
                     previewContentService.createPreviewContent(context, bitstream, fi);
                 }
@@ -176,38 +186,30 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                 "You can choose from these available options:\n" +
                 "  -i, --info            Show help information\n" +
                 "  -u, --uuid            The UUID of the ITEM for which to create a preview of its bitstreams\n" +
-                "  -e, --email           Email for authentication\n" +
-                "  -p, --password        Password for authentication\n");
+                "  -f, --force           Force to create preview, even when the preview exists\n" +
+                "  -e, --email           Email of the eperson to run the script as\n");
 
     }
 
     /**
-     * Retrieves an EPerson object either by its identifier or by performing an email-based lookup.
-     * It then authenticates the EPerson using the provided email and password.
-     * If the authentication is successful, it returns the EPerson object; otherwise,
-     * it throws an AuthenticationException.
+     * Resolves the EPerson the script runs as: the eperson supplied by the launching context
+     * (e.g. the logged-in user when started from the admin UI) if present, otherwise the eperson
+     * looked up by the {@code -e}/--email option. Like other CLI scripts, command-line invocation
+     * is trusted (shell access implies full server access), so no password is verified here;
+     * admin-only operations remain guarded by authorization checks in the service layer.
      *
      * @param context The Context object used for interacting with the DSpace database and service layer.
-     * @return The authenticated EPerson object corresponding to the provided email,
-     *         if authentication is successful.
-     * @throws SQLException If a database error occurs while retrieving or interacting with the EPerson data.
-     * @throws AuthenticationException If no EPerson is found for the provided email
-     *         or if the authentication fails.
+     * @return The EPerson the script should run as.
+     * @throws SQLException If a database error occurs while retrieving the EPerson data.
+     * @throws AuthenticationException If no EPerson is found for the provided email.
      */
-    private EPerson getAuthenticatedEperson(Context context) throws SQLException, AuthenticationException {
+    private EPerson getEperson(Context context) throws SQLException, AuthenticationException {
         if (getEpersonIdentifier() != null) {
             return ePersonService.find(context, getEpersonIdentifier());
         }
-        String msg;
         EPerson ePerson = ePersonService.findByEmail(context, epersonMail);
         if (ePerson == null) {
-            msg = "No EPerson found for this email: " + epersonMail;
-            handler.logError(msg);
-            throw new AuthenticationException(msg);
-        }
-        int authenticated = authenticateService.authenticate(context, epersonMail, epersonPassword, null, null);
-        if (AuthenticationMethod.SUCCESS != authenticated) {
-            msg = "Authentication failed for email: " + epersonMail;
+            String msg = "No EPerson found for this email: " + epersonMail;
             handler.logError(msg);
             throw new AuthenticationException(msg);
         }

--- a/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreviewConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreviewConfiguration.java
@@ -39,15 +39,12 @@ public class FilePreviewConfiguration<T extends FilePreview> extends ScriptConfi
             options.getOption("u").setType(String.class);
             options.getOption("u").setRequired(false);
 
+            options.addOption("f", "force", false, "Force to create preview, even when the preview exists.");
+
             options.addOption("e", "email", true,
-                    "Email for authentication.");
+                    "Email of the eperson to run the script as.");
             options.getOption("e").setType(String.class);
             options.getOption("e").setRequired(true);
-
-            options.addOption("p", "password", true,
-                    "Password for authentication.");
-            options.getOption("p").setType(String.class);
-            options.getOption("p").setRequired(true);
 
             super.options = options;
         }

--- a/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreviewConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreviewConfiguration.java
@@ -44,7 +44,6 @@ public class FilePreviewConfiguration<T extends FilePreview> extends ScriptConfi
             options.addOption("e", "email", true,
                     "Email of the eperson to run the script as.");
             options.getOption("e").setType(String.class);
-            options.getOption("e").setRequired(true);
 
             super.options = options;
         }

--- a/dspace-api/src/test/java/org/dspace/scripts/filepreview/FilePreviewIT.java
+++ b/dspace-api/src/test/java/org/dspace/scripts/filepreview/FilePreviewIT.java
@@ -105,20 +105,10 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @Test
-    public void testUnauthorizedPassword() throws Exception {
-        // Run the script
-        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
-        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail()};
-        int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
-                testDSpaceRunnableHandler, kernelImpl);
-        assertEquals(1, run); // Since a ParseException was caught, expect return code 1
-    }
-
-    @Test
     public void testWhenNoFilesRun() throws Exception {
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
 
-        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail(), "-p",  PASSWORD };
+        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail() };
         int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
                 testDSpaceRunnableHandler, kernelImpl);
         assertEquals(0, run);
@@ -129,7 +119,8 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     public void testForSpecificItem() throws Exception {
         Item item2 = createOtherWorkspaceItemWithBitstream(ePerson, 0);
         // Run the script
-        runScriptForItemWithBitstreams(item2, ePerson, PASSWORD);
+        TestDSpaceRunnableHandler testHandler = runScriptForItemWithBitstreams(item2, ePerson);
+        checkHandlerMessages(testHandler, ePerson, item2, "logos.tgz", true);
 
         Bitstream b = bitstreamService.findAll(context).stream()
                 .filter(bitstream -> bitstream.getName().equals("logos.tgz"))
@@ -147,7 +138,8 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     public void testWhenScriptCannotCreateFilePreview() throws Exception {
         Item item2 = createOtherWorkspaceItemWithBitstream(eperson, 0);
         // Run the script as another user, without admin rights
-        runScriptForItemWithBitstreams(item2, ePerson, PASSWORD);
+        TestDSpaceRunnableHandler testHandler = runScriptForItemWithBitstreams(item2, ePerson);
+        checkHandlerMessages(testHandler, ePerson, item2, null, false);
 
         Bitstream b = bitstreamService.findAll(context).stream()
                 .filter(bitstream -> bitstream.getName().equals("logos.tgz"))
@@ -161,7 +153,8 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
         assertFalse("Expects preview content not created.", previewContentService.hasPreview(context, b));
 
         // Run the script as admin user
-        runScriptForItemWithBitstreams(item2, admin, password);
+        testHandler = runScriptForItemWithBitstreams(item2, admin);
+        checkHandlerMessages(testHandler, admin, item2, "logos.tgz", true);
 
         // now the preview content was created since the script was run by admin user
         assertTrue("Expects preview content created.", previewContentService.hasPreview(context, b));
@@ -173,7 +166,8 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
         configurationService.setProperty("sync.storage.service.enabled", true);
         Item item2 = createOtherWorkspaceItemWithBitstream(ePerson, SYNC_STORE_NUMBER);
         // Run the script
-        runScriptForItemWithBitstreams(item2, ePerson, PASSWORD);
+        TestDSpaceRunnableHandler testHandler = runScriptForItemWithBitstreams(item2, ePerson);
+        checkHandlerMessages(testHandler, ePerson, item2, "logos.tgz", true);
 
         Bitstream b = bitstreamService.findAll(context).stream()
                 .filter(bitstream -> bitstream.getStoreNumber() == SYNC_STORE_NUMBER)
@@ -188,12 +182,40 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     public void testForAllItem() throws Exception {
         // Run the script
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
-        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail(), "-p",  PASSWORD};
+        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail()};
         int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
                 testDSpaceRunnableHandler, kernelImpl);
         assertEquals(0, run);
         // There should be no errors or warnings
         checkNoError(testDSpaceRunnableHandler);
+    }
+
+    @Test
+    public void testPreviewWithForce() throws Exception {
+        Item item2 = createOtherWorkspaceItemWithBitstream(ePerson, 0);
+        // Run the script
+        TestDSpaceRunnableHandler testHandler1 = runScriptForItemWithBitstreams(item2, ePerson);
+        checkHandlerMessages(testHandler1, ePerson, item2, "logos.tgz", true);
+
+        // run again with force option, the existing preview content should be deleted and new one created
+        TestDSpaceRunnableHandler testHandler2 = new TestDSpaceRunnableHandler();
+        String[] args = new String[] { "file-preview", "-u", item2.getID().toString(),
+                "-e", admin.getEmail(), "-f"};
+        int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testHandler2, kernelImpl);
+        assertEquals(0, run);
+        checkNoError(testHandler2);
+
+        List<String> messages = testHandler2.getInfoMessages();
+        assertThat(messages, hasSize(7));
+
+        assertThat(messages, hasItem(containsString("Deleting existing preview content:")));
+
+        Bitstream b = bitstreamService.findAll(context).stream()
+                .filter(bitstream -> bitstream.getName().equals("logos.tgz"))
+                .findFirst().orElse(null);
+
+        assertTrue("Expects preview content created.", previewContentService.hasPreview(context, b));
+        assertEquals(2, previewContentService.getPreview(context, b).size());
     }
 
     private void checkNoError(TestDSpaceRunnableHandler testDSpaceRunnableHandler) {
@@ -201,24 +223,35 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
         assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
     }
 
-    private void runScriptForItemWithBitstreams(Item item, EPerson user, String password) throws Exception {
+    private TestDSpaceRunnableHandler runScriptForItemWithBitstreams(Item item, EPerson user)
+            throws Exception {
         // Run the script
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
         String[] args = new String[] { "file-preview", "-u", item.getID().toString(),
-                "-e", user.getEmail(), "-p",  password};
+                "-e", user.getEmail()};
         int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
                 testDSpaceRunnableHandler, kernelImpl);
         assertEquals(0, run);
         // There should be no errors or warnings
         checkNoError(testDSpaceRunnableHandler);
 
-        // There should be an info message about generating the file previews for the specified item
+        return testDSpaceRunnableHandler;
+    }
+
+    private void checkHandlerMessages(TestDSpaceRunnableHandler testDSpaceRunnableHandler,
+                                      EPerson user,
+                                      Item item,
+                                      String fileName,
+                                      boolean previewGenerationExpected) {
         List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
-        assertThat(messages, hasSize(2));
+        assertThat(messages, hasSize(previewGenerationExpected ? 3 : 2));
         assertThat(messages, hasItem(containsString("Generate the file previews for the specified item with " +
                 "the given UUID: " + item.getID())));
-        assertThat(messages,
-                hasItem(containsString("Authentication by user: " + user.getEmail())));
+        assertThat(messages, hasItem(containsString("Authentication by user: " + user.getEmail())));
+        if (previewGenerationExpected) {
+            // There should be an info message about generating the file previews for the specified bitstream
+            assertThat(messages, hasItem(containsString("Generating file preview for bitstream: " + fileName)));
+        }
     }
 
     private Item createOtherWorkspaceItemWithBitstream(EPerson user, int storageNumber) throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
@@ -245,11 +245,8 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
         BitstreamBuilder.deleteBitstream(tarGzFile.getID());
 
         BitstreamFormat customMimeTypeFormat = tarXGzipFile.getFormat(context);
-        BitstreamBuilder.deleteBitstream(tarXGzipFile.getID());
-        if (customMimeTypeFormat != null) {
-            bitstreamFormatService.delete(context, customMimeTypeFormat);
-        }
 
+        BitstreamBuilder.deleteBitstream(tarXGzipFile.getID());
         BitstreamBuilder.deleteBitstream(tgzFile.getID());
         BitstreamBuilder.deleteBitstream(gzFile.getID());
         BitstreamBuilder.deleteBitstream(tarXzFile.getID());
@@ -257,6 +254,11 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
         BitstreamBuilder.deleteBitstream(tgzFileWithGzipMimeType.getID());
         BitstreamBuilder.deleteBitstream(tarGzFileWithWrongExtension.getID());
         BitstreamBuilder.deleteBitstream(tarXzFileWithIncorrectMimeType.getID());
+
+        // removing custom mime type format created for tarXGzipFile and tgzFileWithGzipMimeType files
+        if (customMimeTypeFormat != null) {
+            bitstreamFormatService.delete(context, customMimeTypeFormat);
+        }
 
         super.destroy();
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
@@ -66,6 +66,7 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
     Bitstream gzFile;
     Bitstream tarXzFile;
     Bitstream xzFile;
+    Bitstream tgzFileWithGzipMimeType;
     Bitstream tarGzFileWithWrongExtension;
     Bitstream tarXzFileWithIncorrectMimeType;
 
@@ -130,6 +131,15 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
                     .withName("logos.tar.gz")
                     .withDescription("tar.gz compressed file")
                     .withCustomMimeType("application/x-gzip")
+                    .build();
+        }
+
+        try (InputStream is = getClass().getResourceAsStream("assetstore/logos.tgz")) {
+            tgzFileWithGzipMimeType = BitstreamBuilder.
+                    createBitstream(context, bundle1, is)
+                    .withName("logos.tgz")
+                    .withDescription("tar.gz compressed file with tgz extension")
+                    .withMimeType("application/x-gzip")
                     .build();
         }
 
@@ -244,6 +254,7 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
         BitstreamBuilder.deleteBitstream(gzFile.getID());
         BitstreamBuilder.deleteBitstream(tarXzFile.getID());
         BitstreamBuilder.deleteBitstream(xzFile.getID());
+        BitstreamBuilder.deleteBitstream(tgzFileWithGzipMimeType.getID());
         BitstreamBuilder.deleteBitstream(tarGzFileWithWrongExtension.getID());
         BitstreamBuilder.deleteBitstream(tarXzFileWithIncorrectMimeType.getID());
 
@@ -336,6 +347,11 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
     @Test
     public void testXzContent() throws Exception {
         assertFileInfo(xzFile, "logos", 24);
+    }
+
+    @Test
+    public void testTgzContentWithGzipMimetype() throws Exception {
+        assertFileInfos(tgzFileWithGzipMimeType);
     }
 
     @Test


### PR DESCRIPTION
Port of ufal/clarin-dspace#1372 by @kuchtiak-ufal to `dtq-dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--force` flag to regenerate file previews even when previews already exist
  * Improved support for `.tgz` compressed archive files in preview generation
  * Updated authentication to use email-based approach (password no longer required)

* **Tests**
  * Added test coverage for `.tgz` file preview handling
  * Updated preview generation tests to reflect new authentication method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->