### PR TITLE
CLARIN-DSpace v9/Port #1350 + #1347 + #1338 (DOI dedup, Shib special groups, tgz preview) to the v9 base

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -277,7 +277,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
 
             // Step 4: Log the user in.
             context.setCurrentUser(eperson);
-            request.getSession().setAttribute("shib.authenticated", true);
+            request.setAttribute("shib.authenticated", true);
             AuthenticateServiceFactory.getInstance().getAuthenticationService().initEPerson(context, request, eperson);
 
             log.info(eperson.getEmail() + " has been authenticated via shibboleth.");
@@ -330,42 +330,35 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
     @Override
     public List<Group> getSpecialGroups(Context context, HttpServletRequest request) {
         try {
-            // User has not successfuly authenticated via shibboleth.
-            if (request == null ||
-                    context.getCurrentUser() == null ||
-                    request.getSession().getAttribute("shib.authenticated") == null) {
-                return Collections.EMPTY_LIST;
+            // User has not successfully authenticated via shibboleth.
+            if (request == null || context.getCurrentUser() == null) {
+                return Collections.emptyList();
             }
 
-            // If we have already calculated the special groups then return them.
-            if (request.getSession().getAttribute("shib.specialgroup") != null) {
-                log.debug("Returning cached special groups.");
-                List<UUID> sessionGroupIds = (List<UUID>) request.getSession().getAttribute("shib.specialgroup");
-                List<Group> result = new ArrayList<>();
-                for (UUID uuid : sessionGroupIds) {
-                    result.add(groupService.find(context, uuid));
-                }
-                return result;
+            List<Group> specialGroups = context.getSpecialGroups();
+            if (!specialGroups.isEmpty()) {
+                log.debug("Returning special groups from context.");
+                return specialGroups;
             }
 
+            if (request.getAttribute("shib.authenticated") == null) {
+                log.debug("User has not been authenticated via shibboleth, returning empty list of special groups.");
+                return Collections.emptyList();
+            }
 
             List<UUID> groupIds = new ShibGroup(new ShibHeaders(request), context).get();
-            // Cache the special groups, so we don't have to recalculate them again
-            // for this session.
-            request.getSession().setAttribute("shib.specialgroup", groupIds);
 
             List<Group> groups = new ArrayList<>();
             for (UUID uuid : groupIds) {
                 Group foundGroup = groupService.find(context, uuid);
-                if (Objects.isNull(foundGroup)) {
-                    continue;
+                if (foundGroup != null) {
+                    groups.add(foundGroup);
                 }
-                groups.add(foundGroup);
             }
             return groups;
         } catch (Throwable t) {
-            log.error("Unable to validate any sepcial groups this user may belong too because of an exception.", t);
-            return Collections.EMPTY_LIST;
+            log.error("Unable to validate any special groups this user may belong to because of an exception.", t);
+            return Collections.emptyList();
         }
     }
 
@@ -1291,7 +1284,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
     public boolean isUsed(final Context context, final HttpServletRequest request) {
         if (request != null &&
                 context.getCurrentUser() != null &&
-                request.getSession().getAttribute("shib.authenticated") != null) {
+                request.getAttribute("shib.authenticated") != null) {
             return true;
         }
         return false;

--- a/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/PreviewContentServiceImpl.java
@@ -369,7 +369,7 @@ public class PreviewContentServiceImpl implements PreviewContentService {
         if (fileName == null) {
             logBitstreamNameIsNull();
         } else {
-            if (fileName.toLowerCase().endsWith("tar.gz")) {
+            if (fileName.toLowerCase().endsWith(".tar.gz") || fileName.toLowerCase().endsWith(".tgz")) {
                 processTarGzipFile(filePaths, file, bitstream);
             } else {
                 try (InputStream is = new GzipCompressorInputStream(new FileInputStream(file))) {

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -686,7 +686,12 @@ public class Context implements AutoCloseable {
     public List<Group> getSpecialGroups() throws SQLException {
         List<Group> myGroups = new ArrayList<>();
         for (UUID groupId : specialGroups) {
-            myGroups.add(EPersonServiceFactory.getInstance().getGroupService().find(this, groupId));
+            Group group = EPersonServiceFactory.getInstance().getGroupService().find(this, groupId);
+            // A special group UUID may reference a group that has since been deleted; skip nulls
+            // so callers never receive a list containing null (avoids NPE downstream).
+            if (group != null) {
+                myGroups.add(group);
+            }
         }
 
         return myGroups;

--- a/dspace-api/src/main/java/org/dspace/ctask/general/ItemMetadataQAChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/ItemMetadataQAChecker.java
@@ -87,6 +87,7 @@ public class ItemMetadataQAChecker extends AbstractCurationTask {
                     "dc.rights.label",
                     "dc.date.available",
                     "dc.source.uri",
+                    "dc.identifier.doi",
                     "metashare.ResourceInfo#DistributionInfo#LicenseInfo.license"
                 });
         strangeMetadata = configurationService.getArrayProperty("lr.curation.metadata.strange", new String[]{

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -1069,13 +1069,26 @@ public class DOIIdentifierProvider extends FilteredIdentifierProvider {
         }
         Item item = (Item) dso;
 
-        itemService.addMetadata(context, item, MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null,
-            doiService.DOIToExternalForm(doi));
-        try {
-            itemService.update(context, item);
-        } catch (SQLException | AuthorizeException ex) {
-            throw ex;
+        String doiURL = doiService.DOIToExternalForm(doi);
+
+        // Add the DOI to the metadata only if this exact value is not present yet. This keeps the operation
+        // idempotent (re-registration does not create duplicate values) without ever deleting metadata: a
+        // pre-existing, different DOI is left untouched. This method is called after the DOI has already been
+        // registered with the external agency, so destroying metadata here would be lossy and irreversible.
+        // Items that end up with more than one dc.identifier.doi value are surfaced by the ItemMetadataQAChecker
+        // curation task for manual review.
+        List<MetadataValue> existing = itemService.getMetadata(item, MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, Item.ANY);
+        boolean alreadyPresent = existing.stream()
+                .anyMatch(metadataValue -> doiURL.equals(metadataValue.getValue()));
+
+        if (alreadyPresent) {
+            log.debug("The DOI {} is already part of the metadata of Item {}. Not adding it again.",
+                    doi, item.getID());
+            return;
         }
+
+        itemService.addMetadata(context, item, MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null, doiURL);
+        itemService.update(context, item);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreview.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreview.java
@@ -16,12 +16,10 @@ import javax.naming.AuthenticationException;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
-import org.dspace.authenticate.AuthenticationMethod;
-import org.dspace.authenticate.factory.AuthenticateServiceFactory;
-import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
+import org.dspace.content.PreviewContent;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.PreviewContentService;
@@ -46,13 +44,12 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
             ContentServiceFactory.getInstance().getPreviewContentService();
     private EPersonService ePersonService = EPersonServiceFactory.getInstance()
             .getEPersonService();
-    private AuthenticationService authenticateService = AuthenticateServiceFactory.getInstance()
-            .getAuthenticationService();
 
     /**
      * `-i`: Info, show help information.
      */
     private boolean info = false;
+    private boolean force = false;
 
     /**
      * `-u`: UUID of the Item for which to create a preview of its bitstreams.
@@ -60,7 +57,6 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
     private String specificItemUUID = null;
 
     private String epersonMail = null;
-    private String epersonPassword = null;
 
     @Override
     public FilePreviewConfiguration getScriptConfiguration() {
@@ -84,11 +80,14 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                     specificItemUUID);
         }
 
-        epersonMail = commandLine.getOptionValue('e');
-        epersonPassword = commandLine.getOptionValue('p');
+        if (commandLine.hasOption('f')) {
+            force = true;
+        }
 
-        if (getEpersonIdentifier() == null && (epersonMail == null || epersonPassword == null)) {
-            throw new ParseException("Provide both -e/--email and -p/--password when no eperson is supplied.");
+        epersonMail = commandLine.getOptionValue('e');
+
+        if (getEpersonIdentifier() == null && epersonMail == null) {
+            throw new ParseException("Provide -e/--email when no eperson is supplied.");
         }
     }
 
@@ -101,7 +100,7 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
 
         Context context = new Context();
         try {
-            context.setCurrentUser(getAuthenticatedEperson((context)));
+            context.setCurrentUser(getEperson(context));
             handler.logInfo("Authentication by user: " + context.getCurrentUser().getEmail());
             if (StringUtils.isNotBlank(specificItemUUID)) {
                 // Generate the preview only for a specific item
@@ -152,7 +151,17 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                 }
                 // Generate new content if we didn't find any
                 if (previewContentService.hasPreview(context, bitstream)) {
-                    continue;
+                    if (force) {
+                        List<PreviewContent> previewContents = previewContentService
+                                .findByBitstream(context, bitstream.getID());
+                        for (PreviewContent content : previewContents) {
+                            handler.logInfo("Deleting existing preview content: '" + content.getName() +
+                                    "', for bitstream: '" + bitstream.getName() + "'");
+                            previewContentService.delete(context, content);
+                        }
+                    } else {
+                        continue;
+                    }
                 }
 
                 List<FileInfo> fileInfos = previewContentService.getFilePreviewContent(context, bitstream);
@@ -162,6 +171,7 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                     continue;
                 }
 
+                handler.logInfo("Generating file preview for bitstream: " + bitstream.getName());
                 for (FileInfo fi : fileInfos) {
                     previewContentService.createPreviewContent(context, bitstream, fi);
                 }
@@ -176,38 +186,30 @@ public class FilePreview extends DSpaceRunnable<FilePreviewConfiguration> {
                 "You can choose from these available options:\n" +
                 "  -i, --info            Show help information\n" +
                 "  -u, --uuid            The UUID of the ITEM for which to create a preview of its bitstreams\n" +
-                "  -e, --email           Email for authentication\n" +
-                "  -p, --password        Password for authentication\n");
+                "  -f, --force           Force to create preview, even when the preview exists\n" +
+                "  -e, --email           Email of the eperson to run the script as\n");
 
     }
 
     /**
-     * Retrieves an EPerson object either by its identifier or by performing an email-based lookup.
-     * It then authenticates the EPerson using the provided email and password.
-     * If the authentication is successful, it returns the EPerson object; otherwise,
-     * it throws an AuthenticationException.
+     * Resolves the EPerson the script runs as: the eperson supplied by the launching context
+     * (e.g. the logged-in user when started from the admin UI) if present, otherwise the eperson
+     * looked up by the {@code -e}/--email option. Like other CLI scripts, command-line invocation
+     * is trusted (shell access implies full server access), so no password is verified here;
+     * admin-only operations remain guarded by authorization checks in the service layer.
      *
      * @param context The Context object used for interacting with the DSpace database and service layer.
-     * @return The authenticated EPerson object corresponding to the provided email,
-     *         if authentication is successful.
-     * @throws SQLException If a database error occurs while retrieving or interacting with the EPerson data.
-     * @throws AuthenticationException If no EPerson is found for the provided email
-     *         or if the authentication fails.
+     * @return The EPerson the script should run as.
+     * @throws SQLException If a database error occurs while retrieving the EPerson data.
+     * @throws AuthenticationException If no EPerson is found for the provided email.
      */
-    private EPerson getAuthenticatedEperson(Context context) throws SQLException, AuthenticationException {
+    private EPerson getEperson(Context context) throws SQLException, AuthenticationException {
         if (getEpersonIdentifier() != null) {
             return ePersonService.find(context, getEpersonIdentifier());
         }
-        String msg;
         EPerson ePerson = ePersonService.findByEmail(context, epersonMail);
         if (ePerson == null) {
-            msg = "No EPerson found for this email: " + epersonMail;
-            handler.logError(msg);
-            throw new AuthenticationException(msg);
-        }
-        int authenticated = authenticateService.authenticate(context, epersonMail, epersonPassword, null, null);
-        if (AuthenticationMethod.SUCCESS != authenticated) {
-            msg = "Authentication failed for email: " + epersonMail;
+            String msg = "No EPerson found for this email: " + epersonMail;
             handler.logError(msg);
             throw new AuthenticationException(msg);
         }

--- a/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreviewConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/filepreview/FilePreviewConfiguration.java
@@ -39,15 +39,11 @@ public class FilePreviewConfiguration<T extends FilePreview> extends ScriptConfi
             options.getOption("u").setType(String.class);
             options.getOption("u").setRequired(false);
 
-            options.addOption("e", "email", true,
-                    "Email for authentication.");
-            options.getOption("e").setType(String.class);
-            options.getOption("e").setRequired(true);
+            options.addOption("f", "force", false, "Force to create preview, even when the preview exists.");
 
-            options.addOption("p", "password", true,
-                    "Password for authentication.");
-            options.getOption("p").setType(String.class);
-            options.getOption("p").setRequired(true);
+            options.addOption("e", "email", true,
+                    "Email of the eperson to run the script as.");
+            options.getOption("e").setType(String.class);
 
             super.options = options;
         }

--- a/dspace-api/src/test/java/org/dspace/curate/ItemMetadataQACheckerIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/ItemMetadataQACheckerIT.java
@@ -63,6 +63,7 @@ public class ItemMetadataQACheckerIT extends AbstractIntegrationTestWithDatabase
     Item itemWithIncorrectLanguageName;
     Item itemWithTwoAvailableDates;
     Item itemWithTwoAvailableDatesAndLang;
+    Item itemWithTwoDois;
     Item itemVersion1;
     Item itemVersion2;
     Item itemVersion3;
@@ -145,6 +146,13 @@ public class ItemMetadataQACheckerIT extends AbstractIntegrationTestWithDatabase
 
             itemService.addMetadata(context, itemWithTwoAvailableDatesAndLang,"dc", "date",
                     "available", "en_US", "2021-01-01");
+
+            itemWithTwoDois = ItemBuilder.createItem(context, collection)
+                    .withTitle("Item With Two DOIs")
+                    .withMetadata("dc", "type", null, "corpus")
+                    .withMetadata("dc", "identifier", "doi", "https://doi.org/10.5072/test-1")
+                    .withMetadata("dc", "identifier", "doi", "https://doi.org/10.5072/test-2")
+                    .build();
 
             itemVersion1 = ItemBuilder.createItem(context, collection)
                     .withTitle("Item Version 1")
@@ -231,6 +239,20 @@ public class ItemMetadataQACheckerIT extends AbstractIntegrationTestWithDatabase
                 Curator.CURATE_FAIL, status);
         String result = curator.getResult(TASK_NAME);
         assertTrue("Result should mention multiple dc.date.available", result.contains("dc.date.available"));
+    }
+
+    @Test
+    public void testItemWithTwoDois() throws IOException {
+        Curator curator = new Curator();
+        curator.addTask(TASK_NAME);
+        context.setCurrentUser(admin);
+
+        // Run curator task for item with two dc.identifier.doi - should fail
+        curator.curate(context, itemWithTwoDois.getHandle());
+        int status = curator.getStatus(TASK_NAME);
+        assertEquals("Curation should fail for item with two dc.identifier.doi", Curator.CURATE_FAIL, status);
+        String result = curator.getResult(TASK_NAME);
+        assertTrue("Result should mention multiple dc.identifier.doi", result.contains("dc.identifier.doi"));
     }
 
     @Test

--- a/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -330,6 +331,52 @@ public class DOIIdentifierProviderTest
             }
         }
         assertTrue("Cannot store DOI as item metadata value.", result);
+    }
+
+    @Test
+    public void testStore_DOI_keeps_existing_different_doi_metadata() throws SQLException, AuthorizeException,
+            IOException, IdentifierException, IllegalAccessException, WorkflowException {
+        Item item = newItem();
+
+        // this checks that the method does not fail if there is already a *different* DOI in the metadata,
+        // here we verify that the existing DOI is preserved (not deleted) and the new one is added alongside it.
+        // Items with more than one DOI are reported by the ItemMetadataQAChecker curation task, not silently
+        // cleaned up here.
+        String oldDoi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR + "1234";
+        String newDoi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR
+            + Long.toHexString(Instant.now().toEpochMilli());
+
+        context.turnOffAuthorisationSystem();
+        itemService.addMetadata(context, item, DOIIdentifierProvider.MD_SCHEMA,
+                DOIIdentifierProvider.DOI_ELEMENT,
+                DOIIdentifierProvider.DOI_QUALIFIER,
+                null,
+                doiService.DOIToExternalForm(oldDoi));
+        provider.saveDOIToObject(context, item, newDoi);
+        context.restoreAuthSystemState();
+
+        checkDoiMetadata(item, oldDoi, newDoi);
+    }
+
+    @Test
+    public void testStore_DOI_check_single_doi_metadata() throws SQLException, AuthorizeException, IOException,
+            IdentifierException, IllegalAccessException, WorkflowException {
+        Item item = newItem();
+
+        // this checks that the method does not fail if there is already a DOI in the metadata,
+        // here we check if DOI metadata are not duplicated
+        String doi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR + Long.toHexString(Instant.now().toEpochMilli());
+
+        context.turnOffAuthorisationSystem();
+        itemService.addMetadata(context, item, DOIIdentifierProvider.MD_SCHEMA,
+                DOIIdentifierProvider.DOI_ELEMENT,
+                DOIIdentifierProvider.DOI_QUALIFIER,
+                null,
+                doiService.DOIToExternalForm(doi));
+        provider.saveDOIToObject(context, item, doi);
+        context.restoreAuthSystemState();
+
+        checkSingleDoiMetadata(item, doi);
     }
 
     @Test
@@ -867,5 +914,35 @@ public class DOIIdentifierProviderTest
     // updateMetadataOnline
     // registerOnline
     // reserveOnline
+
+    private void checkSingleDoiMetadata(Item item, String doi) throws IdentifierException {
+        List<MetadataValue> metadata = itemService.getMetadata(item, DOIIdentifierProvider.MD_SCHEMA,
+                DOIIdentifierProvider.DOI_ELEMENT,
+                DOIIdentifierProvider.DOI_QUALIFIER,
+                Item.ANY);
+        boolean result = false;
+        if (metadata.size() == 1 && metadata.get(0).getValue().equals(doiService.DOIToExternalForm(doi))) {
+            result = true;
+        }
+        assertTrue("Invalid or duplicate 'dc.identifier.doi' metadata value(s).", result);
+    }
+
+    private void checkDoiMetadata(Item item, String... dois) throws IdentifierException {
+        List<String> values = itemService.getMetadata(item, DOIIdentifierProvider.MD_SCHEMA,
+                        DOIIdentifierProvider.DOI_ELEMENT,
+                        DOIIdentifierProvider.DOI_QUALIFIER,
+                        Item.ANY)
+                .stream()
+                .map(MetadataValue::getValue)
+                .collect(Collectors.toList());
+
+        List<String> expected = new ArrayList<>();
+        for (String doi : dois) {
+            expected.add(doiService.DOIToExternalForm(doi));
+        }
+
+        assertEquals("Unexpected number of 'dc.identifier.doi' metadata values.", expected.size(), values.size());
+        assertTrue("Expected 'dc.identifier.doi' metadata values are missing.", values.containsAll(expected));
+    }
 
 }

--- a/dspace-api/src/test/java/org/dspace/scripts/filepreview/FilePreviewIT.java
+++ b/dspace-api/src/test/java/org/dspace/scripts/filepreview/FilePreviewIT.java
@@ -103,20 +103,10 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @Test
-    public void testUnauthorizedPassword() throws Exception {
-        // Run the script
-        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
-        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail()};
-        int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
-                testDSpaceRunnableHandler, kernelImpl);
-        assertEquals(1, run); // Since a ParseException was caught, expect return code 1
-    }
-
-    @Test
     public void testWhenNoFilesRun() throws Exception {
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
 
-        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail(), "-p",  PASSWORD };
+        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail() };
         int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
                 testDSpaceRunnableHandler, kernelImpl);
         assertEquals(0, run);
@@ -127,7 +117,8 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     public void testForSpecificItem() throws Exception {
         Item item2 = createOtherWorkspaceItemWithBitstream(ePerson, 0);
         // Run the script
-        runScriptForItemWithBitstreams(item2, ePerson, PASSWORD);
+        TestDSpaceRunnableHandler testHandler = runScriptForItemWithBitstreams(item2, ePerson);
+        checkHandlerMessages(testHandler, ePerson, item2, "logos.tgz", true);
 
         Bitstream b = bitstreamService.findAll(context).stream()
                 .filter(bitstream -> bitstream.getName().equals("logos.tgz"))
@@ -145,7 +136,8 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     public void testWhenScriptCannotCreateFilePreview() throws Exception {
         Item item2 = createOtherWorkspaceItemWithBitstream(eperson, 0);
         // Run the script as another user, without admin rights
-        runScriptForItemWithBitstreams(item2, ePerson, PASSWORD);
+        TestDSpaceRunnableHandler testHandler = runScriptForItemWithBitstreams(item2, ePerson);
+        checkHandlerMessages(testHandler, ePerson, item2, null, false);
 
         Bitstream b = bitstreamService.findAll(context).stream()
                 .filter(bitstream -> bitstream.getName().equals("logos.tgz"))
@@ -159,7 +151,8 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
         assertFalse("Expects preview content not created.", previewContentService.hasPreview(context, b));
 
         // Run the script as admin user
-        runScriptForItemWithBitstreams(item2, admin, password);
+        testHandler = runScriptForItemWithBitstreams(item2, admin);
+        checkHandlerMessages(testHandler, admin, item2, "logos.tgz", true);
 
         // now the preview content was created since the script was run by admin user
         assertTrue("Expects preview content created.", previewContentService.hasPreview(context, b));
@@ -170,12 +163,40 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
     public void testForAllItem() throws Exception {
         // Run the script
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
-        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail(), "-p",  PASSWORD};
+        String[] args = new String[] { "file-preview", "-e", ePerson.getEmail()};
         int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
                 testDSpaceRunnableHandler, kernelImpl);
         assertEquals(0, run);
         // There should be no errors or warnings
         checkNoError(testDSpaceRunnableHandler);
+    }
+
+    @Test
+    public void testPreviewWithForce() throws Exception {
+        Item item2 = createOtherWorkspaceItemWithBitstream(ePerson, 0);
+        // Run the script
+        TestDSpaceRunnableHandler testHandler1 = runScriptForItemWithBitstreams(item2, ePerson);
+        checkHandlerMessages(testHandler1, ePerson, item2, "logos.tgz", true);
+
+        // run again with force option, the existing preview content should be deleted and new one created
+        TestDSpaceRunnableHandler testHandler2 = new TestDSpaceRunnableHandler();
+        String[] args = new String[] { "file-preview", "-u", item2.getID().toString(),
+                "-e", admin.getEmail(), "-f"};
+        int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testHandler2, kernelImpl);
+        assertEquals(0, run);
+        checkNoError(testHandler2);
+
+        List<String> messages = testHandler2.getInfoMessages();
+        assertThat(messages, hasSize(7));
+
+        assertThat(messages, hasItem(containsString("Deleting existing preview content:")));
+
+        Bitstream b = bitstreamService.findAll(context).stream()
+                .filter(bitstream -> bitstream.getName().equals("logos.tgz"))
+                .findFirst().orElse(null);
+
+        assertTrue("Expects preview content created.", previewContentService.hasPreview(context, b));
+        assertEquals(2, previewContentService.getPreview(context, b).size());
     }
 
     private void checkNoError(TestDSpaceRunnableHandler testDSpaceRunnableHandler) {
@@ -183,24 +204,35 @@ public class FilePreviewIT extends AbstractIntegrationTestWithDatabase {
         assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
     }
 
-    private void runScriptForItemWithBitstreams(Item item, EPerson user, String password) throws Exception {
+    private TestDSpaceRunnableHandler runScriptForItemWithBitstreams(Item item, EPerson user)
+            throws Exception {
         // Run the script
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
         String[] args = new String[] { "file-preview", "-u", item.getID().toString(),
-                "-e", user.getEmail(), "-p",  password};
+                "-e", user.getEmail()};
         int run = ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
                 testDSpaceRunnableHandler, kernelImpl);
         assertEquals(0, run);
         // There should be no errors or warnings
         checkNoError(testDSpaceRunnableHandler);
 
-        // There should be an info message about generating the file previews for the specified item
+        return testDSpaceRunnableHandler;
+    }
+
+    private void checkHandlerMessages(TestDSpaceRunnableHandler testDSpaceRunnableHandler,
+                                      EPerson user,
+                                      Item item,
+                                      String fileName,
+                                      boolean previewGenerationExpected) {
         List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
-        assertThat(messages, hasSize(2));
+        assertThat(messages, hasSize(previewGenerationExpected ? 3 : 2));
         assertThat(messages, hasItem(containsString("Generate the file previews for the specified item with " +
                 "the given UUID: " + item.getID())));
-        assertThat(messages,
-                hasItem(containsString("Authentication by user: " + user.getEmail())));
+        assertThat(messages, hasItem(containsString("Authentication by user: " + user.getEmail())));
+        if (previewGenerationExpected) {
+            // There should be an info message about generating the file previews for the specified bitstream
+            assertThat(messages, hasItem(containsString("Generating file preview for bitstream: " + fileName)));
+        }
     }
 
     private Item createOtherWorkspaceItemWithBitstream(EPerson user, int storageNumber) throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
@@ -66,6 +66,7 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
     Bitstream gzFile;
     Bitstream tarXzFile;
     Bitstream xzFile;
+    Bitstream tgzFileWithGzipMimeType;
     Bitstream tarGzFileWithWrongExtension;
     Bitstream tarXzFileWithIncorrectMimeType;
 
@@ -130,6 +131,15 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
                     .withName("logos.tar.gz")
                     .withDescription("tar.gz compressed file")
                     .withCustomMimeType("application/x-gzip")
+                    .build();
+        }
+
+        try (InputStream is = getClass().getResourceAsStream("assetstore/logos.tgz")) {
+            tgzFileWithGzipMimeType = BitstreamBuilder.
+                    createBitstream(context, bundle1, is)
+                    .withName("logos.tgz")
+                    .withDescription("tar.gz compressed file with tgz extension")
+                    .withMimeType("application/x-gzip")
                     .build();
         }
 
@@ -235,17 +245,20 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
         BitstreamBuilder.deleteBitstream(tarGzFile.getID());
 
         BitstreamFormat customMimeTypeFormat = tarXGzipFile.getFormat(context);
-        BitstreamBuilder.deleteBitstream(tarXGzipFile.getID());
-        if (customMimeTypeFormat != null) {
-            bitstreamFormatService.delete(context, customMimeTypeFormat);
-        }
 
+        BitstreamBuilder.deleteBitstream(tarXGzipFile.getID());
         BitstreamBuilder.deleteBitstream(tgzFile.getID());
         BitstreamBuilder.deleteBitstream(gzFile.getID());
         BitstreamBuilder.deleteBitstream(tarXzFile.getID());
         BitstreamBuilder.deleteBitstream(xzFile.getID());
+        BitstreamBuilder.deleteBitstream(tgzFileWithGzipMimeType.getID());
         BitstreamBuilder.deleteBitstream(tarGzFileWithWrongExtension.getID());
         BitstreamBuilder.deleteBitstream(tarXzFileWithIncorrectMimeType.getID());
+
+        // removing custom mime type format created for tarXGzipFile and tgzFileWithGzipMimeType files
+        if (customMimeTypeFormat != null) {
+            bitstreamFormatService.delete(context, customMimeTypeFormat);
+        }
 
         super.destroy();
     }
@@ -336,6 +349,11 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
     @Test
     public void testXzContent() throws Exception {
         assertFileInfo(xzFile, "logos", 24);
+    }
+
+    @Test
+    public void testTgzContentWithGzipMimetype() throws Exception {
+        assertFileInfos(tgzFileWithGzipMimeType);
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethSpecialGroupsIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/ClarinShibbolethSpecialGroupsIT.java
@@ -1,0 +1,181 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.util.Util;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.core.I18nUtil;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Integration test verifying that the Shibboleth special groups (e.g. the default `Authenticated` group)
+ * survive into tokens which are minted on stateless REST requests after the login:
+ * the short-lived token used for bitstream downloads and the refreshed login token.
+ *
+ * Replicates https://github.com/dataquest-dev/DSpace/issues/900 - a bitstream restricted to the
+ * `Authenticated` group is visible after the Shibboleth login, but its download returns 403,
+ * because the special groups are lost when the short-lived token is generated
+ * (see ufal/clarin-dspace#1373).
+ *
+ * @author Milan Majchrak (milan.majchrak at dataquest.sk)
+ */
+public class ClarinShibbolethSpecialGroupsIT extends AbstractControllerIntegrationTest {
+
+    public static final String[] SHIB_ONLY = {"org.dspace.authenticate.clarin.ClarinShibAuthentication"};
+    private static final String NET_ID_TEST_EPERSON = "123456789";
+    private static final String IDP_TEST_EPERSON = "Test Idp";
+
+    private EPerson clarinEperson;
+    private Bitstream restrictedBitstream;
+
+    @Autowired
+    ConfigurationService configurationService;
+
+    @Before
+    public void setup() throws Exception {
+        super.setUp();
+
+        // Enable Shibboleth login for all tests
+        configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", SHIB_ONLY);
+
+        context.turnOffAuthorisationSystem();
+
+        // Create an eperson with netID - that means the user already exists in the database
+        clarinEperson = EPersonBuilder.createEPerson(context)
+                .withCanLogin(false)
+                .withEmail("clarin@email.com")
+                .withNameInMetadata("first", "last")
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .withNetId(Util.formatNetId(NET_ID_TEST_EPERSON, IDP_TEST_EPERSON))
+                .build();
+
+        // The group every shibboleth-authenticated user is implicitly added to (as a special group)
+        String defaultGroupName = configurationService.getProperty("authentication-shibboleth.default.auth.group");
+        Group authenticatedGroup = GroupBuilder.createGroup(context)
+                .withName(defaultGroupName)
+                .build();
+
+        // A bitstream readable only by the shibboleth default special group
+        Community community = CommunityBuilder.createCommunity(context)
+                .withName("Community")
+                .build();
+        Collection collection = CollectionBuilder.createCollection(context, community)
+                .withName("Collection")
+                .build();
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle("Item with a restricted bitstream")
+                .build();
+        try (InputStream is = IOUtils.toInputStream("Restricted content", CharEncoding.UTF_8)) {
+            restrictedBitstream = BitstreamBuilder.createBitstream(context, item, is)
+                    .withName("restricted.txt")
+                    .withMimeType("text/plain")
+                    .withReaderGroup(authenticatedGroup)
+                    .build();
+        }
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Replication of the issue #900:
+     * 1. Sign in via Shibboleth - the user is implicitly added into the `Authenticated` special group.
+     * 2. The bitstream restricted to the `Authenticated` group is readable with the login token.
+     * 3. The UI downloads the bitstream with a short-lived token minted on a separate stateless request
+     *    - the download must succeed too.
+     */
+    @Test
+    public void shouldDownloadRestrictedBitstreamWithShortLivedTokenAfterShibLogin() throws Exception {
+        String loginToken = shibLogin();
+
+        // Sanity check: the login token keeps the special groups (its `sg` claim was computed
+        // during the shibboleth login request), so the restricted bitstream is readable.
+        getClient(loginToken).perform(get("/api/core/bitstreams/" + restrictedBitstream.getID() + "/content"))
+                .andExpect(status().isOk());
+
+        // The short-lived token is minted on a stateless request - the special groups must be
+        // obtained from the user context (restored from the login token), not from the session.
+        String shortLivedToken = getShortLivedToken(loginToken);
+        getClient().perform(get("/api/core/bitstreams/" + restrictedBitstream.getID()
+                        + "/content?authentication-token=" + shortLivedToken))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * The refreshed login token (POST /api/authn/login with the Bearer token, no shibboleth headers)
+     * must keep the special groups too, otherwise the user loses the access after the first token refresh
+     * (see ufal/clarin-dspace#1373).
+     */
+    @Test
+    public void shouldKeepSpecialGroupsAfterLoginTokenRefresh() throws Exception {
+        String loginToken = shibLogin();
+
+        // Sanity check: the restricted bitstream is readable with the login token
+        getClient(loginToken).perform(get("/api/core/bitstreams/" + restrictedBitstream.getID() + "/content"))
+                .andExpect(status().isOk());
+
+        // Refresh the login token on a stateless request (no shibboleth session/headers)
+        String refreshedAuthHeader = getClient(loginToken).perform(post("/api/authn/login"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getHeader(AUTHORIZATION_HEADER);
+        assertNotNull("The token refresh must return the Authorization header", refreshedAuthHeader);
+        String refreshedToken = refreshedAuthHeader.replace(AUTHORIZATION_TYPE, "");
+
+        // The restricted bitstream must still be readable with the refreshed token
+        getClient(refreshedToken).perform(get("/api/core/bitstreams/" + restrictedBitstream.getID() + "/content"))
+                .andExpect(status().isOk());
+    }
+
+    private String shibLogin() throws Exception {
+        String authHeader = getClient().perform(get("/api/authn/shibboleth")
+                        .header("SHIB-MAIL", clarinEperson.getEmail())
+                        .header("Shib-Identity-Provider", IDP_TEST_EPERSON)
+                        .header("SHIB-NETID", NET_ID_TEST_EPERSON))
+                .andExpect(status().is3xxRedirection())
+                .andReturn().getResponse().getHeader(AUTHORIZATION_HEADER);
+        assertNotNull("The shibboleth login must return the Authorization header", authHeader);
+        return authHeader.replace(AUTHORIZATION_TYPE, "");
+    }
+
+    private String getShortLivedToken(String loginToken) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        MvcResult mvcResult = getClient(loginToken).perform(post("/api/authn/shortlivedtokens"))
+                .andExpect(status().isOk())
+                .andReturn();
+        String content = mvcResult.getResponse().getContentAsString();
+        JsonNode token = mapper.readTree(content).get("token");
+        assertNotNull("The shortlivedtokens response must contain the token field", token);
+        return token.asText();
+    }
+}


### PR DESCRIPTION
## Tranža BE-1 (Vlna 1) — post-snapshot sync dtq-dev → dtq-dev-9-base

Per CLARIN_V9_POST_SNAPSHOT_SYNC_PLAN.md §4 Vlna 1 / BE-1. Source commits from `origin/dtq-dev`, one commit per source commit.

### `e9392ae191` (fork PR #1350) — DOI dedup + QA-checker nonrepeatable — PORT
Clean cherry-pick. **Mandatory fixup applied** (silent-clean-merge trap from the plan card): the two new DOIIdentifierProviderTest tests carried `new Date().getTime()` while v9-base's Date→Instant migration removed the `java.util.Date` import — rewritten to `Instant.now().toEpochMilli()` (+ one 121-char line wrapped for checkstyle). `java.util.Date` NOT reintroduced.

### `74f5862748` (fork PR #1347) — Shib special groups on token refresh — PORT
Conflict-free pick (method bodies only; jakarta imports untouched; Context.getSpecialGroups null-guard included). **Regression IT added**: `ClarinShibbolethSpecialGroupsIT` (2 tests) copied verbatim from zcu backport head `b7d3c786ac` (`origin/zcu-pub/backport-1347-shib-special-groups`) — fix from the canonical dtq-dev commit, test from the backport branch, per the plan card.

### `15b296aa2a` (fork PR #1338) — tgz preview detection + file-preview --force + password drop — PORT
Single conflict in FilePreviewIT resolved toward the v9-base deletion of `testPreviewWithSyncStorage`/`SyncBitstreamStorageServiceImpl` (class absent on v9-base); everything else applied. Resulting FilePreviewIT has exactly 6 tests. ⚠️ **Intentional semantics change carried from the fork:** the file-preview CLI no longer requires `-p/--password` — EPerson resolved from context (UI) or `-e` email, consistent with other DSpace CLI scripts; admin-only operations stay guarded server-side (`testWhenScriptCannotCreateFilePreview`). Not a regression.

### Gates
- `mvn clean install -DskipTests` (incl. checkstyle) — **BUILD SUCCESS** locally.
- Content ACs (acceptance doc §5) verified on the branch: alreadyPresent guard, dc.identifier.doi in nonRepeatableMetadata, zero `shib.specialgroup`/`getSession()`, `request.setAttribute("shib.authenticated")`, Context null-guard, tgz endsWith fix, zero password machinery, --force option.
- Targeted unit/IT battery running locally (results will be reported on this PR); CI Unit+Integration jobs are the record gate.
- dev-6 live probes follow after merge with the Vlna 1 live check (plan §4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)