### PR TITLE
UFAL/fix: RFC 5987 Content-Disposition for single-file + allzip download (backport vanilla #11260, port #1267)

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamByHandleRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamByHandleRestController.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.text.Normalizer;
 import java.util.List;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
@@ -279,25 +280,50 @@ public class BitstreamByHandleRestController {
     }
 
     /**
-     * Build a Content-Disposition header value using RFC 5987 encoding.
-     * Includes both {@code filename} (ASCII fallback) and {@code filename*}
-     * (UTF-8 percent-encoded) so that curl -J and browsers can save files
-     * with non-ASCII characters in the name correctly.
-     *
-     * @param name the original filename
-     * @return the Content-Disposition header value
+     * Build the Content-Disposition value the way vanilla's HttpHeadersInitializer does: an ASCII
+     * fallback in {@code filename} for clients that predate RFC 5987, plus the real UTF-8 name in
+     * {@code filename*} for everyone else. This endpoint has no upstream counterpart, so the logic
+     * is copied from vanilla rather than shared, to keep it tracking upstream's behaviour.
+     * curl -J on Windows cannot create files with non-ASCII characters from a raw UTF-8 header,
+     * which is why this endpoint needs it too.
      */
     private String buildContentDisposition(String name) {
-        // RFC 5987 percent-encoding for filename*
-        String encoded = URLEncoder.encode(name, StandardCharsets.UTF_8)
-                .replace("+", "%20");
-        // ASCII fallback: replace non-ASCII chars with underscore, escape quotes.
-        // Modern clients use filename* (RFC 5987 / RFC 6266) with real UTF-8 name.
-        String asciiFallback = name.replaceAll("[^\\x20-\\x7E]", "_")
+        return String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                createFallbackAsciiName(name), createEncodedUtf8Name(name));
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        // Deviates from vanilla by escaping \ and ": the value is a quoted-string, and a name
+        // containing a quote closes it early. That is the bug #1267 fixed; vanilla still has it.
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "")
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"");
-        return String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
-                asciiFallback, encoded);
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        return URLEncoder.encode(originalFilename, StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -11,7 +11,10 @@ import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFI
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.text.Normalizer;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -115,7 +118,7 @@ public class MetadataBitstreamController {
         // This bitstream is used to get it's item in the statistics tracker
         Bitstream bitstreamForStatistics = null;
         name = item.getName() + ".zip";
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s\"", name));
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, buildContentDisposition(name));
         response.setContentType("application/zip");
         List<Bundle> bundles = item.getBundles("ORIGINAL");
 
@@ -142,5 +145,50 @@ public class MetadataBitstreamController {
         zip.close();
         matomoBitstreamTracker.trackBitstreamDownload(context, request, bitstreamForStatistics, true);
         response.getOutputStream().flush();
+    }
+
+    /**
+     * Build the Content-Disposition value the way vanilla's HttpHeadersInitializer does: an ASCII
+     * fallback in {@code filename} for clients that predate RFC 5987, plus the real UTF-8 name in
+     * {@code filename*} for everyone else. This endpoint has no upstream counterpart, so the logic
+     * is copied from vanilla rather than shared, to keep it tracking upstream's behaviour.
+     */
+    private String buildContentDisposition(String name) {
+        return String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                createFallbackAsciiName(name), createEncodedUtf8Name(name));
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        // Deviates from vanilla by escaping \ and ": the value is a quoted-string, and an item name
+        // containing a quote closes it early. That is the bug #1267 fixed; vanilla still has it.
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        return URLEncoder.encode(originalFilename, StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -9,9 +9,11 @@ package org.dspace.app.rest.utils;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static javax.mail.internet.MimeUtility.encodeText;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -171,9 +173,16 @@ public class HttpHeadersInitializer {
 
         // distposition may be null here if contentType is null
         if (!isNullOrEmpty(disposition)) {
-            httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
-                                                                                         disposition,
-                                                                                         encodeText(fileName))));
+            String fallbackAsciiName = createFallbackAsciiName(this.fileName);
+            String encodedUtf8Name = createEncodedUtf8Name(this.fileName);
+
+            String headerValue = String.format(
+                "%s; filename=\"%s\"; filename*=UTF-8''%s",
+                disposition,
+                fallbackAsciiName,
+                encodedUtf8Name
+            );
+            httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(headerValue));
         }
         log.debug("Content-Disposition : {}", disposition);
 
@@ -259,6 +268,43 @@ public class HttpHeadersInitializer {
         String[] matchValues = matchHeader.split("\\s*,\\s*");
         Arrays.sort(matchValues);
         return Arrays.binarySearch(matchValues, toMatch) > -1 || Arrays.binarySearch(matchValues, "*") > -1;
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "");
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        try {
+            String encoded = URLEncoder.encode(originalFilename, StandardCharsets.UTF_8.toString());
+            return encoded.replace("+", "%20");
+        } catch (java.io.UnsupportedEncodingException e) {
+            // Fallback to a simple ASCII name if encoding fails.
+            log.error("UTF-8 encoding not supported, which should not happen.", e);
+            return createFallbackAsciiName(originalFilename);
+        }
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamByHandleRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamByHandleRestControllerIT.java
@@ -260,8 +260,8 @@ public class BitstreamByHandleRestControllerIT extends AbstractControllerIntegra
                         + "/M%C3%A9di%C3%A1%20(3).jfif")))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
-                        // ASCII fallback replaces non-ASCII with underscore; filename* has UTF-8 encoding
-                        equalTo("attachment; filename=\"M_di_ (3).jfif\"; "
+                        // ASCII fallback transliterates the diacritics away; filename* keeps the real name
+                        equalTo("attachment; filename=\"Media (3).jfif\"; "
                                 + "filename*=UTF-8''M%C3%A9di%C3%A1%20%283%29.jfif")))
                 .andExpect(content().string(bitstreamContent));
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static java.util.UUID.randomUUID;
-import static javax.mail.internet.MimeUtility.encodeText;
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.io.IOUtils.toInputStream;
@@ -364,7 +363,11 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         //2. A public item with a bitstream
 
         String bitstreamContent = "0123456789";
-        String bitstreamName = "ภาษาไทย";
+        String bitstreamName = "ภาษาไทย-com-acentuação.pdf";
+        String expectedAscii = "-com-acentuacao.pdf";
+        String expectedUtf8Encoded =
+        "%E0%B8%A0%E0%B8%B2%E0%B8%A9%E0%B8%B2%E0%B9%84%E0%B8%97%E0%B8%A2-"
+        + "com-acentua%C3%A7%C3%A3o.pdf";
 
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
 
@@ -388,7 +391,9 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
             //We expect the content disposition to have the encoded bitstream name
             .andExpect(header().string(
                 "Content-Disposition",
-                "attachment;filename=\"" + encodeText(bitstreamName) + "\""
+                String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                              expectedAscii,
+                              expectedUtf8Encoded)
             ));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.ByteArrayInputStream;
@@ -103,5 +104,63 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
         assertEquals(1, entryCount);
         assertEquals(Set.of(bts.getName()), entries.keySet());
         assertEquals(BITSTREAM_CONTENT, entries.get(bts.getName()));
+    }
+
+    @Test
+    public void downloadAllZipWithDoubleQuotesInItemName() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // Double quotes in the name used to close the header's quoted-string early, which browsers
+        // reported as ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION.
+        Item itemWithQuotes = ItemBuilder.createItem(context, col)
+                .withTitle("Supported data for manuscript \"Thermally-induced evolution\"")
+                .withAuthor(AUTHOR)
+                .build();
+
+        try (InputStream is = IOUtils.toInputStream("QuotedItemContent", CharEncoding.UTF_8)) {
+            BitstreamBuilder.createBitstream(context, itemWithQuotes, is)
+                    .withName("data.csv")
+                    .withMimeType("text/csv")
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + itemWithQuotes.getID() +
+                        "/" + ALL_ZIP_PATH).param(HANDLE_PARAM, itemWithQuotes.getHandle()))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"Supported data for manuscript"
+                        + " \\\"Thermally-induced evolution\\\".zip\";"
+                        + " filename*=UTF-8''Supported%20data%20for%20manuscript"
+                        + "%20%22Thermally-induced%20evolution%22.zip"));
+    }
+
+    @Test
+    public void downloadAllZipWithNonAsciiItemName() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item itemWithDiacritics = ItemBuilder.createItem(context, col)
+                .withTitle("Příliš žluťoučký kůň")
+                .withAuthor(AUTHOR)
+                .build();
+
+        try (InputStream is = IOUtils.toInputStream("DiacriticsContent", CharEncoding.UTF_8)) {
+            BitstreamBuilder.createBitstream(context, itemWithDiacritics, is)
+                    .withName("file.txt")
+                    .withMimeType("text/plain")
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + itemWithDiacritics.getID() +
+                        "/" + ALL_ZIP_PATH).param(HANDLE_PARAM, itemWithDiacritics.getHandle()))
+                .andExpect(status().isOk())
+                // fallback transliterates the diacritics away; filename* carries the real name
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"Prilis zlutoucky kun.zip\";"
+                        + " filename*=UTF-8''P%C5%99%C3%ADli%C5%A1%20%C5%BElu%C5%A5ou%C4%8Dk%C3%BD"
+                        + "%20k%C5%AF%C5%88.zip"));
     }
 }


### PR DESCRIPTION
Downloading a file whose name has diacritics gives the wrong filename. There were two separate causes; this fixes both on `dtq-dev`. Everything here is propagated **from** vanilla — no new fork API is introduced.

## Before / after, on a real DSpace

![before and after](https://raw.githubusercontent.com/dataquest-dev/DSpace/demo-evidence-cd/before-after.png)

Two backend images built from source and run against the **same Postgres, same item, same URL** — only the image is swapped:

| | image | commit |
|---|---|---|
| before | `01abd129d3fc` | `origin/dtq-dev` @ `00501a2db0` |
| after | `0e023581d69e` | this PR @ `1e1b1fea5f` |

Item title and bitstream name are both `Příliš žluťoučký kůň`. Headers are captured off the wire; filenames are whatever the client itself chose (Chrome via Playwright, and `curl -OJ`). Raw JSON captures are on the [`demo-evidence-cd`](https://github.com/dataquest-dev/DSpace/tree/demo-evidence-cd) branch.

**Read the middle block before the top one.** The single-file path shows **no difference in Chrome**, because Chrome and Firefox decode RFC 2047 even though RFC 6266 App. C.1 forbids it. That row is in the screenshot precisely because it does not show a win.

## 1. allzip — the path the report was actually about

`MetadataBitstreamController` built `attachment;filename="<raw name>"` with no encoding at all. Raw UTF-8 in a header is not merely mangled — **Tomcat drops the header entirely**, so the response carries no `Content-Disposition` and Chrome falls back to the URL segment and saves `allzip.zip`. The name is lost outright. [#1267](https://github.com/dataquest-dev/DSpace/pull/1267) fixed this but landed only on `customer/zcu-data`; this ports it.

Item names containing a `"` were the other half of #1267: an unescaped quote closes the header's quoted-string early (`ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION`).

## 2. Single file — cherry-pick from vanilla

`HttpHeadersInitializer` encoded the name with `MimeUtility.encodeText`, i.e. an RFC 2047 encoded-word (`=?UTF-8?Q?...?=`) — an *email* header format that RFC 6266 App. C.1 does not allow in HTTP. Chrome and Firefox decode it anyway; **Safari and `curl -OJ` do not**, and since the encoded-word ends in `?=` the real extension ends up buried mid-name. That is why this bug looked intermittent.

Clean `cherry-pick -x` of `fe4077acee` ([#11269](https://github.com/DSpace/DSpace/pull/11269), the `dspace-7_x` backport of [#11260](https://github.com/DSpace/DSpace/pull/11260), released in 7.6.6). The file is **byte-identical to vanilla** before and after, so the upstream sync stays conflict-free. [#1340](https://github.com/dataquest-dev/DSpace/pull/1340) put us nominally on 7.6.7 but cherry-picked only the CVE commits, so this never came along.

⚠️ Because it is byte-identical to vanilla, this path **still does not escape quotes** — vanilla has that bug too. A bitstream named with a `"` breaks the header even on a clean 7.6.6. Not fixed here on purpose; it belongs upstream.

## 3. Why the logic is copied, not shared

`MetadataBitstreamController` (allzip) and `BitstreamByHandleRestController` (curl endpoint) have **no counterpart upstream** — they are fork-only classes. Each now carries its own private copy of vanilla's `createFallbackAsciiName` / `createEncodedUtf8Name`, exactly as vanilla's own `HttpHeadersInitializer` does.

That is deliberate duplication. A shared helper would be a fork-invented API to maintain forever, and would force divergence in a file we want to keep identical to upstream.

`BitstreamByHandleRestController` was **not broken** — it already emitted `filename*` on `dtq-dev`. Only its ASCII fallback changes here (`P__li_ _lu_ou_k_ k__` → `Prilis zlutoucky kun`), for consistency with the other two paths.

## One deviation from vanilla — please check in review

Both fork copies escape `\` and `"` in the ASCII fallback; vanilla does not. Copying vanilla verbatim would have regressed #1267, which exists because of real ZCU item names like `Supported data for manuscript "Thermally-induced evolution"`. Marked in a comment at both sites.

## Behaviour change to note in review

The fallback now transliterates instead of blanking out, so `BitstreamByHandleRestControllerIT` expects `"Media (3).jfif"` where it expected `"M_di_ (3).jfif"`. Only clients that ignore `filename*` ever see this value.

## Verified

- `mvn compile` / `test-compile` on `dspace-api` + `dspace-server-webapp` — pass
- `mvn checkstyle:check` — 0 violations
- `HttpHeadersInitializer` confirmed byte-identical to vanilla `fe4077acee`
- the A/B run above, against a real backend built from each commit
- ITs **not** run locally (need Postgres + Solr) — left to CI

## Scope of the demo — what it does not show

- the S3 presigned-URL path ([#1371](https://github.com/dataquest-dev/DSpace/pull/1371)) is **not exercised** — there is no S3 in this compose
- pre-fix output depends on the server's default charset. This container is `file.encoding=UTF-8`, which is the **best** case; on a non-UTF-8 JVM the name is destroyed before it leaves the server, and not even Chrome can recover it
- `curl -OJ` "after" saves the ASCII fallback, not the diacritics name, because curl reads only `filename` and ignores `filename*`. Unreadable → readable is the win there, not perfect

## Follow-ups (not in this PR)

- backports: [#1369](https://github.com/dataquest-dev/DSpace/pull/1369) (`customer/zcu-pub`), [#1370](https://github.com/dataquest-dev/DSpace/pull/1370) (`customer/zcu-data`); S3 in [#1371](https://github.com/dataquest-dev/DSpace/pull/1371)
- `dtq-dev-9-base` still has the old allzip line, so the v9 migration would reintroduce cause 1
- vanilla's fix does not escape quotes — worth an upstream issue
- delete the `demo-evidence-cd` branch once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
