### PR TITLE
CLARIN-DSpace v9/Port #1346 + #1344 (CI test de-flakes) to the v9 base

### DIFF
--- a/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
@@ -21,6 +21,10 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Random;
 
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.ItemBuilder;
@@ -43,6 +47,12 @@ import org.junit.Test;
 /**
  * Test for checkhandles curation task.
  *
+ * <p>The handle URLs are served by a local {@link MockWebServer} instead of the live handle resolver
+ * (http://hdl.handle.net/), which the task contacts over HTTP. Hitting the live resolver made these tests
+ * flaky: when the network was slow the HEAD request timed out and the task reported {@code 617}
+ * (SocketTimeoutException) instead of the expected status. The mock dispatcher returns deterministic
+ * responses keyed by path.</p>
+ *
  * @author mkuchtiak
  */
 public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
@@ -55,11 +65,10 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
     private static final String HANDLE_ITEM3 = HANDLE_COLLECTION + "-3";
     private static final String HANDLE_ITEM4 = HANDLE_COLLECTION + "-4";
     private static final String HANDLE_NON_EXISTING = HANDLE_COLLECTION + "-999";
-    private static final String HANDLE_URL_REAL = "http://hdl.handle.net/20.1000/5555";
-    private static final String HANDLE_INVALID = HANDLE_URL_REAL + "/..??^^/";
+    // Path (relative to the mock server) of a handle that the resolver answers with a 302 redirect to a 200 page.
+    private static final String HANDLE_REDIRECT_PATH = "20.1000/5555";
     private static final String HANDLE_IGNORED_1 = "11234/998";
     private static final String HANDLE_IGNORED_2 = "11234/999";
-    private static final String HANDLE_URL_IGNORED = "http://hdl.handle.net/" + HANDLE_IGNORED_2;
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
@@ -77,15 +86,50 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
     private Curator curator;
     private CuratorReportTest.ListReporter reporter;
 
+    // Local stand-in for the handle resolver. Started in setUp(); its base URL becomes handle.canonical.prefix.
+    private MockWebServer mockHandleServer;
+    // Previous handle.canonical.prefix, captured in setUp and restored in destroy so the shared config is not
+    // left pointing at the now-closed mock server for later tests in the same JVM.
+    private String originalHandlePrefix;
+    // URLs that point at the mock server (computed from its dynamic port in setUp).
+    private String handleUrlReal;
+    private String handleUrlRedirectTarget;
+    private String handleInvalid;
+    private String handleUrlIgnored;
+
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
         CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
         try {
+            // Serve handle URLs from a local mock server so the task never contacts the live resolver.
+            mockHandleServer = new MockWebServer();
+            String baseUrl = mockHandleServer.url("/").toString();
+            handleUrlReal = baseUrl + HANDLE_REDIRECT_PATH;
+            handleUrlRedirectTarget = baseUrl + HANDLE_REDIRECT_PATH + "-target";
+            handleInvalid = handleUrlReal + "/..??^^/";
+            handleUrlIgnored = baseUrl + HANDLE_IGNORED_2;
+            mockHandleServer.setDispatcher(new Dispatcher() {
+                @Override
+                public MockResponse dispatch(RecordedRequest request) {
+                    String path = request.getPath();
+                    if (("/" + HANDLE_REDIRECT_PATH).equals(path)) {
+                        // a "real" handle: 302 redirect; the task follows redirects manually via the Location header
+                        return new MockResponse().setResponseCode(302).setHeader("Location", handleUrlRedirectTarget);
+                    }
+                    if (("/" + HANDLE_REDIRECT_PATH + "-target").equals(path)) {
+                        return new MockResponse().setResponseCode(200);
+                    }
+                    // any other (well-formed, non-ignored) handle URL is treated as "not found"
+                    return new MockResponse().setResponseCode(404);
+                }
+            });
+
             //we have to create a new community in the database
             context.turnOffAuthorisationSystem();
-            cfg.setProperty("handle.canonical.prefix", "http://hdl.handle.net/");
+            originalHandlePrefix = cfg.getProperty("handle.canonical.prefix");
+            cfg.setProperty("handle.canonical.prefix", baseUrl);
             cfg.setProperty("curate.checklist.ignore", HANDLE_IGNORED_1 + "," + HANDLE_IGNORED_2);
 
             this.parentCommunity = communityService.create(null, context);
@@ -131,7 +175,7 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testItemHandleRedirected() throws IOException {
-        replaceHandleUrl(item2, HANDLE_URL_REAL);
+        replaceHandleUrl(item2, handleUrlReal);
         curator.curate(context, HANDLE_ITEM2);
         assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
         assertTrue(curator.getResult(TASK_NAME).contains(redirectedResultForItem(item2)));
@@ -150,18 +194,18 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testInvalidHandleUrl() throws IOException {
-        replaceHandleUrl(item3, HANDLE_INVALID);
+        replaceHandleUrl(item3, handleInvalid);
         curator.curate(context, HANDLE_ITEM3);
         assertEquals("Curation should fail", Curator.CURATE_FAIL, curator.getStatus(TASK_NAME));
         String singleReport = reporter.getReport().get(0);
-        assertTrue(singleReport.contains(HANDLE_INVALID + " = 500 - FAILED\n"));
+        assertTrue(singleReport.contains(handleInvalid + " = 500 - FAILED\n"));
         assertTrue(singleReport.contains("Error: java.net.URISyntaxException: Illegal character"));
         reporter.getReport().clear();
     }
 
     @Test
     public void testHandleUrlIgnored() throws IOException {
-        replaceHandleUrl(item4, HANDLE_URL_IGNORED);
+        replaceHandleUrl(item4, handleUrlIgnored);
         curator.curate(context, HANDLE_ITEM4);
         assertEquals("Curation should skip", Curator.CURATE_SKIP, curator.getStatus(TASK_NAME));
         assertEquals("Item: " + HANDLE_ITEM4 + "\n", reporter.getReport().get(0));
@@ -170,9 +214,9 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testCurateCollection() throws IOException {
-        replaceHandleUrl(item2, HANDLE_URL_REAL);
-        replaceHandleUrl(item3, HANDLE_INVALID);
-        replaceHandleUrl(item4, HANDLE_URL_IGNORED);
+        replaceHandleUrl(item2, handleUrlReal);
+        replaceHandleUrl(item3, handleInvalid);
+        replaceHandleUrl(item4, handleUrlIgnored);
         curator.curate(context, HANDLE_COLLECTION);
         // the final curator status is derived from the status of the latest checked item
         // so the final curator status is unpredictable
@@ -184,7 +228,7 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
                 both(
                      containsString("Item: " + item2.getHandle())).and(containsString(" = 200 - OK\n")
                 ), // item2
-                containsString(HANDLE_INVALID + " = 500 - FAILED"), // item 3
+                containsString(handleInvalid + " = 500 - FAILED"), // item 3
                 is("Item: " + HANDLE_ITEM4 + "\n") // item 4 (ignored)
         ));
     }
@@ -192,6 +236,13 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
     @After
     @Override
     public void destroy() throws Exception {
+        if (mockHandleServer != null) {
+            mockHandleServer.close();
+        }
+        // restore the shared config so a later test is not left pointing at the now-closed mock server
+        if (originalHandlePrefix != null) {
+            cfg.setProperty("handle.canonical.prefix", originalHandlePrefix);
+        }
         // remove all registered handles properly
         identifierService.delete(context, item1, HANDLE_ITEM1);
         identifierService.delete(context, item2, HANDLE_ITEM2);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -63,6 +63,7 @@ import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -133,6 +134,42 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
      * this hold a reference to the test feature {@link TrueForUsersInGroupTestFeature}
      */
     private AuthorizationFeature trueForUsersInGroupTest;
+
+    private static final String SSR_URL_KEY = "dspace.server.ssr.url";
+    private static final String SSR_URL = "http://ssr.example.com/api";
+    private static final String ALWAYS_THROW_TURNOFF_KEY =
+            "org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff";
+
+    /**
+     * Configure the SSR object-by-URI resolution used by the {@code search/object} tests (disarm the
+     * AlwaysThrowExceptionFeature and define the SSR base URL), setting both as JVM <em>system properties</em>
+     * (+ {@link ConfigurationService#reloadConfig()}) instead of {@code configurationService.setProperty(...)}.
+     *
+     * <p>A plain {@code setProperty(...)} override only lives in the in-memory combined-config view and is
+     * silently dropped whenever that view is rebuilt by the auto-reload listener (which fires when any
+     * reloadable cfg file's mtime changes, e.g. another test writing {@code local.cfg}). When that rebuild
+     * lands mid-test the SSR url disappears and {@code search/object} no longer resolves the uri -> 400 (and a
+     * dropped turnoff would let {@code alwaysexception} throw -> 500). A system property sits in the
+     * highest-precedence override layer and is re-read on every rebuild, so it survives auto-reload; it is
+     * cleared in {@link #clearSsrObjectResolution()}. Same pattern as
+     * AuthenticationRestControllerIT#setAuthenticationMethodSequence.</p>
+     */
+    private void enableSsrObjectResolution() {
+        System.setProperty(ALWAYS_THROW_TURNOFF_KEY, "true");
+        System.setProperty(SSR_URL_KEY, SSR_URL);
+        configurationService.reloadConfig();
+    }
+
+    /**
+     * Remove the system-property overrides set by {@link #enableSsrObjectResolution()} so they do not leak into
+     * other tests in the same JVM. Runs before the superclass {@code @After}, whose {@code reloadConfig()} then
+     * restores the on-disk defaults.
+     */
+    @After
+    public void clearSsrObjectResolution() {
+        System.clearProperty(SSR_URL_KEY);
+        System.clearProperty(ALWAYS_THROW_TURNOFF_KEY);
+    }
 
     @Override
     @Before
@@ -852,9 +889,9 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
         String siteUri = "http://ssr.example.com/api/core/sites/" + siteRest.getId();
 
-        // disarm the alwaysThrowExceptionFeature
-        configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
-        configurationService.setProperty("dspace.server.ssr.url", "http://ssr.example.com/api");
+        // Disarm the alwaysThrowExceptionFeature and define the SSR base URL via system properties so the
+        // overrides survive a mid-test config auto-reload (see enableSsrObjectResolution).
+        enableSsrObjectResolution();
 
         String adminToken = getAuthToken(admin.getEmail(), password);
         String epersonToken = getAuthToken(eperson.getEmail(), password);
@@ -969,9 +1006,9 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
      */
     @Test
     public void findByObjectBadRequestSSRTest() throws Exception {
-        // disarm the alwaysThrowExceptionFeature
-        configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
-        configurationService.setProperty("dspace.server.ssr.url", "http://ssr.example.com/api");
+        // Disarm the alwaysThrowExceptionFeature and define the SSR base URL via system properties so the
+        // overrides survive a mid-test config auto-reload (see enableSsrObjectResolution).
+        enableSsrObjectResolution();
         String[] invalidUris = new String[] {
             "invalid-uri",
             "",
@@ -1050,9 +1087,9 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
     public void findByNotExistingObjectSSSTest() throws Exception {
         String wrongSiteUri = "http://localhost/api/core/sites/" + UUID.randomUUID();
 
-        // disarm the alwaysThrowExceptionFeature
-        configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
-        configurationService.setProperty("dspace.server.ssr.url", "http://ssr.example.com/api");
+        // Disarm the alwaysThrowExceptionFeature and define the SSR base URL via system properties so the
+        // overrides survive a mid-test config auto-reload (see enableSsrObjectResolution).
+        enableSsrObjectResolution();
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -924,6 +924,13 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
             .contentType(contentType))
                                 .andExpect(status().isCreated());
 
+        // Force a commit that waits for a new searcher so the two just-posted view events are guaranteed to be
+        // flushed and visible to the report query below. This covers both ways the report could otherwise come
+        // back empty: postView()'s own commit uses waitSearcher=false (can return before the searcher reopens),
+        // and if the solr-statistics.autoCommit=false override were dropped by a mid-test config reload then
+        // postView() skips its commit entirely (Solr's own autoCommit only fires after 10s).
+        StatisticsServiceFactory.getInstance().getSolrLoggerService().commit();
+
         // And request that collection's TopCountries report
         getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))


### PR DESCRIPTION
## Tranža BE-2 (Vlna 1) — post-snapshot sync dtq-dev → dtq-dev-9-base

Per CLARIN_V9_POST_SNAPSHOT_SYNC_PLAN.md §4 Vlna 1 / BE-2. Test-only PR — zero production code.

### `867e43d13d` (fork PR #1346) — de-flake ItemHandleCheckerIT — PORT
Clean cherry-pick, single file. Live hdl.handle.net resolver replaced by okhttp3 MockWebServer (already a v9-base test dep, 4.12.0).

### `f6f13561cb` (fork PR #1344) — de-flake ORCID cache / allzip ZIP / SSR authz / TopCountries — PORT, Part 1 of 2
- `AuthorizationRestRepositoryIT` (SSR overrides via JVM system props + `@After` clearSsrObjectResolution) and `StatisticsRestRepositoryIT` (solrLoggerService.commit() before TopCountries report) merged clean.
- `CachingOrcidRestConnectorTest.java` + `MetadataBitstreamControllerIT.java` do **not exist** on v9-base → delete/modify conflicts resolved with `git rm` (**DEFERRED Part 2**): when the backlog test-port items land (CLARIN_V9_PARITY_BACKLOG.md lines 217/514/530), those files MUST be sourced from `f6f13561cb` state (== fork head), never from snapshot `8f4b80d514`, or the flaky byte-for-byte ZIP assert and live-ORCID-sandbox dependency get re-introduced (acceptance doc ACs 8–9 DEFERRED).

### Gates
- Diff touches only `src/test` paths (AC1).
- Content ACs verified: 3× enableSsrObjectResolution, 0× setProperty("dspace.server.ssr.url"), 2× System.clearProperty with @After, 1× commit(), zero HANDLE_URL_REAL, MockWebServer wired.
- Local IT battery (ItemHandleCheckerIT ×3, SSR ITs ×3, TopCountries ×3, companion run) follows the BE-1 battery; CI Unit+Integration jobs are the record gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)