### PR TITLE
JCU/Add CitacePRO configuration (ported from customer/mendelu)

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -287,11 +287,7 @@ identifier.doi.prefix = 10.5072
 identifier.doi.namespaceseparator = dspace/
 
 ##### Citacepro config ######
-# CitacePRO citation service (https://www.citacepro.com). Ported from customer/mendelu.
-# The frontend item-page widget reads these 3 properties (exposed in modules/rest.cfg)
-# and embeds an iframe: <citace.pro.url>:<citace.pro.university>:<item-handle>.
 citace.pro.url = https://www.citacepro.com/api/dspace/citace/oai
-# TODO_JCU: set JCU's CitacePRO-registered repository host (placeholder; mendelu = repozitar.mendelu.cz)
 citace.pro.university = dspace.jcu.cz
 
 # only use true or false for the value of citace pro allowed

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -286,6 +286,17 @@ identifier.doi.prefix = 10.5072
 # it from other services also minting DOIs under your prefix?
 identifier.doi.namespaceseparator = dspace/
 
+##### Citacepro config ######
+# CitacePRO citation service (https://www.citacepro.com). Ported from customer/mendelu.
+# The frontend item-page widget reads these 3 properties (exposed in modules/rest.cfg)
+# and embeds an iframe: <citace.pro.url>:<citace.pro.university>:<item-handle>.
+citace.pro.url = https://www.citacepro.com/api/dspace/citace/oai
+# TODO_JCU: set JCU's CitacePRO-registered repository host (placeholder; mendelu = repozitar.mendelu.cz)
+citace.pro.university = dspace.jcu.cz
+
+# only use true or false for the value of citace pro allowed
+citace.pro.allowed = true
+
 ##### Plugin management #####
 
 # Where to look for third-party plugin packages.  The value is a colon-separated

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -72,8 +72,6 @@ rest.properties.exposed = matomo.tracker.url
 rest.properties.exposed = bulkedit.export.max.items
 rest.properties.exposed = orcid.domain-url
 rest.properties.exposed = iiif.enabled
-
-# CitacePRO config exposed for the item-page citation widget (ported from customer/mendelu)
 rest.properties.exposed = citace.pro.url
 rest.properties.exposed = citace.pro.allowed
 rest.properties.exposed = citace.pro.university

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -72,3 +72,8 @@ rest.properties.exposed = matomo.tracker.url
 rest.properties.exposed = bulkedit.export.max.items
 rest.properties.exposed = orcid.domain-url
 rest.properties.exposed = iiif.enabled
+
+# CitacePRO config exposed for the item-page citation widget (ported from customer/mendelu)
+rest.properties.exposed = citace.pro.url
+rest.properties.exposed = citace.pro.allowed
+rest.properties.exposed = citace.pro.university


### PR DESCRIPTION
## What is CitacePRO?

[CitacePRO](https://www.citacepro.com) is a Czech citation-generation service. The DSpace frontend embeds a CitacePRO `<iframe>` on the item page; CitacePRO composes the citation from metadata it harvests via OAI‑PMH from the institution's public repository.

This PR ports the **CitacePRO configuration** from `customer/mendelu` to `customer/jcu`, adapted for JCU. It is the backend half of the CitacePRO item‑page widget (companion frontend PR: dataquest-dev/dspace-angular, branch `feature/jcu-citacepro`).

## What was ported

- **`dspace/config/dspace.cfg`** — new `Citacepro config` block:
  - `citace.pro.url = https://www.citacepro.com/api/dspace/citace/oai` (shared CitacePRO API base)
  - `citace.pro.university = dspace.jcu.cz` — **⚠️ FLAGGED PLACEHOLDER** (see below)
  - `citace.pro.allowed = true`
- **`dspace/config/modules/rest.cfg`** — exposes the three properties over REST so the UI can read them via `ConfigurationDataService`:
  - `rest.properties.exposed = citace.pro.url` / `citace.pro.allowed` / `citace.pro.university`

## Source (customer/mendelu)

Branch: https://github.com/dataquest-dev/DSpace/tree/customer/mendelu

- #1210 — MENDELU/Citace pro config (`dspace.cfg` + `modules/rest.cfg`) — **ported**.

### Intentionally NOT ported (per decision with the requester)

The mendelu OAI‑PMH work that shapes `oai_dc.xsl` for CitacePRO harvesting:
- #1233, #1297, #1312, #1314 (and the broader OAI/OpenAIRE reconfig in #1165, #1295)

Reasons:
- It only affects **production** OAI‑PMH harvesting, not the widget rendering.
- It is **metadata-schema-specific to mendelu** (`local.volume`, `local.number`, `dc.relation.ispartof`, `dc.description.version`, `dc.identifier.isbn`) and would produce wrong output if applied blindly to a different schema.
- JCU's OAI formatting will be done separately on JCU prod against JCU's own schema.

Also skipped: the old ZCU PR #686 (put the same props in `clarin-dspace.cfg`; superseded by #1210 which relocated them to `dspace.cfg`), and the closed duplicate #1311 (superseded by #1312).

## ⚠️ JCU-specific value still needed

- **`citace.pro.university = dspace.jcu.cz`** is a placeholder. The real value is JCU's CitacePRO-registered repository host (mendelu uses `repozitar.mendelu.cz`). It must be **confirmed with the customer / CitacePRO** and swapped in before production; the property is flagged with a `TODO_JCU` comment in `dspace.cfg`.

## Verification

- ✅ Config is **volume-mounted** into the running backend container; after restarting it, all three properties are served over REST:
  - `GET /server/api/config/properties/citace.pro.allowed` → `["true"]`
  - `GET /server/api/config/properties/citace.pro.university` → `["dspace.jcu.cz"]`
  - `GET /server/api/config/properties/citace.pro.url` → `["https://www.citacepro.com/api/dspace/citace/oai"]`
- ✅ Frontend widget renders end-to-end against this config (see companion FE PR).
- ℹ️ **No Java changed** — this is config only, so the Maven test suite is not affected by this change and was not run.
