### PR TITLE
ZCU-PUB/fix: RFC 5987 Content-Disposition for single-file + allzip download (backport #1368)

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -11,7 +11,10 @@ import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFI
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.text.Normalizer;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -110,7 +113,7 @@ public class MetadataBitstreamController {
 
         Item item = (Item) dso;
         name = item.getName() + ".zip";
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s\"", name));
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, buildContentDisposition(name));
         response.setContentType("application/zip");
         List<Bundle> bundles = item.getBundles("ORIGINAL");
 
@@ -133,5 +136,50 @@ public class MetadataBitstreamController {
         }
         zip.close();
         response.getOutputStream().flush();
+    }
+
+    /**
+     * Build the Content-Disposition value the way vanilla's HttpHeadersInitializer does: an ASCII
+     * fallback in {@code filename} for clients that predate RFC 5987, plus the real UTF-8 name in
+     * {@code filename*} for everyone else. This endpoint has no upstream counterpart, so the logic
+     * is copied from vanilla rather than shared, to keep it tracking upstream's behaviour.
+     */
+    private String buildContentDisposition(String name) {
+        return String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                createFallbackAsciiName(name), createEncodedUtf8Name(name));
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        // Deviates from vanilla by escaping \ and ": the value is a quoted-string, and an item name
+        // containing a quote closes it early. That is the bug #1267 fixed; vanilla still has it.
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        return URLEncoder.encode(originalFilename, StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -282,7 +282,11 @@ public class HttpHeadersInitializer {
         }
         String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
         String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "");
+        // Escape \ and ": the value is placed in a quoted-string, so a filename containing a quote
+        // would close it early and break the header. Mirrors MetadataBitstreamController (bug #1267).
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
     }
 
     /**
@@ -296,14 +300,7 @@ public class HttpHeadersInitializer {
         if (originalFilename == null) {
             return "";
         }
-        try {
-            String encoded = URLEncoder.encode(originalFilename, StandardCharsets.UTF_8.toString());
-            return encoded.replace("+", "%20");
-        } catch (java.io.UnsupportedEncodingException e) {
-            // Fallback to a simple ASCII name if encoding fails.
-            log.error("UTF-8 encoding not supported, which should not happen.", e);
-            return createFallbackAsciiName(originalFilename);
-        }
+        return URLEncoder.encode(originalFilename, StandardCharsets.UTF_8).replace("+", "%20");
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -9,9 +9,11 @@ package org.dspace.app.rest.utils;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static javax.mail.internet.MimeUtility.encodeText;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
@@ -165,9 +167,16 @@ public class HttpHeadersInitializer {
 
         httpHeaders.put(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
                         Collections.singletonList(HttpHeaders.ACCEPT_RANGES));
-        httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
-                                                                                     disposition,
-                                                                                     encodeText(fileName))));
+        String fallbackAsciiName = createFallbackAsciiName(this.fileName);
+        String encodedUtf8Name = createEncodedUtf8Name(this.fileName);
+
+        String headerValue = String.format(
+            "%s; filename=\"%s\"; filename*=UTF-8''%s",
+            disposition,
+            fallbackAsciiName,
+            encodedUtf8Name
+        );
+        httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(headerValue));
         log.debug("Content-Disposition : {}", disposition);
 
         // Content phase
@@ -258,6 +267,43 @@ public class HttpHeadersInitializer {
         String[] matchValues = matchHeader.split("\\s*,\\s*");
         Arrays.sort(matchValues);
         return Arrays.binarySearch(matchValues, toMatch) > -1 || Arrays.binarySearch(matchValues, "*") > -1;
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "");
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        try {
+            String encoded = URLEncoder.encode(originalFilename, StandardCharsets.UTF_8.toString());
+            return encoded.replace("+", "%20");
+        } catch (java.io.UnsupportedEncodingException e) {
+            // Fallback to a simple ASCII name if encoding fails.
+            log.error("UTF-8 encoding not supported, which should not happen.", e);
+            return createFallbackAsciiName(originalFilename);
+        }
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static java.util.UUID.randomUUID;
-import static javax.mail.internet.MimeUtility.encodeText;
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.io.IOUtils.toInputStream;
@@ -332,7 +331,11 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         //2. A public item with a bitstream
 
         String bitstreamContent = "0123456789";
-        String bitstreamName = "ภาษาไทย";
+        String bitstreamName = "ภาษาไทย-com-acentuação.pdf";
+        String expectedAscii = "-com-acentuacao.pdf";
+        String expectedUtf8Encoded =
+        "%E0%B8%A0%E0%B8%B2%E0%B8%A9%E0%B8%B2%E0%B9%84%E0%B8%97%E0%B8%A2-"
+        + "com-acentua%C3%A7%C3%A3o.pdf";
 
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
 
@@ -356,7 +359,9 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
             //We expect the content disposition to have the encoded bitstream name
             .andExpect(header().string(
                 "Content-Disposition",
-                "attachment;filename=\"" + encodeText(bitstreamName) + "\""
+                String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                              expectedAscii,
+                              expectedUtf8Encoded)
             ));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.ByteArrayOutputStream;
@@ -96,5 +97,63 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
                 .andExpect(status().isOk())
                 .andExpect(content().bytes(byteArrayOutputStream.toByteArray()));
 
+    }
+
+    @Test
+    public void downloadAllZipWithDoubleQuotesInItemName() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // Double quotes in the name used to close the header's quoted-string early, which browsers
+        // reported as ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION.
+        Item itemWithQuotes = ItemBuilder.createItem(context, col)
+                .withTitle("Supported data for manuscript \"Thermally-induced evolution\"")
+                .withAuthor(AUTHOR)
+                .build();
+
+        try (InputStream is = IOUtils.toInputStream("QuotedItemContent", CharEncoding.UTF_8)) {
+            BitstreamBuilder.createBitstream(context, itemWithQuotes, is)
+                    .withName("data.csv")
+                    .withMimeType("text/csv")
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + itemWithQuotes.getID() +
+                        "/" + ALL_ZIP_PATH).param(HANDLE_PARAM, itemWithQuotes.getHandle()))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"Supported data for manuscript"
+                        + " \\\"Thermally-induced evolution\\\".zip\";"
+                        + " filename*=UTF-8''Supported%20data%20for%20manuscript"
+                        + "%20%22Thermally-induced%20evolution%22.zip"));
+    }
+
+    @Test
+    public void downloadAllZipWithNonAsciiItemName() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item itemWithDiacritics = ItemBuilder.createItem(context, col)
+                .withTitle("Příliš žluťoučký kůň")
+                .withAuthor(AUTHOR)
+                .build();
+
+        try (InputStream is = IOUtils.toInputStream("DiacriticsContent", CharEncoding.UTF_8)) {
+            BitstreamBuilder.createBitstream(context, itemWithDiacritics, is)
+                    .withName("file.txt")
+                    .withMimeType("text/plain")
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + itemWithDiacritics.getID() +
+                        "/" + ALL_ZIP_PATH).param(HANDLE_PARAM, itemWithDiacritics.getHandle()))
+                .andExpect(status().isOk())
+                // fallback transliterates the diacritics away; filename* carries the real name
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"Prilis zlutoucky kun.zip\";"
+                        + " filename*=UTF-8''P%C5%99%C3%ADli%C5%A1%20%C5%BElu%C5%A5ou%C4%8Dk%C3%BD"
+                        + "%20k%C5%AF%C5%88.zip"));
     }
 }


### PR DESCRIPTION
Backport of [#1368](https://github.com/dataquest-dev/DSpace/pull/1368) to `customer/zcu-pub`. Fixes the wrong filename when downloading a file whose name has diacritics — both causes.

Customer branches never merge `dtq-dev` (they sit ~258 commits behind and take individual backports), so this cannot ride along on #1368.

## Evidence

The before/after A/B run is in [#1368](https://github.com/dataquest-dev/DSpace/pull/1368) — two real backend images against the same database. It was run on the `dtq-dev` pair, **not** on this branch, so treat it as evidence for the shared fix rather than for this backport specifically.

![before and after](https://raw.githubusercontent.com/dataquest-dev/DSpace/demo-evidence-cd/before-after.png)

## What's fixed

1. **allzip** — `MetadataBitstreamController` built `attachment;filename="<raw name>"` with no encoding. Raw UTF-8 in a header makes **Tomcat drop the header entirely**, so the browser gets no filename at all and falls back to the URL segment (`allzip.zip`). A `"` in an item name closed the quoted-string early (`ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION`).
2. **Single file** — `HttpHeadersInitializer` used `MimeUtility.encodeText`, i.e. an RFC 2047 encoded-word, which RFC 6266 App. C.1 forbids in HTTP. Cherry-pick of vanilla `fe4077acee` ([#11269](https://github.com/DSpace/DSpace/pull/11269) → 7.6.6). Note Chrome and Firefox decode RFC 2047 anyway, so this half is invisible to them — it bites Safari and `curl -OJ`.

As on #1368, `MetadataBitstreamController` carries its own private copy of vanilla's `createFallbackAsciiName` / `createEncodedUtf8Name` rather than a shared fork helper: it is a fork-only class with no upstream counterpart, so copying keeps it tracking vanilla and adds no API to maintain.

## Differences from #1368 — please check these in review

- **`BitstreamByHandleRestController` does not exist on this branch** (the curl endpoint from #1252 was never backported here), so it is not touched.
- **The `HttpHeadersInitializer` cherry-pick conflicted** and was hand-resolved. This branch's copy predates vanilla's `isNullOrEmpty(disposition)` guard and has its own `METHOD_HEAD` early-return; I kept this branch's structure and swapped only the encoding. Unlike on `dtq-dev`, this file is **not** byte-identical to vanilla — it already wasn't.

## One deviation from vanilla

The ASCII fallback escapes `\` and `"`; vanilla omits this, so a name containing a quote breaks the header even on a clean 7.6.6. Copying vanilla verbatim would have regressed #1267. Marked in a comment at the call site.

## Verified

- `mvn test-compile` on `dspace-api` + `dspace-server-webapp` — pass
- checkstyle is not wired up on this 7.6.1 branch, so it is a no-op here; the same code passes it on `dtq-dev`
- ITs **not** run locally (need Postgres + Solr) — left to CI
- the A/B run was done on the `dtq-dev` pair, not on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
