### PR TITLE
JCU/fix: prevent orphaned items - abort leaked request Context (backport #1352 to jcu)

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
@@ -106,9 +106,9 @@ public class StatelessAuthenticationFilter extends BasicAuthenticationFilter {
         try {
             chain.doFilter(req, res);
         } finally {
-            // Complete the context to avoid transactions getting stuck in the connection pool in the
-            // `idle in transaction` state.
-            // TODO add the issue url
+            // Abort the request-scoped DSpace Context if it is still open, so a leaked, dirty
+            // Hibernate session is not left bound to the worker thread (prevents orphaned items).
+            // See https://github.com/dataquest-dev/DSpace/issues/1353
             Context context = (Context) req.getAttribute(ContextUtil.DSPACE_CONTEXT);
             // Ensure the context is cleared after the request is done
             if (context != null && context.isValid()) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
@@ -102,7 +102,23 @@ public class StatelessAuthenticationFilter extends BasicAuthenticationFilter {
         if (authentication != null) {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-        chain.doFilter(req, res);
+
+        try {
+            chain.doFilter(req, res);
+        } finally {
+            // Complete the context to avoid transactions getting stuck in the connection pool in the
+            // `idle in transaction` state.
+            // TODO add the issue url
+            Context context = (Context) req.getAttribute(ContextUtil.DSPACE_CONTEXT);
+            // Ensure the context is cleared after the request is done
+            if (context != null && context.isValid()) {
+                try {
+                    context.abort();
+                } catch (Exception e) {
+                    log.error("{} occurred while trying to close", e.getMessage(), e);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem
On this customer branch a submitted item can silently become **orphaned** — `owning_collection = NULL`, `in_archive = false`, while its `collection2item` mapping and handle survive — so it vanishes from search/listings, has no breadcrumb, and "Edit Item" throws HTTP 500. Tracking issue: dataquest-dev/DSpace#1353. Source: #1352 (and original `dc57ffded8` / #852).

## Root cause
On the request error path a slow submission upload throws before `context.commit()`. `DSpaceRequestContextFilter` assigns its `context` local only **after** `chain.doFilter(...)`, so on an exception the local stays `null` and its `finally` skips the abort → the Hibernate session leaks, still bound to the Tomcat thread holding a dirty, stale Item. A later request on that thread flushes the stale Item as a full-row `UPDATE` (Item has no `@DynamicUpdate`/`@Version`), reverting `owning_collection → NULL` / `in_archive → false`.

## Change set
Backport of the single behavioral hunk from `dc57ffded8` (as shipped to `customer/zcu-data` in #1352, commit `ea6116ebec1`): the **outer** `StatelessAuthenticationFilter` now wraps `chain.doFilter(...)` in `try/finally` and, in the `finally`, reads the Context from `req.getAttribute(ContextUtil.DSPACE_CONTEXT)` and `abort()`s it when still valid — cleaning up the leaked context the inner filter missed. No-op on the success path (request already committed → context no longer valid). One file, +17/-1; no new imports (`Context`/`ContextUtil`/`log` already present). Diagnostic/CI files from `dc57ffded8` intentionally omitted.

## Test evidence
```
# Cherry-pick applied cleanly (identical context) onto this branch.
# Added-hunk signature identical (b8c3482c8bdc) to the CI-green source commit ea6116ebec1 (#1352).
# Full module build + checkstyle + tests run in this PR's CI.
```

## Risk & rollback
Very low: 17-line change, no schema/API change, success path is a no-op; identical to code already merged on `dtq-dev` / `customer/zcu-data` / `customer/vsb-tuo` / `customer/lindat`. Rollback = revert this single commit; no data migration.

## Notes / assumptions
Behavioral-only backport. Defense-in-depth follow-ups are tracked separately in #1353 (null-local fix in `DSpaceRequestContextFilter`; `@DynamicUpdate`/`@Version` on `Item`/`DSpaceObject`; read-path 500 guard #1348).