### PR TITLE
TUL/fix: log discover 422 (missing filter operator) as WARN, not ERROR (#781)

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -251,9 +251,11 @@ logging.server.include-query-string = false
 # repeating the assignment
 # A 422 on the discover endpoints is an expected client error (e.g. a legacy/crawled search
 # URL whose filter is missing its operator, "f.subject=foo" instead of "f.subject=foo,equals"),
-# not a server fault. Keep this empty so such 4xx are logged at WARN instead of ERROR and do
-# not trip error-rate monitoring (5xx are still logged as ERROR). See dataquest-dev/dspace-customers#781.
-logging.server.include-stacktrace-for-httpcode =
+# not a server fault. Setting this to 0 (a value that matches no real HTTP status) keeps such 4xx
+# logged at WARN instead of ERROR so they don't trip error-rate monitoring (5xx are still ERROR).
+# NB: an empty value would be parsed as a single blank entry and log a "Non-integer HTTP status
+# code" WARN on every error response, so use 0 here. See dataquest-dev/dspace-customers#781.
+logging.server.include-stacktrace-for-httpcode = 0
 logging.server.max-payload-length = 10000
 
 ##### DOI registration agency credentials ######

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -249,7 +249,11 @@ logging.server.include-payload = false
 logging.server.include-query-string = false
 # include-stacktrace-for-httpcode accepts multiple values, comma-separated or by
 # repeating the assignment
-logging.server.include-stacktrace-for-httpcode = 422
+# A 422 on the discover endpoints is an expected client error (e.g. a legacy/crawled search
+# URL whose filter is missing its operator, "f.subject=foo" instead of "f.subject=foo,equals"),
+# not a server fault. Keep this empty so such 4xx are logged at WARN instead of ERROR and do
+# not trip error-rate monitoring (5xx are still logged as ERROR). See dataquest-dev/dspace-customers#781.
+logging.server.include-stacktrace-for-httpcode =
 logging.server.max-payload-length = 10000
 
 ##### DOI registration agency credentials ######


### PR DESCRIPTION
## Problem

TUL monitoring (NewRelic) alerts on a burst of `ERROR ... Unprocessable or invalid entity (status:422)` from the discover endpoints (dataquest-dev/dspace-customers#781).

These 422s are the **correct, documented** DSpace behaviour: a search filter without an operator (`f.subject=foo` instead of `f.subject=foo,equals`) is rejected by `SearchFilterResolver` per the [DSpace REST Contract](https://github.com/DSpace/RestContract/blob/main/search-endpoint.md) ("If the filter operator is absent or invalid a '422 Unprocessable Entity' will be returned"). Latest DSpace `main` behaves identically. The operator-less URLs come from legacy/crawled links (today's UI always emits `,equals`).

So the 422 itself is not a server fault — but `logging.server.include-stacktrace-for-httpcode = 422` (the shipped default) logs it at **ERROR with a stack trace**, which is what trips the error-rate monitor.

## Fix

Set `logging.server.include-stacktrace-for-httpcode =` (empty). These expected 4xx are then logged at **WARN** via `logClientError` instead of ERROR; genuine 5xx are still logged as ERROR. The property is kept present-but-empty on purpose — deleting the line falls back to the compiled default `{422}` (see `DSpaceApiExceptionControllerAdvice.LOG_AS_ERROR_DEFAULT`), which would keep logging 422 as ERROR.

## Scope

- This only stops the **monitoring noise**. A companion frontend PR (dspace-angular customer/TUL) makes the operator-less legacy URLs actually work (defaults the operator to `equals`), so they return 200 instead of 422.
- Config-only change; no API/behaviour change.

## Testing

- `logging.server.include-stacktrace-for-httpcode =` follows the existing empty-value idiom already used in `dspace.cfg` (e.g. `solr.multicorePrefix =`), so the property is present with an empty array and 422 drops out of the ERROR set.
- After deploy: trigger an operator-less filter (`GET /server/api/discover/search/objects?f.subject=foo`) and confirm the log line is `WARN` (not `ERROR`).