### PR TITLE
build: pull dspace-dependencies from dataquest, not upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@
 # To build with other versions, use "--build-arg JDK_VERSION=[value]"
 ARG JDK_VERSION=17
 # The Docker version tag to build from
-ARG DSPACE_VERSION=dspace-9_x
+ARG DSPACE_VERSION=dtq-dev-9-base
 # The Docker registry to use for DSpace images. Defaults to "docker.io"
 # NOTE: non-DSpace images are hardcoded to use "docker.io" and are not impacted by this build argument
 ARG DOCKER_REGISTRY=docker.io
 
 # Step 1 - Run Maven Build
-FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
+FROM ${DOCKER_REGISTRY}/dataquest/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -7,13 +7,13 @@
 # To build with other versions, use "--build-arg JDK_VERSION=[value]"
 ARG JDK_VERSION=17
 # The Docker version tag to build from
-ARG DSPACE_VERSION=dspace-9_x
+ARG DSPACE_VERSION=dtq-dev-9-base
 # The Docker registry to use for DSpace images. Defaults to "docker.io"
 # NOTE: non-DSpace images are hardcoded to use "docker.io" and are not impacted by this build argument
 ARG DOCKER_REGISTRY=docker.io
 
 # Step 1 - Run Maven Build
-FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
+FROM ${DOCKER_REGISTRY}/dataquest/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -9,13 +9,13 @@
 # To build with other versions, use "--build-arg JDK_VERSION=[value]"
 ARG JDK_VERSION=17
 # The Docker version tag to build from
-ARG DSPACE_VERSION=dspace-9_x
+ARG DSPACE_VERSION=dtq-dev-9-base
 # The Docker registry to use for DSpace images. Defaults to "docker.io"
 # NOTE: non-DSpace images are hardcoded to use "docker.io" and are not impacted by this build argument
 ARG DOCKER_REGISTRY=docker.io
 
 # Step 1 - Run Maven Build
-FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
+FROM ${DOCKER_REGISTRY}/dataquest/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install


### PR DESCRIPTION
Follow-up to #1367 (deliberately split out — it needed #1367 merged first, see *Ordering* below).

## Why

The v9 Dockerfiles still pull **vanilla's** `dspace/dspace-dependencies:dspace-9_x`, so the `dataquest/dspace-dependencies` image our own CI publishes is never consumed: we build it, serialise three jobs behind it via `needs:`, and throw the result away. `dtq-dev` has always pulled `dataquest/dspace-dependencies:dspace-7_x`.

Worse, upstream's `dspace-9_x` is a **moving target that has already drifted away from us**:

| | version | maven-enforcer-plugin |
|---|---|---|
| this branch | **9.3** | **3.6.2** |
| upstream `dspace-9_x` | **9.4-SNAPSHOT** | **3.6.3** |

So its Maven cache never matches our POMs, every build re-resolves from Maven Central, and Central intermittently answers **403 Forbidden**. That is exactly what failed the first `dspace` build on #1367: it died after 0.7s on `maven-enforcer-plugin:3.6.2`, while `dspace-test` and `dspace-cli` — same base image, started within the same second — built through fine. The drift only widens as vanilla moves toward 9.4.

## What

`Dockerfile`, `Dockerfile.cli`, `Dockerfile.test` — two lines each:

```diff
-ARG DSPACE_VERSION=dspace-9_x
+ARG DSPACE_VERSION=dtq-dev-9-base
-FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
+FROM ${DOCKER_REGISTRY}/dataquest/dspace-dependencies:${DSPACE_VERSION} AS build
```

The tag is the **branch name** because the reusable workflow tags non-default branches with `type=ref,event=branch`. (`dtq-dev` hardcodes `dspace-7_x` for the same reason — that is its default-branch raw tag.)

The `dspace-dependencies` job builds from **this branch's POMs**, so enforcer 3.6.2 is already in its `~/.m2` and no Central round-trip is needed.

## Ordering (why this is a separate PR)

`dataquest/dspace-dependencies:dtq-dev-9-base` only comes into existence on a **push** to this branch — PR builds build the dependencies image but never push it (`push: ${{ ! matrix.isPr }}`). So this change could not be part of #1367: its own PR checks would have failed on a missing tag.

Now that #1367 is merged, the tag exists and is publicly pullable:

```
dataquest/dspace-dependencies:dtq-dev-9-base -> HTTP 200
```

so this PR's checks should be green. On future pushes, `needs: dspace-dependencies` guarantees the image is rebuilt **and pushed** before anything pulls it, so the branch keeps bootstrapping itself. PR builds reuse the last pushed image, exactly as on `dtq-dev`.

## Note for local builds

A local build now needs our image rather than vanilla's:

```
docker pull dataquest/dspace-dependencies:dtq-dev-9-base
```

or override with `--build-arg DSPACE_VERSION=...`. `docker compose build dspace` goes through `Dockerfile.test` with no build-args, so it picks up the new default. Same as on `dtq-dev` today.

`CLARIN_V9_ACCEPTANCE_CRITERIA.md` still instructs `docker pull dspace/dspace-dependencies:dspace-9_x` in two places; that becomes stale with this change. Left alone to keep this PR narrow — happy to fix it here or separately.

## Follow-up not covered here

When this branch eventually becomes the default branch (or merges into `dtq-dev`), the reusable workflow will start tagging it with the raw `dspace-7_x` tag, and `DSPACE_VERSION` here will need revisiting — that raw tag is also wrong for a v9 codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)