### PR TITLE
fix: NPE (HTTP 500) in CanManageMappingsFeature for item with null owning collection

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanManageMappingsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanManageMappingsFeature.java
@@ -64,14 +64,18 @@ public class CanManageMappingsFeature implements AuthorizationFeature {
         }
         if (object instanceof ItemRest) {
             Item item = itemService.find(context, UUID.fromString(((ItemRest) object).getUuid()));
-            if (!authorizeService.authorizeActionBoolean(context, item, Constants.WRITE)) {
+            if (item == null || !authorizeService.authorizeActionBoolean(context, item, Constants.WRITE)) {
                 return false;
             }
+            // An orphaned item (e.g. one whose owning collection was lost) has no owning collection.
+            // Guard against it so the feature evaluation does not throw a NullPointerException.
+            Collection owningCollection = item.getOwningCollection();
             try {
                 Optional<Collection> collections = collectionService.findCollectionsWithSubmit(StringUtils.EMPTY,
                                                  context, null, 0, Integer.MAX_VALUE)
                                                 .stream()
-                                                .filter(c -> !c.getID().equals(item.getOwningCollection().getID()))
+                                                .filter(c -> owningCollection == null
+                                                    || !c.getID().equals(owningCollection.getID()))
                                                 .filter(c -> {
                                                     try {
                                                         return collectionService.canEditBoolean(context, c);


### PR DESCRIPTION
## Problem description

`CanManageMappingsFeature.isAuthorized()` throws a `NullPointerException` (HTTP 500) for any **item whose `owning_collection` is NULL**. In production this made an item completely unmanageable from the UI: opening **Edit Item** as an administrator returned 500.

Observed in production (`data-dspace.zcu.cz`) for item `62133a8a-fbd1-474f-9b55-fa92d318aa03` (handle `20.500.14592/107`). The page `/items/<uuid>/edit/metadata` calls `GET /api/authz/authorizations/search/object`, which evaluates the `canManageMappings` feature and crashes:

```
java.lang.NullPointerException: null
  at org.dspace.app.rest.authorization.impl.CanManageMappingsFeature.lambda$isAuthorized$0(CanManageMappingsFeature.java:74)
  at ...ReferencePipeline... findFirst
  at org.dspace.app.rest.authorization.impl.CanManageMappingsFeature.isAuthorized(CanManageMappingsFeature.java:82)
  at org.dspace.app.rest.repository.AuthorizationRestRepository.findByObjectAndFeature(AuthorizationRestRepository.java:277)
```

## Analysis

### Exact cause
The stream filter dereferenced the item's owning collection without a null check:

```java
.filter(c -> !c.getID().equals(item.getOwningCollection().getID()))
```

When `item.getOwningCollection()` is `null`, `.getID()` is called on `null` → `NullPointerException`. The exception only reaches users who pass the preceding `WRITE` authorization check (i.e. administrators), which is why anonymous/non-write users saw the item but admins got a 500 when editing it.

This is a **latent upstream bug**: the same unguarded `item.getOwningCollection().getID()` is still present in upstream DSpace (`dspace-7_x`, `main`, `dspace-8_x`). It only manifests for an item that is in an inconsistent state with **no owning collection**.

### How an item reaches that state (real incident)
The affected item was created by a normal UI submission and its workflow deposit committed successfully (handle assigned, `collection2item` mapping created, Solr-indexed, workspace item deleted). However the item row ended up with `owning_collection = NULL` and `in_archive = false` while the `collection2item` mapping remained — an inconsistent half-reverted state. With `owning_collection = NULL`, this feature crashes. (Repairing that specific item's data — re-setting `owning_collection` + `in_archive` and reindexing — is a separate operational fix and is **not** part of this PR. This PR makes the code robust so the feature never 500s regardless of how an item lost its owning collection.)

## Fix
- Resolve the owning collection once and treat `null` as "there is no owning collection to exclude" in the filter — mirroring the defensive pattern already used by `DeleteFeature`.
- Also guard against `itemService.find()` returning `null`.

```java
if (item == null || !authorizeService.authorizeActionBoolean(context, item, Constants.WRITE)) {
    return false;
}
Collection owningCollection = item.getOwningCollection();
...
.filter(c -> owningCollection == null || !c.getID().equals(owningCollection.getID()))
```

After this change, evaluating `canManageMappings` for an orphaned item returns a normal authorization result instead of throwing, so **Edit Item** no longer returns 500.

## Problems
None.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

Manual repro: with an item whose `owning_collection IS NULL`, open Edit Item as admin → before: HTTP 500 (NPE); after: page loads, no exception.

### Copilot review
- [ ] Requested review from Copilot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item authorization checks to handle items without an owning collection, preventing errors during editability checks.
  * Added safer handling when item data is unavailable, reducing the chance of unexpected authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->