### PR TITLE
TUL/fix: make Subject a plain facet to stop vocabulary=undefined 400s (#781)

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
@@ -48,7 +48,7 @@ public class FacetEntryMatcher {
     public static Matcher<? super Object> subjectFacet(boolean hasNext) {
         return allOf(
             hasJsonPath("$.name", is("subject")),
-            hasJsonPath("$.facetType", is("hierarchical")),
+            hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/subject")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/subject"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
@@ -44,7 +44,7 @@ public class SearchFilterMatcher {
         return allOf(
                 hasJsonPath("$.filter", is("subject")),
                 hasJsonPath("$.hasFacets", is(true)),
-                hasJsonPath("$.type", is("hierarchical")),
+                hasJsonPath("$.type", is("text")),
                 hasJsonPath("$.openByDefault", is(false)),
                 checkOperators()
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -2444,7 +2444,11 @@
 
     </bean>
 
-    <bean id="searchFilterSubject" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">
+    <!-- TUL: dc.subject holds free-text keywords, not a controlled hierarchy, so this is a
+         plain facet. Using HierarchicalSidebarFacetConfiguration makes the Angular UI probe
+         vocabularyEntryDetails/search/top with vocabulary=undefined (no srsc vocabulary is
+         wired for TUL), yielding an HTTP 400 on every search-page render. See dspace-customers#781. -->
+    <bean id="searchFilterSubject" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="subject"/>
         <property name="metadataFields">
             <list>
@@ -2454,8 +2458,6 @@
         <property name="facetLimit" value="5"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
-        <property name="splitter" value="::"/>
-
     </bean>
 
     <bean id="searchFilterIssued" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">


### PR DESCRIPTION
## Problem

TUL's monitoring (NewRelic) surfaced a burst of API errors (issue dataquest-dev/dspace-customers#781). Investigation of the attached log showed, among other noise, **96 WARN `No choices plugin was configured for authorityName "undefined"`** (HTTP 400) on `GET /server/api/submission/vocabularyEntryDetails/search/top?vocabulary=undefined`..

You can replicate it by running this command:
https://dspace.tul.cz/search?f.dateIssued.max=2021&f.has_content_in_original_bundle=false,equals&f.subject=radiodiagnostika&query=radiolog&scope=713b6c9f-c979-483b-8e83-1882cc589ce8&spc.page=1&spc.sd=DESC&spc.sf=dc.date.issued&view=grid

## Root cause

`searchFilterSubject` in `discovery.xml` is a `HierarchicalSidebarFacetConfiguration`. That makes the Angular UI render `SearchHierarchyFilterComponent`, whose `ngOnInit` probes the vocabulary tree via `searchTopEntries(getVocabularyEntry())`. `getVocabularyEntry()` returns **`undefined`** because no `srsc` vocabulary is enabled for TUL (the FE `vocabularies` config default is `enabled: false`). The UI therefore sends `vocabulary=undefined` on **every search-page render, for every user** → HTTP 400.

TUL's `dc.subject` values are **free-text keywords** (e.g. "radiologie", "computed tomography", "FMEA analýza", "Karcinom prsu"), not a controlled hierarchy — so a hierarchical/vocabulary facet is the wrong type for this data.

## Fix

Switch `searchFilterSubject` from `HierarchicalSidebarFacetConfiguration` to a plain `DiscoverySearchFilterFacet` and drop the hierarchical `::` splitter. The facet renders as a normal text facet; the FE no longer probes the vocabulary tree, so the `vocabulary=undefined` 400s stop.

## Scope / notes

- **Only the 400 is addressed here.** The NewRelic alert itself is driven by the separate ERROR-level 422s (malformed operator-less `f.subject` filter URLs from a crawler) and is out of scope for this PR by request.
- No frontend change required — the facet type is read dynamically from the backend facet-config API.
- **Deployment:** run `dspace index-discovery -b` after deploy; this changes how `dc.subject` is indexed for faceting.

## Testing

- Config-only change; `discovery.xml` validated as well-formed XML.
- After deploy + reindex: load a `/search` page with the Subject filter → confirm no `vocabularyEntryDetails/search/top?vocabulary=undefined` request is emitted and the Subject facet still lists/filters values.