### PR TITLE
ci: build & push Docker images from dtq-dev-9-base

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,31 +1,32 @@
 # DSpace Docker image build for hub.docker.com
 name: Docker images
 
-# Run this Build for all pushes to 'main' or maintenance branches, or tagged releases.
-# Also run for PRs to ensure PR doesn't break Docker build process
-# NOTE: uses "reusable-docker-build.yml" to actually build each of the Docker images.
+# Run this Build for all pushes to 'dtq-dev-9-base' (the CLARIN/DSpace 9 base branch).
+# Also run for PRs to ensure PR doesn't break Docker build process (PRs build, but do not push).
+# NOTE: uses the "reusable-docker-build.yml" from the 'dtq-dev' branch to actually build each of the
+# Docker images. That is the same reusable workflow which builds our 'dtq-dev' and 'customer/*' images,
+# and it pushes straight to hub.docker.com/u/dataquest. The vanilla DSpace copy of
+# "reusable-docker-build.yml" that lives on this branch is NOT usable here: it builds via
+# 'ghcr.io/<image_name>', which resolves to 'ghcr.io/dataquest/...' -- a namespace this org does not own.
 on:
   push:
     branches:
-      - main
-      - 'dspace-**'
-    tags:
-      - 'dspace-**'
+      - dtq-dev-9-base
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)
-  packages: write #  to write images to GitHub Container Registry (GHCR)
 
 jobs:
   ####################################################
-  # Build/Push the 'dspace/dspace-dependencies' image.
+  # Build/Push the 'dataquest/dspace-dependencies' image.
   # This image is used by all other DSpace build jobs.
   ####################################################
   dspace-dependencies:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
-    if: github.repository == 'dataquest-dev/dspace' && github.event_name != 'pull_request'
-    uses: ./.github/workflows/reusable-docker-build.yml
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/DSpace'
+    if: github.repository == 'dataquest-dev/dspace'
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-dependencies
       image_name: dataquest/dspace-dependencies
@@ -35,56 +36,54 @@ jobs:
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   #######################################
-  # Build/Push the 'dspace/dspace' image
+  # Build/Push the 'dataquest/dspace' image
   #######################################
   dspace:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
-    if: github.repository == 'dataquest-dev/dspace' && github.event_name != 'pull_request'
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/DSpace'
+    if: github.repository == 'dataquest-dev/dspace'
     # Must run after 'dspace-dependencies' job above
     needs: dspace-dependencies
-    uses: ./.github/workflows/reusable-docker-build.yml
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-prod
       image_name: dataquest/dspace
       dockerfile_path: ./Dockerfile
       run_python_version_script: true
+      # Must match 'build.version.file.path' in dspace/config/clarin-dspace.cfg
+      python_version_script_dest: dspace/config/VERSION_D.txt
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      # Enable redeploy of sandbox & demo if the branch for this image matches the deployment branch of
-      # these sites as specified in reusable-docker-build.xml
-      REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_URL }}
-      REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
 
   #############################################################
-  # Build/Push the 'dspace/dspace' image ('-test' tag)
+  # Build/Push the 'dataquest/dspace' image ('-test' tag)
   #############################################################
   dspace-test:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
-    if: github.repository == 'dataquest-dev/dspace' && github.event_name != 'pull_request'
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/DSpace'
+    if: github.repository == 'dataquest-dev/dspace'
     # Must run after 'dspace-dependencies' job above
     needs: dspace-dependencies
-    uses: ./.github/workflows/reusable-docker-build.yml
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-test
       image_name: dataquest/dspace
       dockerfile_path: ./Dockerfile.test
       # As this is a test/development image, its tags are all suffixed with "-test". Otherwise, it uses the same
-      # tagging logic as the primary 'dspace/dspace' image above.
+      # tagging logic as the primary 'dataquest/dspace' image above.
       tags_flavor: suffix=-test
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   ###########################################
-  # Build/Push the 'dspace/dspace-cli' image
+  # Build/Push the 'dataquest/dspace-cli' image
   ###########################################
   dspace-cli:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
-    if: github.repository == 'dataquest-dev/dspace' && github.event_name != 'pull_request'
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/DSpace'
+    if: github.repository == 'dataquest-dev/dspace'
     # Must run after 'dspace-dependencies' job above
     needs: dspace-dependencies
-    uses: ./.github/workflows/reusable-docker-build.yml
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-cli
       image_name: dataquest/dspace-cli
@@ -94,12 +93,12 @@ jobs:
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   ###########################################
-  # Build/Push the 'dspace/dspace-solr' image
+  # Build/Push the 'dataquest/dspace-solr' image
   ###########################################
   dspace-solr:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
-    if: github.repository == 'dataquest-dev/dspace' && github.event_name != 'pull_request'
-    uses: ./.github/workflows/reusable-docker-build.yml
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/DSpace'
+    if: github.repository == 'dataquest-dev/dspace'
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-solr
       image_name: dataquest/dspace-solr
@@ -109,18 +108,14 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      # Enable redeploy of sandbox & demo SOLR instance whenever dspace-solr image changes for deployed branch.
-      # These URLs MUST use different secrets than 'dspace/dspace' image build above as they are deployed separately.
-      REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_SOLR_URL }}
-      REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_SOLR_URL }}
 
   ########################################################
-  # Build/Push the 'dspace/dspace-postgres-loadsql' image
+  # Build/Push the 'dataquest/dspace-postgres-loadsql' image
   ########################################################
   dspace-postgres-loadsql:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
-    if: github.repository == 'dataquest-dev/dspace' && github.event_name != 'pull_request'
-    uses: ./.github/workflows/reusable-docker-build.yml
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/DSpace'
+    if: github.repository == 'dataquest-dev/dspace'
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-postgres-loadsql
       image_name: dataquest/dspace-postgres-loadsql
@@ -130,117 +125,3 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-  #################################################################################
-  # Test Deployment via Docker to ensure newly built images are working properly
-  #################################################################################
-  docker-deploy:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
-    if: github.repository == 'dataquest-dev/dspace' && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    # Must run after all major images are built
-    needs: [dspace, dspace-test, dspace-cli, dspace-solr]
-    env:
-      # Override defaults dspace.server.url because backend starts at http://127.0.0.1:8080
-      dspace__P__server__P__url: http://127.0.0.1:8080/server
-      # Enable all optional modules / controllers for this test deployment.
-      # This helps check for errors in deploying these modules via Spring Boot
-      iiif__P__enabled: true
-      ldn__P__enabled: true
-      oai__P__enabled: true
-      rdf__P__enabled: true
-      signposting__P__enabled: true
-      sword__D__server__P__enabled: true
-      swordv2__D__server__P__enabled: true
-      # If this is a PR against main (default branch), use "latest".
-      # Else if this is a PR against a different branch, used the base branch name.
-      # Else if this is a commit on main (default branch), use the "latest" tag.
-      # Else, just use the branch name.
-      # NOTE: DSPACE_VER is used because our docker compose scripts default to using the "-test" image.
-      DSPACE_VER: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.ref == github.event.repository.default_branch && 'latest') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref) || (github.ref_name == github.event.repository.default_branch && 'latest') || github.ref_name }}
-      # Docker Registry to use for Docker compose scripts below.
-      # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.
-      DOCKER_REGISTRY: ghcr.io
-    steps:
-      # Checkout our codebase (to get access to Docker Compose scripts)
-      - name: Checkout codebase
-        uses: actions/checkout@v6
-      # Download Docker image artifacts (which were just built by reusable-docker-build.yml)
-      - name: Download Docker image artifacts
-        uses: actions/download-artifact@v8
-        with:
-          # Download all amd64 Docker images (TAR files) into the /tmp/docker directory
-          pattern: docker-image-*-linux-amd64
-          path: /tmp/docker
-          merge-multiple: true
-      # Load each of the images into Docker by calling "docker image load" for each.
-      # This ensures we are using the images just built & not any prior versions on DockerHub
-      - name: Load all downloaded Docker images
-        run: |
-          find /tmp/docker -type f -name "*.tar" -exec docker image load --input "{}" \;
-          docker image ls -a
-      # Start backend using our compose script in the codebase.
-      - name: Start backend in Docker
-        run: |
-          docker compose -f docker-compose.yml up -d
-          sleep 10
-          docker container ls
-      # Create a test admin account. Load test data from a simple set of AIPs as defined in cli.ingest.yml
-      # NOTE: Before creating test data, we wait for the backend to become responsive by requesting it every 10 sec.
-      # Timeout after 5 minutes. This is done to ensure the backend is fully initialized before we create test data.
-      - name: Load test data into Backend
-        run: |
-          timeout 5m wget --retry-connrefused -t 0 --waitretry=10 http://127.0.0.1:8080/server/api
-          docker compose -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
-          docker compose -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
-      # Verify backend started successfully.
-      # 1. Make sure root endpoint is responding (check for dspace.name defined in docker-compose.yml)
-      # 2. Also check /collections endpoint to ensure the test data loaded properly (check for a collection name in AIPs)
-      - name: Verify backend is responding properly
-        run: |
-          result=$(wget -O- -q http://127.0.0.1:8080/server/api)
-          echo "$result"
-          echo "$result" |  grep -oE "\"DSpace Started with Docker Compose\","
-          result=$(wget -O- -q http://127.0.0.1:8080/server/api/core/collections)
-          echo "$result"
-          echo "$result" |  grep -oE "\"Dog in Yard\","
-      # Verify basic backend logging is working.
-      # 1. Access the top communities list. Verify that the "Before request" INFO statement is logged
-      # 2. Access an invalid endpoint (and ignore 404 response). Verify that a "status:404" WARN statement is logged
-      - name: Verify backend is logging properly
-        run: |
-          wget -O/dev/null -q http://127.0.0.1:8080/server/api/core/communities/search/top
-          logs=$(docker compose -f docker-compose.yml logs -n 5 dspace)
-          echo "$logs"
-          echo "$logs" | grep -o "Before request \[GET /server/api/core/communities/search/top\]"
-          wget -O/dev/null -q http://127.0.0.1:8080/server/api/does/not/exist || true
-          logs=$(docker compose -f docker-compose.yml logs -n 5 dspace)
-          echo "$logs"
-          echo "$logs" | grep -o "status:404 exception: The repository type does.not was not found"
-      # Verify Handle Server can be stared and is working properly
-      # 1. First generate the "[dspace]/handle-server" folder with the sitebndl.zip
-      # 2. Start the Handle Server (and wait 20 seconds to let it start up)
-      # 3. Verify logs do NOT include "Exception" in the text (as that means an error occurred)
-      # 4. Check that Handle Proxy HTML page is responding on default port (8000)
-      - name: Verify Handle Server is working properly
-        run: |
-          docker exec -i dspace /dspace/bin/make-handle-config
-          echo "Starting Handle Server..."
-          docker exec -i dspace /dspace/bin/start-handle-server
-          sleep 20
-          echo "Checking for errors in error.log"
-          result=$(docker exec -i dspace sh -c "cat /dspace/handle-server/logs/error.log* || echo ''")
-          echo "$result"
-          echo "$result" | grep -vqz "Exception"
-          echo "Checking for errors in handle-server.log..."
-          result=$(docker exec -i dspace cat /dspace/log/handle-server.log)
-          echo "$result"
-          echo "$result" | grep -vqz "Exception"
-          echo "Checking to see if Handle Proxy webpage is available..."
-          result=$(wget -O- -q http://127.0.0.1:8000/)
-          echo "$result"
-          echo "$result" | grep -oE "Handle Proxy"
-      # Shutdown our containers
-      - name: Shutdown Docker containers
-        run: |
-          docker compose -f docker-compose.yml down


### PR DESCRIPTION
## Why

After the CLARIN-DSpace v9 merge, `dtq-dev-9-base` produces **no images** in hub.docker.com/u/dataquest, so there is nothing to deploy from it. `dtq-dev` and `customer/*` build fine.

There are three independent reasons, not one:

1. **The workflow never triggers.** The `docker.yml` on this branch is still vanilla DSpace's — it only fires on pushes to `main` / `dspace-**`. `dtq-dev-9-base` matches neither.
2. **The vanilla reusable workflow cannot work in this fork.** It builds via `ghcr.io/${image_name}` → `ghcr.io/dataquest/*`. Our GitHub org is `dataquest-dev`; `dataquest` is an **unrelated GitHub user account**, so `GITHUB_TOKEN` has no rights to that namespace (`ghcr.io/dataquest/dspace` → HTTP 403). This path has never actually executed here: every Docker run on a v9 branch is either `skipped` (BE) or a build-only PR run whose `docker-copy_to_dockerhub` job was skipped (FE). The GHCR push has literally never run.
3. **`run_python_version_script` wrote to the wrong place** — vanilla's default `./version.txt`, while `dspace/config/clarin-dspace.cfg:294` reads `build.version.file.path = ${dspace.dir}/config/VERSION_D.txt`.

## What this does

Trigger on pushes to `dtq-dev-9-base` (plus PRs and `workflow_dispatch`), and build via `reusable-docker-build.yml@dtq-dev` — the *same* reusable workflow that builds our `dtq-dev` and `customer/*` images today, which pushes straight to DockerHub.

The vanilla `reusable-docker-build.yml` on this branch is **left untouched**, so future vanilla merges don't conflict with it.

Also:
- **Dropped the vanilla `docker-deploy` job.** It consumes `docker-image-*-linux-amd64` artifacts that the dtq-dev reusable never uploads (its artifact/digest steps are commented out), so it could not succeed here.
- **Pointed the version script at `dspace/config/VERSION_D.txt`** to match `clarin-dspace.cfg`.

## Resulting images (tag `dtq-dev-9-base`, linux/amd64)

| Image | Tags |
|---|---|
| `dataquest/dspace` | `dtq-dev-9-base`, `<sha>` |
| `dataquest/dspace` (test) | `dtq-dev-9-base-test`, `<sha>-test` |
| `dataquest/dspace-cli` | `dtq-dev-9-base`, `<sha>` |
| `dataquest/dspace-solr` | `dtq-dev-9-base`, `<sha>` |
| `dataquest/dspace-dependencies` | `dtq-dev-9-base`, `<sha>` |
| `dataquest/dspace-postgres-loadsql` | `dtq-dev-9-base`, `<sha>` (new repo, auto-created) |

`dspace-7_x` and `latest` are **not** at risk: the reusable only emits those when `github.ref_name == default_branch`, and the default branch is `dtq-dev`.

Frontend counterpart: dataquest-dev/dspace-angular#1379

## Notes / follow-ups (deliberately not in this PR)

- **The BE Docker build has never run on any v9 branch** — this PR is the first time the v9 Dockerfiles get exercised in CI. That's the point, but expect the first run to surface v9 build issues rather than CI-wiring issues.
- `dataquest/dspace-postgres-loadsql` doesn't exist on DockerHub yet; the first push auto-creates it. Worth confirming it lands **public** (all six sibling `dataquest/*` repos are). Same mechanism that created `dataquest/dspace-solr` in #540.
- **The dependencies image is dead weight on this branch.** Unlike `dtq-dev` (whose `Dockerfile` pulls `dataquest/dspace-dependencies:dspace-7_x`), v9's Dockerfiles pull *upstream* `dspace/dspace-dependencies:dspace-9_x`. So we publish `dataquest/dspace-dependencies:dtq-dev-9-base` and never consume it, and our CLARIN Maven deps go uncached. Harmless (the upstream image exists and is fresh) — worth repointing the `ARG`/`FROM` later.
- PRs now build images without pushing (matching `dtq-dev`), which costs CI time per PR. Easy to gate off if it's too heavy.

## Verification

Reviewed by a fan-out of adversarial agents across six lenses (Actions semantics, tag computation, Docker build chain, removal fallout, version script, secrets/push). Every `with:`/`secrets:` key was cross-checked against the `@dtq-dev` reusable's declared `workflow_call` signature; all referenced Dockerfiles/contexts confirmed present; tag derivation confirmed against live DockerHub data. 6 candidate findings were raised and all 6 were refuted on precedent or evidence. No must-fix items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
