### PR TITLE
Port #1325 (ClarinLicenseLabel PUT/DELETE) to the v9 base

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseLabelServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseLabelServiceImpl.java
@@ -77,6 +77,11 @@ public class ClarinLicenseLabelServiceImpl implements ClarinLicenseLabelService 
     }
 
     @Override
+    public ClarinLicenseLabel findByLabel(Context context, String label) throws SQLException {
+        return clarinLicenseLabelDAO.findByLabel(context, label);
+    }
+
+    @Override
     public void delete(Context context, ClarinLicenseLabel license) throws SQLException, AuthorizeException {
         if (!authorizeService.isAdmin(context)) {
             throw new AuthorizeException(

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseServiceImpl.java
@@ -98,6 +98,11 @@ public class ClarinLicenseServiceImpl implements ClarinLicenseService {
     }
 
     @Override
+    public List<ClarinLicense> findByLabel(Context context, String label) throws SQLException {
+        return clarinLicenseDAO.findByLabel(context, label);
+    }
+
+    @Override
     public void addLicenseMetadataToItem(Context context, ClarinLicense clarinLicense, Item item) throws SQLException {
         if (Objects.isNull(clarinLicense) || Objects.isNull(item)) {
             log.error("Cannot add clarin license to the item metadata because the Item or the CLARIN License is null.");

--- a/dspace-api/src/main/java/org/dspace/content/dao/clarin/ClarinLicenseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/clarin/ClarinLicenseDAO.java
@@ -28,4 +28,6 @@ public interface ClarinLicenseDAO extends GenericDAO<ClarinLicense> {
 
     List<ClarinLicense> findByNameLike(Context context, String name) throws SQLException;
 
+    List<ClarinLicense> findByLabel(Context context, String label) throws SQLException;
+
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/clarin/ClarinLicenseLabelDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/clarin/ClarinLicenseLabelDAO.java
@@ -7,7 +7,10 @@
  */
 package org.dspace.content.dao.clarin;
 
+import java.sql.SQLException;
+
 import org.dspace.content.clarin.ClarinLicenseLabel;
+import org.dspace.core.Context;
 import org.dspace.core.GenericDAO;
 
 /**
@@ -19,4 +22,6 @@ import org.dspace.core.GenericDAO;
  * @author Milan Majchrak (milan.majchrak at dataquest.sk)
  */
 public interface ClarinLicenseLabelDAO extends GenericDAO<ClarinLicenseLabel> {
+
+    ClarinLicenseLabel findByLabel(Context context, String label) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseDAOImpl.java
@@ -13,8 +13,12 @@ import java.util.List;
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.SetJoin;
 import org.dspace.content.clarin.ClarinLicense;
+import org.dspace.content.clarin.ClarinLicenseLabel;
+import org.dspace.content.clarin.ClarinLicenseLabel_;
 import org.dspace.content.clarin.ClarinLicense_;
 import org.dspace.content.dao.clarin.ClarinLicenseDAO;
 import org.dspace.core.AbstractHibernateDAO;
@@ -52,6 +56,22 @@ public class ClarinLicenseDAOImpl extends AbstractHibernateDAO<ClarinLicense> im
         criteriaQuery.select(clarinLicenseRoot);
         criteriaQuery.where(criteriaBuilder.like(clarinLicenseRoot.get(ClarinLicense_.name), "%" + name + "%"));
         criteriaQuery.orderBy(criteriaBuilder.asc(clarinLicenseRoot.get(ClarinLicense_.name)));
+        return list(context, criteriaQuery, false, ClarinLicense.class, -1, -1);
+    }
+
+    @Override
+    public List<ClarinLicense> findByLabel(Context context, String label) throws SQLException {
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery<ClarinLicense> criteriaQuery = getCriteriaQuery(criteriaBuilder, ClarinLicense.class);
+        Root<ClarinLicense> clarinLicenseRoot = criteriaQuery.from(ClarinLicense.class);
+
+        SetJoin<ClarinLicense, ClarinLicenseLabel> labelJoin =
+                clarinLicenseRoot.joinSet(ClarinLicense_.CLARIN_LICENSE_LABELS);
+
+        Predicate labelPredicate = criteriaBuilder.equal(labelJoin.get(ClarinLicenseLabel_.LABEL), label);
+
+        criteriaQuery.select(clarinLicenseRoot).where(labelPredicate);
+
         return list(context, criteriaQuery, false, ClarinLicense.class, -1, -1);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseLabelDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/clarin/ClarinLicenseLabelDAOImpl.java
@@ -7,9 +7,16 @@
  */
 package org.dspace.content.dao.impl.clarin;
 
+import java.sql.SQLException;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 import org.dspace.content.clarin.ClarinLicenseLabel;
+import org.dspace.content.clarin.ClarinLicenseLabel_;
 import org.dspace.content.dao.clarin.ClarinLicenseLabelDAO;
 import org.dspace.core.AbstractHibernateDAO;
+import org.dspace.core.Context;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the Clarin License Label object.
@@ -22,5 +29,15 @@ public class ClarinLicenseLabelDAOImpl extends AbstractHibernateDAO<ClarinLicens
         implements ClarinLicenseLabelDAO {
     protected ClarinLicenseLabelDAOImpl() {
         super();
+    }
+
+    @Override
+    public ClarinLicenseLabel findByLabel(Context context, String label) throws SQLException {
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery<ClarinLicenseLabel> criteriaQuery = getCriteriaQuery(criteriaBuilder, ClarinLicenseLabel.class);
+        Root<ClarinLicenseLabel> cllRoot = criteriaQuery.from(ClarinLicenseLabel.class);
+        criteriaQuery.select(cllRoot);
+        criteriaQuery.where(criteriaBuilder.equal(cllRoot.get(ClarinLicenseLabel_.label), label));
+        return uniqueResult(context, criteriaQuery, true, ClarinLicenseLabel.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinLicenseLabelService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinLicenseLabelService.java
@@ -53,6 +53,16 @@ public interface ClarinLicenseLabelService {
     ClarinLicenseLabel find(Context context, int valueId) throws SQLException;
 
     /**
+     * Find the clarin license label object by label name
+     *
+     * @param context DSpace context object
+     * @param label label name of the searching clarin license label object
+     * @return found clarin license label object or null
+     * @throws SQLException if database error
+     */
+    ClarinLicenseLabel findByLabel(Context context, String label) throws SQLException;
+
+    /**
      * Find all clarin license label objects
      * @param context DSpace context object
      * @return list of all clarin license label objects

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinLicenseService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinLicenseService.java
@@ -77,6 +77,16 @@ public interface ClarinLicenseService {
      */
     List<ClarinLicense> findByNameLike(Context context, String name) throws SQLException;
 
+    /**
+     * Find Clarin Licenses by the license label.
+     *
+     * @param context DSpace context object
+     * @param label the license label
+     * @return List of clarin licenses which contain the specified license label.
+     * @throws SQLException if database error
+     */
+    List<ClarinLicense> findByLabel(Context context, String label) throws SQLException;
+
     void addLicenseMetadataToItem(Context context, ClarinLicense clarinLicense, Item item) throws SQLException;
 
     void clearLicenseMetadataFromItem(Context context, Item item) throws SQLException;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2026.06.01__license_label_constraint.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2026.06.01__license_label_constraint.sql
@@ -1,0 +1,18 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+ALTER TABLE license_label_extended_mapping
+    DROP CONSTRAINT IF EXISTS license_label_license_label_extended_mapping_fk;
+
+-- here the "ON DELETE RESTRICT" clause (default clause) is used, which prevents deletion of a license_label record
+-- when there are any license_label_extended_mapping records that reference it
+ALTER TABLE license_label_extended_mapping
+    ADD CONSTRAINT license_label_license_label_extended_mapping_fk FOREIGN KEY (label_id) REFERENCES license_label(label_id);
+
+ALTER TABLE license_label DROP CONSTRAINT IF EXISTS license_label_label_unique;
+ALTER TABLE license_label ADD CONSTRAINT license_label_label_unique UNIQUE(label);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2026.06.01__license_label_constraint.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2026.06.01__license_label_constraint.sql
@@ -1,0 +1,18 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+ALTER TABLE license_label_extended_mapping
+    DROP CONSTRAINT IF EXISTS license_label_license_label_extended_mapping_fk;
+
+-- here the "ON DELETE RESTRICT" clause (default clause) is used, which prevents deletion of a license_label record
+-- when there are any license_label_extended_mapping records that reference it
+ALTER TABLE license_label_extended_mapping
+    ADD CONSTRAINT license_label_license_label_extended_mapping_fk FOREIGN KEY (label_id) REFERENCES license_label(label_id);
+
+ALTER TABLE license_label DROP CONSTRAINT IF EXISTS license_label_label_unique;
+ALTER TABLE license_label ADD CONSTRAINT license_label_label_unique UNIQUE(label);

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -19,6 +19,8 @@ import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.BitstreamFormatBuilder;
 import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.ClaimedTaskBuilder;
+import org.dspace.builder.ClarinLicenseBuilder;
+import org.dspace.builder.ClarinLicenseLabelBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
@@ -89,6 +91,8 @@ public class AbstractBuilderCleanupUtil {
         map.put(SiteBuilder.class.getName(), new ArrayList<>());
         map.put(ProcessBuilder.class.getName(), new ArrayList<>());
         map.put(PreviewContentBuilder.class.getName(), new ArrayList<>());
+        map.put(ClarinLicenseBuilder.class.getName(), new ArrayList<>());
+        map.put(ClarinLicenseLabelBuilder.class.getName(), new ArrayList<>());
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/ClarinLicenseLabelNotFoundException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/ClarinLicenseLabelNotFoundException.java
@@ -1,0 +1,26 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import jakarta.ws.rs.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when Clarin License Label not found
+ *
+ * @author Milan Kuchtiak
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ClarinLicenseLabelNotFoundException extends NotFoundException {
+
+    public ClarinLicenseLabelNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinLicenseLabelRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinLicenseLabelRestRepository.java
@@ -13,14 +13,19 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import org.dspace.app.rest.exception.ClarinLicenseLabelNotFoundException;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
-import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.ClarinLicenseLabelRest;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.clarin.ClarinLicense;
 import org.dspace.content.clarin.ClarinLicenseLabel;
 import org.dspace.content.service.clarin.ClarinLicenseLabelService;
+import org.dspace.content.service.clarin.ClarinLicenseService;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -36,8 +41,16 @@ import org.springframework.stereotype.Component;
 @Component(ClarinLicenseLabelRest.CATEGORY + "." + ClarinLicenseLabelRest.PLURAL_NAME)
 public class ClarinLicenseLabelRestRepository extends DSpaceRestRepository<ClarinLicenseLabelRest, Integer> {
 
+    private static final int MAX_LABEL_LENGTH = 5;
+
+    @Autowired
+    ClarinLicenseService clarinLicenseService;
+
     @Autowired
     ClarinLicenseLabelService clarinLicenseLabelService;
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     @Override
     @PreAuthorize("permitAll()")
@@ -73,7 +86,7 @@ public class ClarinLicenseLabelRestRepository extends DSpaceRestRepository<Clari
         // parse request body
         ClarinLicenseLabelRest clarinLicenseLabelRest;
         try {
-            clarinLicenseLabelRest = new ObjectMapper().readValue(
+            clarinLicenseLabelRest = objectMapper.readValue(
                     getRequestService().getCurrentRequest().getHttpServletRequest().getInputStream(),
                     ClarinLicenseLabelRest.class
             );
@@ -81,27 +94,98 @@ public class ClarinLicenseLabelRestRepository extends DSpaceRestRepository<Clari
             throw new DSpaceBadRequestException("error parsing request body", excIO);
         }
 
-        // validate fields
-        if (isBlank(clarinLicenseLabelRest.getLabel()) || isBlank(clarinLicenseLabelRest.getTitle())) {
-            throw new UnprocessableEntityException("CLARIN License Label title, label, icon cannot be null or empty");
+        checkLabelAndTitle(clarinLicenseLabelRest);
+        if (clarinLicenseLabelService.findByLabel(context, clarinLicenseLabelRest.getLabel().trim()) != null) {
+            throw new DSpaceBadRequestException("Clarin License Label with label " + clarinLicenseLabelRest.getLabel() +
+                    " already exists");
         }
 
         // create
         ClarinLicenseLabel clarinLicenseLabel;
         clarinLicenseLabel = clarinLicenseLabelService.create(context);
-//        if (Objects.nonNull(clarinLicenseLabelRest.getId())) {
-//            clarinLicenseLabel.setId(clarinLicenseLabelRest.getId());
-//        }
-        clarinLicenseLabel.setLabel(clarinLicenseLabelRest.getLabel());
-        clarinLicenseLabel.setTitle(clarinLicenseLabelRest.getTitle());
-        clarinLicenseLabel.setIcon(clarinLicenseLabelRest.getIcon());
-        clarinLicenseLabel.setExtended(clarinLicenseLabelRest.isExtended());
+        updateClarinLicenseLabel(clarinLicenseLabel, clarinLicenseLabelRest);
 
         clarinLicenseLabelService.update(context, clarinLicenseLabel);
         // return
         return converter.toRest(clarinLicenseLabel, utils.obtainProjection());
     }
 
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ClarinLicenseLabelRest put(Context context,
+                                      HttpServletRequest request,
+                                      String apiCategory,
+                                      String model,
+                                      Integer id,
+                                      JsonNode jsonNode) throws SQLException, AuthorizeException {
+        ClarinLicenseLabel clarinLicenseLabel = clarinLicenseLabelService.find(context, id);
+        if (Objects.isNull(clarinLicenseLabel)) {
+            throw new ClarinLicenseLabelNotFoundException("Clarin License Label with id " + id + " was not found");
+        }
+
+        // parse request body
+        ClarinLicenseLabelRest clarinLicenseLabelRest;
+        try {
+            clarinLicenseLabelRest = objectMapper.treeToValue(jsonNode, ClarinLicenseLabelRest.class);
+        } catch (IOException excIO) {
+            throw new DSpaceBadRequestException("error parsing request body", excIO);
+        }
+
+        checkLabelAndTitle(clarinLicenseLabelRest);
+
+        ClarinLicenseLabel clarinLicenseLabelWithSameLabel = clarinLicenseLabelService.findByLabel(context,
+                clarinLicenseLabelRest.getLabel().trim());
+        if (clarinLicenseLabelWithSameLabel != null && !clarinLicenseLabelWithSameLabel.getID().equals(id)) {
+            throw new DSpaceBadRequestException("Clarin License Label with label " + clarinLicenseLabelRest.getLabel() +
+                    " already exists");
+        }
+
+        updateClarinLicenseLabel(clarinLicenseLabel, clarinLicenseLabelRest);
+
+        clarinLicenseLabelService.update(context, clarinLicenseLabel);
+
+        return converter.toRest(clarinLicenseLabel, utils.obtainProjection());
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public void delete(Context context, Integer id) throws AuthorizeException {
+        ClarinLicenseLabel clarinLicenseLabel;
+        try {
+            clarinLicenseLabel = clarinLicenseLabelService.find(context, id);
+            if (Objects.isNull(clarinLicenseLabel)) {
+                throw new ClarinLicenseLabelNotFoundException("Clarin License Label with id " + id + " was not found");
+            }
+            List<ClarinLicense> licenses = clarinLicenseService.findByLabel(context, clarinLicenseLabel.getLabel());
+            if (!licenses.isEmpty()) {
+                throw new DSpaceBadRequestException("Clarin License Label " + clarinLicenseLabel.getLabel() +
+                        " is in use and cannot be deleted");
+            }
+            clarinLicenseLabelService.delete(context, clarinLicenseLabel);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private void checkLabelAndTitle(ClarinLicenseLabelRest clarinLicenseLabelRest) {
+        String label = Optional.ofNullable(clarinLicenseLabelRest.getLabel()).map(String::trim).orElse(null);
+        // validate fields
+        if (isBlank(label) || isBlank(clarinLicenseLabelRest.getTitle())) {
+            throw new DSpaceBadRequestException("CLARIN License Label title and label cannot be null or empty");
+        }
+        if (label.length() > MAX_LABEL_LENGTH) {
+            throw new DSpaceBadRequestException(
+                    "CLARIN License Label -> label string cannot be longer than " + MAX_LABEL_LENGTH + " characters");
+        }
+    }
+
+    private static void updateClarinLicenseLabel(ClarinLicenseLabel clarinLicenseLabel,
+                                                 ClarinLicenseLabelRest clarinLicenseLabelRest) {
+        clarinLicenseLabel.setLabel(clarinLicenseLabelRest.getLabel().trim());
+        clarinLicenseLabel.setTitle(clarinLicenseLabelRest.getTitle());
+        clarinLicenseLabel.setIcon(clarinLicenseLabelRest.getIcon());
+        clarinLicenseLabel.setExtended(clarinLicenseLabelRest.isExtended());
+    }
 
     @Override
     public Class<ClarinLicenseLabelRest> getDomainClass() {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseLabelRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseLabelRestRepositoryIT.java
@@ -10,13 +10,17 @@ package org.dspace.app.rest;
 import static com.jayway.jsonpath.JsonPath.read;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,9 +29,12 @@ import org.dspace.app.rest.matcher.ClarinLicenseLabelMatcher;
 import org.dspace.app.rest.model.ClarinLicenseLabelRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.ClarinLicenseBuilder;
 import org.dspace.builder.ClarinLicenseLabelBuilder;
+import org.dspace.content.clarin.ClarinLicense;
 import org.dspace.content.clarin.ClarinLicenseLabel;
 import org.dspace.content.service.clarin.ClarinLicenseLabelService;
+import org.dspace.content.service.clarin.ClarinLicenseService;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,10 +49,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class ClarinLicenseLabelRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Autowired
+    ClarinLicenseService clarinLicenseService;
+
+    @Autowired
     ClarinLicenseLabelService clarinLicenseLabelService;
 
     @Autowired
     ClarinLicenseLabelConverter clarinLicenseLabelConverter;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     ClarinLicenseLabel firstCLicenseLabel;
     ClarinLicenseLabel secondCLicenseLabel;
@@ -107,24 +120,18 @@ public class ClarinLicenseLabelRestRepositoryIT extends AbstractControllerIntegr
 
     @Test
     public void create() throws Exception {
-        // create a new clarin license label
-        context.turnOffAuthorisationSystem();
-        ClarinLicenseLabel clarinLicenseLabel = ClarinLicenseLabelBuilder.createClarinLicenseLabel(context).build();
-        clarinLicenseLabel.setLabel("new");
-        clarinLicenseLabel.setExtended(true);
-        clarinLicenseLabel.setTitle("New CLL");
-        clarinLicenseLabel.setIcon(new byte[100]);
-
-        ClarinLicenseLabelRest clarinLicenseLabelRest = clarinLicenseLabelConverter.convert(clarinLicenseLabel,
-                Projection.DEFAULT);
-        context.restoreAuthSystemState();
+        ClarinLicenseLabelRest clarinLicenseLabelRest  = new ClarinLicenseLabelRest();
+        clarinLicenseLabelRest.setLabel("new");
+        clarinLicenseLabelRest.setExtended(true);
+        clarinLicenseLabelRest.setTitle("New CLL");
+        clarinLicenseLabelRest.setIcon(new byte[100]);
 
         // id of created clarin license
         AtomicReference<Integer> idRef = new AtomicReference<>();
         String authTokenAdmin = getAuthToken(admin.getEmail(), password);
         try {
             getClient(authTokenAdmin).perform(post("/api/core/clarinlicenselabels")
-                            .content(new ObjectMapper().writeValueAsBytes(clarinLicenseLabelRest))
+                            .content(objectMapper.writeValueAsBytes(clarinLicenseLabelRest))
                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.label", is(clarinLicenseLabelRest.getLabel())))
@@ -146,4 +153,195 @@ public class ClarinLicenseLabelRestRepositoryIT extends AbstractControllerIntegr
             }
         }
     }
+
+    @Test
+    public void createWithLongLabel() throws Exception {
+        ClarinLicenseLabelRest clarinLicenseLabelRest  = new ClarinLicenseLabelRest();
+        clarinLicenseLabelRest.setLabel("LONG_LABEL");
+        clarinLicenseLabelRest.setExtended(true);
+        clarinLicenseLabelRest.setTitle("LONG CLL");
+        clarinLicenseLabelRest.setIcon(new byte[100]);
+
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(post("/api/core/clarinlicenselabels")
+                        .content(objectMapper.writeValueAsBytes(clarinLicenseLabelRest))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void createWithDuplicateLabel() throws Exception {
+        ClarinLicenseLabelRest clarinLicenseLabelRest  = new ClarinLicenseLabelRest();
+        clarinLicenseLabelRest.setLabel(firstCLicenseLabel.getLabel());
+        clarinLicenseLabelRest.setExtended(true);
+        clarinLicenseLabelRest.setTitle("Title 1");
+        clarinLicenseLabelRest.setIcon(new byte[100]);
+
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(post("/api/core/clarinlicenselabels")
+                        .content(objectMapper.writeValueAsBytes(clarinLicenseLabelRest))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void updateOk() throws Exception {
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        Integer clarinLicenseLabelId = null;
+        try {
+            context.turnOffAuthorisationSystem();
+            ClarinLicenseLabel clarinLicenseLabel = ClarinLicenseLabelBuilder.createClarinLicenseLabel(context).build();
+            clarinLicenseLabel.setLabel("CLL");
+            clarinLicenseLabel.setExtended(true);
+            clarinLicenseLabel.setTitle("CLL Title4");
+            clarinLicenseLabelService.update(context, clarinLicenseLabel);
+
+            clarinLicenseLabelId = Objects.requireNonNull(clarinLicenseLabel.getID());
+            context.restoreAuthSystemState();
+
+            ClarinLicenseLabelRest clarinLicenseLabelRest = clarinLicenseLabelConverter.convert(clarinLicenseLabel,
+                    Projection.DEFAULT);
+            clarinLicenseLabelRest.setLabel("UPDATED CLL");
+            clarinLicenseLabelRest.setTitle("Updated CLL Title");
+            clarinLicenseLabelRest.setExtended(false);
+
+            // test if the id from the path is used instead of the id from the body
+            clarinLicenseLabelRest.setId(999);
+
+            // check if update ends with Bad Request since the label length is greater than 5
+            getClient(authTokenAdmin).perform(put("/api/core/clarinlicenselabels/" + clarinLicenseLabelId)
+                            .content(objectMapper.writeValueAsBytes(clarinLicenseLabelRest))
+                            .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest());
+
+            // set the label to valid value and check if the update is successful
+            clarinLicenseLabelRest.setLabel(" CLL-X ");
+            getClient(authTokenAdmin).perform(put("/api/core/clarinlicenselabels/" + clarinLicenseLabelId)
+                            .content(objectMapper.writeValueAsBytes(clarinLicenseLabelRest))
+                            .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id", is(clarinLicenseLabelId)))
+                    .andExpect(jsonPath("$.label", is("CLL-X")))
+                    .andExpect(jsonPath("$.title", is("Updated CLL Title")))
+                    .andExpect(jsonPath("$.extended", is(false)))
+                    .andExpect(jsonPath("$.icon", nullValue()))
+                    .andExpect(jsonPath("$.type", is(ClarinLicenseLabelRest.NAME)));
+
+            getClient(authTokenAdmin).perform(get("/api/core/clarinlicenselabels/" + clarinLicenseLabelId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id", is(clarinLicenseLabelId)))
+                    .andExpect(jsonPath("$.label", is("CLL-X")))
+                    .andExpect(jsonPath("$.title", is("Updated CLL Title")))
+                    .andExpect(jsonPath("$.extended", is(false)))
+                    .andExpect(jsonPath("$.icon", nullValue()))
+                    .andExpect(jsonPath("$.type", is(ClarinLicenseLabelRest.NAME)));
+        } finally {
+            ClarinLicenseLabelBuilder.deleteClarinLicenseLabel(clarinLicenseLabelId);
+        }
+    }
+
+    @Test
+    public void updateNotFound() throws Exception {
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(put("/api/core/clarinlicenselabels/999")
+                        .content("{}")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void updateInvalidBody() throws Exception {
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(put("/api/core/clarinlicenselabels/" + firstCLicenseLabel.getID())
+                        .content("{\"label\": \"lbl\", \"invalid_property\": 0}")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void updateMissingTitle() throws Exception {
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(put("/api/core/clarinlicenselabels/" + firstCLicenseLabel.getID())
+                        .content("{\"label\": \"test label\"}")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void updateNotAuthorized() throws Exception {
+        getClient().perform(put("/api/core/clarinlicenselabels/999")
+                        .content("{}")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void updateWithDuplicateLabel() throws Exception {
+        ClarinLicenseLabelRest clarinLicenseLabelRest = new ClarinLicenseLabelRest();
+        clarinLicenseLabelRest.setLabel(firstCLicenseLabel.getLabel());
+        clarinLicenseLabelRest.setExtended(true);
+        clarinLicenseLabelRest.setTitle("Title 1");
+        clarinLicenseLabelRest.setIcon(new byte[100]);
+
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+
+        getClient(authTokenAdmin).perform(put("/api/core/clarinlicenselabels/" + secondCLicenseLabel.getID())
+                        .content(objectMapper.writeValueAsBytes(clarinLicenseLabelRest))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        // set the label to the same value as the secondCLicenseLabel and check if the update is successful
+        clarinLicenseLabelRest.setLabel(secondCLicenseLabel.getLabel());
+        getClient(authTokenAdmin).perform(put("/api/core/clarinlicenselabels/" + secondCLicenseLabel.getID())
+                        .content(objectMapper.writeValueAsBytes(clarinLicenseLabelRest))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void deleteNotAuthorized() throws Exception {
+        getClient().perform(delete("/api/core/clarinlicenselabels/" + firstCLicenseLabel.getID()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void deleteOk() throws Exception {
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(delete("/api/core/clarinlicenselabels/" + firstCLicenseLabel.getID()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void deleteNotFound() throws Exception {
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(delete("/api/core/clarinlicenselabels/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void deleteForLabelUsed() throws Exception {
+        // create ClarinLicense
+        context.turnOffAuthorisationSystem();
+        ClarinLicense firstCLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
+        firstCLicense.setName("CL Name1");
+        firstCLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
+        firstCLicense.setDefinition("CL Definition1");
+        firstCLicense.setRequiredInfo("CL Req1");
+        // add ClarinLicenseLabels to the ClarinLicense
+        firstCLicense.setLicenseLabels(Set.of(firstCLicenseLabel, thirdCLicenseLabel));
+        clarinLicenseService.update(context, firstCLicense);
+        context.restoreAuthSystemState();
+
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+
+        getClient(authTokenAdmin).perform(delete("/api/core/clarinlicenselabels/" + firstCLicenseLabel.getID()))
+                .andExpect(status().isBadRequest());
+        getClient(authTokenAdmin).perform(delete("/api/core/clarinlicenselabels/" + thirdCLicenseLabel.getID()))
+                .andExpect(status().isBadRequest());
+
+        context.turnOffAuthorisationSystem();
+        clarinLicenseService.delete(context, firstCLicense);
+        context.restoreAuthSystemState();
+    }
+
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkspaceItemRestRepositoryIT.java
@@ -638,7 +638,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
         String clarinLicenseName = "Test Clarin License";
 
         // 2. Create clarin license with clarin license label
-        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
+        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info", "lbl",
                 Confirmation.NOT_REQUIRED);
 
         // creating replace operation
@@ -688,7 +688,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
         List<Operation> replaceOperations = new ArrayList<Operation>();
         // 2. Create Clarin License
         String clarinLicenseName = "Test Clarin License";
-        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
+        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info", "lbl",
                 Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
@@ -763,10 +763,11 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
         String updateClarinLicenseName = "Updated Clarin License";
 
         // 2. Create Clarin Licenses
-        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
+        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info", "lbl1",
                 Confirmation.NOT_REQUIRED);
         ClarinLicense updatedClarinLicense =
-                createClarinLicense(updateClarinLicenseName, "Test Def2", "Test R Info2", Confirmation.NOT_REQUIRED);
+                createClarinLicense(updateClarinLicenseName, "Test Def2", "Test R Info2", "lbl2",
+                        Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         // Creating replace operation
@@ -832,7 +833,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
 
         String clarinLicenseName = "Test Section Clarin License";
         ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
-                Confirmation.NOT_REQUIRED);
+                "lbl", Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         List<Operation> replaceOperations = new ArrayList<Operation>();
@@ -870,7 +871,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
 
         String clarinLicenseName = "Distinct Sections Clarin License";
         createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
-                Confirmation.NOT_REQUIRED);
+                "lbl", Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         // Apply the CLARIN license through the section-scoped path
@@ -912,7 +913,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
 
         String clarinLicenseName = "Empty Value Clarin License";
         ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
-                Confirmation.NOT_REQUIRED);
+                "lbl", Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -958,8 +959,8 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
 
         String firstName = "First Clarin License";
         String secondName = "Second Clarin License";
-        ClarinLicense first = createClarinLicense(firstName, "Def1", "Info1", Confirmation.NOT_REQUIRED);
-        ClarinLicense second = createClarinLicense(secondName, "Def2", "Info2", Confirmation.NOT_REQUIRED);
+        ClarinLicense first = createClarinLicense(firstName, "Def1", "Info1", "lbl1", Confirmation.NOT_REQUIRED);
+        ClarinLicense second = createClarinLicense(secondName, "Def2", "Info2", "lbl2", Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -1041,7 +1042,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
         context.turnOffAuthorisationSystem();
         WorkspaceItem witem = createWorkspaceItemWithFile();
         String clarinLicenseName = "Anon Clarin License";
-        createClarinLicense(clarinLicenseName, "Def", "Info", Confirmation.NOT_REQUIRED);
+        createClarinLicense(clarinLicenseName, "Def", "Info", "lbl", Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
@@ -1257,7 +1258,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
     /**
      * Create ClarinLicense object with ClarinLicenseLabel object for testing purposes.
      */
-    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo,
+    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo, String label,
                                               Confirmation confirmation) throws SQLException, AuthorizeException {
         ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicense.setConfirmation(confirmation);
@@ -1267,7 +1268,7 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
 
         // add ClarinLicenseLabels to the ClarinLicense
         HashSet<ClarinLicenseLabel> clarinLicenseLabels = new HashSet<>();
-        ClarinLicenseLabel clarinLicenseLabel = createClarinLicenseLabel("lbl", false, "Test Title");
+        ClarinLicenseLabel clarinLicenseLabel = createClarinLicenseLabel(label, false, label + " Title");
         clarinLicenseLabels.add(clarinLicenseLabel);
         clarinLicense.setLicenseLabels(clarinLicenseLabels);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenanceServiceIT.java
@@ -120,9 +120,9 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
     @Test
     public void updateLicenseTest() throws Exception {
         Bitstream bitstream = createBitstream(item, Constants.LICENSE_BUNDLE_NAME);
-        ClarinLicense clarinLicense1 = createClarinLicense("Test 1", "Test Def");
+        ClarinLicense clarinLicense1 = createClarinLicense("Test 1", "Test Def", "LBL_1");
         ClarinLicenseResourceMapping mapping = createResourceMapping(clarinLicense1, bitstream);
-        ClarinLicense clarinLicense2 = createClarinLicense("Test 2", "Test Def");
+        ClarinLicense clarinLicense2 = createClarinLicense("Test 2", "Test Def", "LBL_2");
 
         String token = getAuthToken(admin.getEmail(), password);
         getClient(token).perform(put("/api/core/items/" + item.getID() + "/bundles")
@@ -138,7 +138,7 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void addLicenseTest() throws Exception {
-        ClarinLicense clarinLicense = createClarinLicense("Test", "Test Def");
+        ClarinLicense clarinLicense = createClarinLicense("Test", "Test Def", "LBL");
 
         String token = getAuthToken(admin.getEmail(), password);
         getClient(token).perform(put("/api/core/items/" + item.getID() + "/bundles")
@@ -152,7 +152,7 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
     @Test
     public void removeLicenseTest() throws Exception {
         Bitstream bitstream = createBitstream(item, Constants.LICENSE_BUNDLE_NAME);
-        ClarinLicense clarinLicense = createClarinLicense("Test", "Test Def");
+        ClarinLicense clarinLicense = createClarinLicense("Test", "Test Def", "LBL");
         ClarinLicenseResourceMapping mapping = createResourceMapping(clarinLicense, bitstream);
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -475,14 +475,14 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
         return clarinLicenseLabel;
     }
 
-    private ClarinLicense createClarinLicense(String name, String definition)
+    private ClarinLicense createClarinLicense(String name, String definition, String label)
             throws SQLException, AuthorizeException {
         context.turnOffAuthorisationSystem();
         ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicense.setDefinition(definition);
         clarinLicense.setName(name);
         HashSet<ClarinLicenseLabel> clarinLicenseLabels = new HashSet<>();
-        ClarinLicenseLabel clarinLicenseLabel = createClarinLicenseLabel("lbl", false, "Test Title");
+        ClarinLicenseLabel clarinLicenseLabel = createClarinLicenseLabel(label, false, label + " Title");
         clarinLicenseLabels.add(clarinLicenseLabel);
         clarinLicense.setLicenseLabels(clarinLicenseLabels);
         clarinLicenseService.update(context, clarinLicense);
@@ -495,11 +495,12 @@ public class ProvenanceServiceIT extends AbstractControllerIntegrationTest {
     }
 
     private void deleteClarinLicense(ClarinLicense license) throws Exception {
-        int size = license.getLicenseLabels().size();
-        for (int i = 0; i < size; i++) {
-            deleteClarinLicenseLable(license.getLicenseLabels().get(i).getID());
-        }
+        // first delete license, then labels, because of the foreign key constraint
+        List<ClarinLicenseLabel> clarinLicenseLabels = license.getLicenseLabels();
         ClarinLicenseBuilder.deleteClarinLicense(license.getID());
+        for (ClarinLicenseLabel clarinLicenseLabel : clarinLicenseLabels) {
+            deleteClarinLicenseLable(clarinLicenseLabel.getID());
+        }
     }
 
     private Collection createCollection() {


### PR DESCRIPTION
Brings back a CLARIN port that was dropped when CLARIN was merged into the v9 base — and with it, the migration whose absence makes importing a dev-5 dump fail.

## How this surfaced

Importing a dev-5 (CLARIN 7.6) dump onto `dtq-dev-9-base` dies with:

```
FlywayValidateException: Detected applied migration not resolved locally: 7.6.2026.06.01.
```

The easy reading is "the dump is CLARIN, the branch is vanilla". **That is wrong.** `dtq-dev-9-base` is *not* vanilla — it carries every other CLARIN 7.6 migration (`Clarin_token`, `insert_default_licenses`, `entity_types_caching`, …). Diffing the migration sets against `dtq-dev` shows **exactly one** missing:

```
V7.6_2026.06.01__license_label_constraint.sql
```

So Flyway complained about exactly one migration because exactly one is gone. And it is not just the SQL file — commit `eebe17dac8` touched 16 files, and on this branch the whole port is absent: `ClarinLicenseLabelRestRepository` has no `put` and no delete, the DAO/service methods are missing, `ClarinLicenseLabelNotFoundException` does not exist, and the migration is missing in both the postgres and h2 copies.

The deploy workflow currently works around this with `dspace database repair` (dataquest-dev/dspace-angular#1383). That treats the symptom: it marks the migration deleted so validation passes — and it would mask the *next* dropped migration just as quietly. This fixes the cause; once it lands, that workaround can go.

## What this is

Cherry-pick of `eebe17dac8` (`-x` provenance kept in the commit), adapted for DSpace 9.

**The adaptation matters.** The branch is fully Jakarta EE — 283 files import `jakarta.servlet.http.HttpServletRequest` and **zero** import the `javax` one; same story for `jakarta.ws.rs`. The 7.6 commit brought `javax.*` imports with it:

| file | change | notes |
|---|---|---|
| `ClarinLicenseDAOImpl` | `javax.persistence.*` → `jakarta.persistence.*` | the only real cherry-pick conflict; adds `Predicate` + `SetJoin` for the new `findByLabel` |
| `ClarinLicenseLabelDAOImpl` | `javax.persistence.*` → `jakarta.persistence.*` | **merged cleanly and silently** — 9-base had no persistence imports at all, so git had nothing to conflict with. Would simply not have compiled. |
| `ClarinLicenseLabelNotFoundException` | `javax.ws.rs` → `jakarta.ws.rs` | new file |
| `ClarinLicenseLabelRestRepository` | `javax.servlet` → `jakarta.servlet` | |

Import order follows the v9 convention checkstyle enforces: `jakarta.*` sits in the third-party group, lexicographically between `com.*` and `org.*`.

## Verified locally

- `dspace-api` compile ✅
- `dspace-server-webapp` compile ✅ and `test-compile` ✅ (the port's ITs included)
- `checkstyle:check` on both modules ✅ (it caught 5 import-order violations from the jakarta move; fixed)

CI will run the actual unit/integration tests.

## Checksum note

The dump records checksum `1518115816` for this migration. The file is cherry-picked verbatim from `dtq-dev` — the same code dev-5 ran — so Flyway should validate it as already-applied rather than try to re-run it. Worth watching on the first import after this merges.

## Follow-up

- After this merges and `dataquest/dspace:dtq-dev-9-base` rebuilds, `dspace database repair` comes out of the deploy workflow (dataquest-dev/dspace-angular#1383) and the import is re-verified against the real dump.
- Worth asking whether other post-snapshot `dtq-dev` commits were dropped the same way. This one was only found because a dump import tripped over it — a silent gap otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)