### PR TITLE
TUL/fix: log unparseable-PDF filter-media errors as WARN, not ERROR (#752)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -8,6 +8,7 @@
 package org.dspace.app.mediafilter;
 
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.logging.log4j.Logger;
@@ -76,6 +77,14 @@ public class PDFBoxThumbnail extends MediaFilter {
             buf = renderer.renderImage(0);
         } catch (InvalidPasswordException ex) {
             log.error("PDF is encrypted. Cannot create thumbnail (item: {})", currentItem::getHandle);
+            return null;
+        } catch (IOException ex) {
+            // A malformed/non-standard PDF (bad %PDF- header, missing xref, truncated file, etc.)
+            // is a data-quality issue in the source bitstream, not a DSpace fault. Skip the
+            // thumbnail instead of failing the whole filter-media run.
+            // See dataquest-dev/dspace-customers#752.
+            log.warn("PDF could not be parsed by PDFBox. Cannot create thumbnail (item: {}): {}",
+                    currentItem::getHandle, ex::getMessage);
             return null;
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
@@ -79,10 +79,13 @@ public class TikaTextExtractionFilter
             tika.setMaxStringLength(maxChars); // Tell Tika the maximum number of characters to extract
             extractedText = tika.parseToString(source);
         } catch (IOException e) {
-            System.err.format("Unable to extract text from bitstream in Item %s%n", currentItem.getID().toString());
-            e.printStackTrace();
-            log.error("Unable to extract text from bitstream in Item {}", currentItem.getID().toString(), e);
-            throw e;
+            // A malformed/non-standard source file (e.g. a PDF with a corrupt header, missing
+            // xref, or truncated content) is a data-quality issue in the bitstream, not a
+            // DSpace fault. Skip text extraction for it instead of failing the whole
+            // filter-media run. See dataquest-dev/dspace-customers#752.
+            log.warn("Unable to extract text from bitstream in Item {}: {}",
+                    currentItem.getHandle(), e.getMessage());
+            return null;
         } catch (OutOfMemoryError oe) {
             System.err.format("OutOfMemoryError occurred when extracting text from bitstream in Item %s. " +
                 "You may wish to enable 'textextractor.use-temp-file'.%n", currentItem.getID().toString());


### PR DESCRIPTION
## Summary
- The nightly `filter-media` cron job floods `dspace.log` with ~4,655 ERROR lines/night because `PDFBoxThumbnail` and `TikaTextExtractionFilter` let a PDFBox parsing `IOException` (thrown for malformed/corrupt PDFs — e.g. `Header doesn't contain versioninfo`, `End-of-File, expected line at offset N`) escape uncaught or get rethrown, and `MediaFilterServiceImpl`'s generic catch logs it again at ERROR — tripping log-based alerting every run.
- These are pre-existing malformed PDFs in the archive (a data-quality issue, not a DSpace fault); the job already skips them safely and continues. This mirrors the approach in #781 ("log discover 422 as WARN, not ERROR") for the same reason: an expected, already-handled condition was paging on ERROR.
- `PDFBoxThumbnail`: added a `catch (IOException ex)` alongside the existing `catch (InvalidPasswordException ex)` — logs at WARN, returns `null` (clean skip).
- `TikaTextExtractionFilter`: the existing `catch (IOException e)` now logs at WARN and returns `null` instead of ERROR-logging + rethrowing.

Closes dataquest-dev/dspace-customers#752.

## Verification
- `dspace-api` compiles clean on this branch (`mvn -pl dspace-api -am compile`).
- `mvn checkstyle:check -pl dspace-api` reports zero violations.
- Reproduced the exact `End-of-File, expected line at offset N` failure standalone against the real PDFBox **2.0.27** this branch pins (not a newer version), confirming the catch fires for genuinely unparseable PDFs and the bitstream is cleanly skipped without an ERROR log.
- Independent code review flagged that the broad `IOException` catch can't distinguish a malformed PDF from a transient storage-read failure (both surface as `IOException` from the same call); accepted as an inherent library limitation — a real infra failure would recur nightly and is not silently lost, just logged at WARN instead of ERROR, and the WARN messages carry the item handle for follow-up.
- Could not run the existing `TikaTextExtractionFilterTest` suite end-to-end on this branch in this environment: `AbstractUnitTest.initDatabase` fails with a Flyway/DB-bootstrap NPE. Confirmed this is **pre-existing and unrelated** — the identical failure occurs on a pristine `customer/TUL` checkout with no changes applied. The identical fix logic passes that suite (16/16) on a sibling branch with a working local test database.

## Test plan
- [ ] CI runs `TikaTextExtractionFilterTest` (16 tests) and passes
- [ ] CI checkstyle passes
- [ ] Manually run `filter-media` against a known malformed PDF in a TUL sandbox and confirm a WARN (not ERROR) is logged and the item is skipped without failing the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)