### PR TITLE
ZCU-DATA/fix: RFC 5987 Content-Disposition for single-file download (backport #1368)

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -14,6 +14,7 @@ import java.io.InputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.text.Normalizer;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -138,17 +139,47 @@ public class MetadataBitstreamController {
     }
 
     /**
-     * Build a Content-Disposition header value using RFC 5987 encoding.
-     * Includes both {@code filename} (ASCII fallback with escaped quotes) and {@code filename*}
-     * (UTF-8 percent-encoded) so that browsers can save files with special characters correctly.
+     * Build the Content-Disposition value the way vanilla's HttpHeadersInitializer does: an ASCII
+     * fallback in {@code filename} for clients that predate RFC 5987, plus the real UTF-8 name in
+     * {@code filename*} for everyone else. This endpoint has no upstream counterpart, so the logic
+     * is copied from vanilla rather than shared, to keep it tracking upstream's behaviour.
      */
     private String buildContentDisposition(String name) {
-        String encoded = URLEncoder.encode(name, StandardCharsets.UTF_8)
-                .replace("+", "%20");
-        String asciiFallback = name.replaceAll("[^\\x20-\\x7E]", "_")
+        return String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                createFallbackAsciiName(name), createEncodedUtf8Name(name));
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        // Deviates from vanilla by escaping \ and ": the value is a quoted-string, and an item name
+        // containing a quote closes it early. That is the bug #1267 fixed; vanilla still has it.
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "")
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"");
-        return String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
-                asciiFallback, encoded);
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        return URLEncoder.encode(originalFilename, StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MetadataBitstreamController.java
@@ -162,9 +162,10 @@ public class MetadataBitstreamController {
         }
         String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
         String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-        // Deviates from vanilla by escaping \ and ": the value is a quoted-string, and an item name
-        // containing a quote closes it early. That is the bug #1267 fixed; vanilla still has it.
-        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "")
+        // Deviates from vanilla: restrict to printable ASCII and escape \ and ". The value is a
+        // quoted-string, so control chars could inject a header and a quote would close it early.
+        // That is the bug #1267 fixed; vanilla still has it.
+        return withoutAccents.replaceAll("[^\\x20-\\x7E]", "")
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"");
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -282,7 +282,12 @@ public class HttpHeadersInitializer {
         }
         String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
         String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "");
+        // Deviates from vanilla: restrict to printable ASCII and escape \ and ". The value is a
+        // quoted-string, so control chars could inject a header and a quote would close it early.
+        // Kept consistent with MetadataBitstreamController.createFallbackAsciiName.
+        return withoutAccents.replaceAll("[^\\x20-\\x7E]", "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -9,9 +9,11 @@ package org.dspace.app.rest.utils;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static javax.mail.internet.MimeUtility.encodeText;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
@@ -165,9 +167,16 @@ public class HttpHeadersInitializer {
 
         httpHeaders.put(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
                         Collections.singletonList(HttpHeaders.ACCEPT_RANGES));
-        httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
-                                                                                     disposition,
-                                                                                     encodeText(fileName))));
+        String fallbackAsciiName = createFallbackAsciiName(this.fileName);
+        String encodedUtf8Name = createEncodedUtf8Name(this.fileName);
+
+        String headerValue = String.format(
+            "%s; filename=\"%s\"; filename*=UTF-8''%s",
+            disposition,
+            fallbackAsciiName,
+            encodedUtf8Name
+        );
+        httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(headerValue));
         log.debug("Content-Disposition : {}", disposition);
 
         // Content phase
@@ -258,6 +267,43 @@ public class HttpHeadersInitializer {
         String[] matchValues = matchHeader.split("\\s*,\\s*");
         Arrays.sort(matchValues);
         return Arrays.binarySearch(matchValues, toMatch) > -1 || Arrays.binarySearch(matchValues, "*") > -1;
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "");
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        try {
+            String encoded = URLEncoder.encode(originalFilename, StandardCharsets.UTF_8.toString());
+            return encoded.replace("+", "%20");
+        } catch (java.io.UnsupportedEncodingException e) {
+            // Fallback to a simple ASCII name if encoding fails.
+            log.error("UTF-8 encoding not supported, which should not happen.", e);
+            return createFallbackAsciiName(originalFilename);
+        }
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static java.util.UUID.randomUUID;
-import static javax.mail.internet.MimeUtility.encodeText;
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.io.IOUtils.toInputStream;
@@ -332,7 +331,11 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         //2. A public item with a bitstream
 
         String bitstreamContent = "0123456789";
-        String bitstreamName = "ภาษาไทย";
+        String bitstreamName = "ภาษาไทย-com-acentuação.pdf";
+        String expectedAscii = "-com-acentuacao.pdf";
+        String expectedUtf8Encoded =
+        "%E0%B8%A0%E0%B8%B2%E0%B8%A9%E0%B8%B2%E0%B9%84%E0%B8%97%E0%B8%A2-"
+        + "com-acentua%C3%A7%C3%A3o.pdf";
 
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
 
@@ -356,7 +359,9 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
             //We expect the content disposition to have the encoded bitstream name
             .andExpect(header().string(
                 "Content-Disposition",
-                "attachment;filename=\"" + encodeText(bitstreamName) + "\""
+                String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                              expectedAscii,
+                              expectedUtf8Encoded)
             ));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamControllerIT.java
@@ -154,9 +154,9 @@ public class MetadataBitstreamControllerIT extends AbstractControllerIntegration
         getClient(token).perform(get(METADATABITSTREAM_ENDPOINT + "/" + itemWithDiacritics.getID() +
                         "/" + ALL_ZIP_PATH).param(HANDLE_PARAM, itemWithDiacritics.getHandle()))
                 .andExpect(status().isOk())
-                // Non-ASCII chars replaced with _ in filename, full UTF-8 in filename*
+                // fallback transliterates the diacritics away; filename* carries the real name
                 .andExpect(header().string("Content-Disposition",
-                        "attachment; filename=\"P__li_ _lu_ou_k_ k__.zip\";"
+                        "attachment; filename=\"Prilis zlutoucky kun.zip\";"
                         + " filename*=UTF-8''P%C5%99%C3%ADli%C5%A1%20%C5%BElu%C5%A5ou%C4%8Dk%C3%BD"
                         + "%20k%C5%AF%C5%88.zip"));
     }


### PR DESCRIPTION
Backport of [#1368](https://github.com/dataquest-dev/DSpace/pull/1368) to `customer/zcu-data`. Fixes the wrong filename when downloading a **single file**.

allzip was already fixed here by [#1267](https://github.com/dataquest-dev/DSpace/pull/1267) — this covers the other half, which was never fixed on any branch.

## What's fixed

`HttpHeadersInitializer` encoded the name with `MimeUtility.encodeText`, i.e. an RFC 2047 encoded-word (`=?UTF-8?Q?...?=`) — an *email* header format that RFC 6266 App. C.1 does not allow in HTTP.

**Be aware what this does and does not change in practice.** Chrome and Firefox decode RFC 2047 anyway, so for them nothing changes — measured, not assumed (see the middle block of the screenshot in [#1368](https://github.com/dataquest-dev/DSpace/pull/1368)). It bites clients that follow the spec: Safari, and `curl -OJ`, which saved the encoded-word verbatim with the extension buried mid-name. That is why this looked intermittent depending on who reported it.

Cherry-pick of vanilla `fe4077acee` ([#11269](https://github.com/DSpace/DSpace/pull/11269) → 7.6.6). The cherry-pick conflicted — this branch's copy predates vanilla's `isNullOrEmpty(disposition)` guard and has its own `METHOD_HEAD` early-return. I kept this branch's structure and swapped only the encoding, so the backport stays surgical.

## Alignment with vanilla

The private `buildContentDisposition()` added by #1267 now uses vanilla's `createFallbackAsciiName` / `createEncodedUtf8Name`, so allzip and single-file render the same way and both track upstream. No shared fork helper — `MetadataBitstreamController` is fork-only, so it keeps its own copy, exactly as vanilla's `HttpHeadersInitializer` does.

The escaping of `\` and `"` that #1267 added is **kept** and marked as a deliberate deviation: vanilla omits it and still has that bug, so copying verbatim would have regressed #1267.

## Behaviour change to note in review

The fallback now transliterates instead of blanking out, so allzip yields `"Prilis zlutoucky kun.zip"` where #1267 produced `"P__li_ _lu_ou_k_ k__.zip"`. The IT from #1267 is updated to match. Only clients that ignore `filename*` ever see this value.

## Verified

- `mvn test-compile` on `dspace-api` + `dspace-server-webapp` — pass
- ITs **not** run locally (need Postgres + Solr) — left to CI
- the A/B run in #1368 was done on the `dtq-dev` pair, not on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
