### PR TITLE
ZCU-DATA/Add bitstream-level access status/embargo date REST endpoint

### DIFF
--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -10,6 +10,7 @@ package org.dspace.access.status;
 import java.sql.SQLException;
 import java.util.Date;
 
+import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -39,4 +40,27 @@ public interface AccessStatusHelper {
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     public String getEmbargoFromItem(Context context, Item item, Date threshold) throws SQLException;
+
+    /**
+     * Calculate the access status for the bitstream.
+     *
+     * @param context the DSpace context
+     * @param bitstream the bitstream
+     * @param threshold the embargo threshold date
+     * @return an access status value
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    public String getAccessStatusFromBitstream(Context context, Bitstream bitstream, Date threshold)
+        throws SQLException;
+
+    /**
+     * Retrieve embargo information for the bitstream
+     *
+     * @param context the DSpace context
+     * @param bitstream the bitstream to check for embargo information
+     * @param threshold the embargo threshold date
+     * @return an embargo date
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    public String getEmbargoFromBitstream(Context context, Bitstream bitstream, Date threshold) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.util.Date;
 
 import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.service.PluginService;
@@ -67,5 +68,15 @@ public class AccessStatusServiceImpl implements AccessStatusService {
     @Override
     public String getEmbargoFromItem(Context context, Item item) throws SQLException {
         return helper.getEmbargoFromItem(context, item, forever_date);
+    }
+
+    @Override
+    public String getAccessStatus(Context context, Bitstream bitstream) throws SQLException {
+        return helper.getAccessStatusFromBitstream(context, bitstream, forever_date);
+    }
+
+    @Override
+    public String getEmbargoFromBitstream(Context context, Bitstream bitstream) throws SQLException {
+        return helper.getEmbargoFromBitstream(context, bitstream, forever_date);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -59,7 +59,7 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
     }
 
     /**
-     * Look at the item's policies to determine an access status value.
+     * Look at the item policies to determine an access status value.
      * It is also considering a date threshold for embargoes and restrictions.
      *
      * If the item is null, simply returns the "unknown" value.
@@ -96,7 +96,7 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
     }
 
     /**
-     * Look at the DSpace object's policies to determine an access status value.
+     * Look at the DSpace object policies to determine an access status value.
      *
      * If the object is null, returns the "metadata.only" value.
      * If any policy attached to the object is valid for the anonymous group,
@@ -170,7 +170,8 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
      *
      * @param context     the DSpace context
      * @param item        the item to embargo
-     * @return an access status value
+     * @param threshold   the embargo threshold date
+     * @return an embargo date
      */
     @Override
     public String getEmbargoFromItem(Context context, Item item, Date threshold)
@@ -211,7 +212,57 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
     }
 
     /**
+     * Look at the policies attached directly to the bitstream to determine an access status value.
+     * It is also considering a date threshold for embargoes and restrictions.
      *
+     * If the bitstream is null, simply returns the "unknown" value.
+     *
+     * @param context     the DSpace context
+     * @param bitstream   the bitstream to check for embargoes
+     * @param threshold   the embargo threshold date
+     * @return an access status value
+     */
+    @Override
+    public String getAccessStatusFromBitstream(Context context, Bitstream bitstream, Date threshold)
+            throws SQLException {
+        if (bitstream == null) {
+            return UNKNOWN;
+        }
+        return calculateAccessStatusForDso(context, bitstream, threshold);
+    }
+
+    /**
+     * Look at the policies of the bitstream to retrieve its embargo.
+     *
+     * If the bitstream is null, simply returns no embargo date.
+     *
+     * @param context     the DSpace context
+     * @param bitstream   the bitstream to embargo
+     * @param threshold   the embargo threshold date
+     * @return an embargo date
+     */
+    @Override
+    public String getEmbargoFromBitstream(Context context, Bitstream bitstream, Date threshold)
+            throws SQLException {
+        if (bitstream == null) {
+            return null;
+        }
+        // If Bitstream status is not "embargo" then return a null embargo date.
+        String accessStatus = getAccessStatusFromBitstream(context, bitstream, threshold);
+        if (!accessStatus.equals(EMBARGO)) {
+            return null;
+        }
+        Date embargoDate = this.retrieveShortestEmbargo(context, bitstream);
+
+        return embargoDate != null ? embargoDate.toString() : null;
+    }
+
+    /**
+     * Look at the read policies of a bitstream to retrieve the shortest active embargo date.
+     *
+     * @param context     the DSpace context
+     * @param bitstream   the bitstream
+     * @return the shortest embargo date, or null if there is none
      */
     private Date retrieveShortestEmbargo(Context context, Bitstream bitstream) throws SQLException {
         Date embargoDate = null;

--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -8,6 +8,7 @@
 package org.dspace.access.status;
 
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -46,6 +47,11 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
     public static final String OPEN_ACCESS = "open.access";
     public static final String RESTRICTED = "restricted";
     public static final String UNKNOWN = "unknown";
+
+    // REST date fields use a plain ISO calendar date (e.g. "2050-01-01"), matching the format used
+    // elsewhere in the REST API (see ResourcePolicyRest). Date#toString() is locale/timezone-dependent
+    // and must not be used for values exposed over REST.
+    private static final String REST_DATE_FORMAT = "yyyy-MM-dd";
 
     protected ItemService itemService =
             ContentServiceFactory.getInstance().getItemService();
@@ -208,7 +214,7 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
 
         embargoDate = this.retrieveShortestEmbargo(context, bitstream);
 
-        return embargoDate != null ? embargoDate.toString() : null;
+        return formatEmbargoDate(embargoDate);
     }
 
     /**
@@ -254,7 +260,19 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
         }
         Date embargoDate = this.retrieveShortestEmbargo(context, bitstream);
 
-        return embargoDate != null ? embargoDate.toString() : null;
+        return formatEmbargoDate(embargoDate);
+    }
+
+    /**
+     * Format an embargo date for REST exposure as a plain ISO calendar date (yyyy-MM-dd),
+     * matching the format used elsewhere in the REST API. SimpleDateFormat is not thread-safe,
+     * so a new instance is created per call.
+     *
+     * @param date the date to format, may be null
+     * @return the formatted date, or null if the given date is null
+     */
+    private String formatEmbargoDate(Date date) {
+        return date != null ? new SimpleDateFormat(REST_DATE_FORMAT).format(date) : null;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
@@ -9,6 +9,7 @@ package org.dspace.access.status.service;
 
 import java.sql.SQLException;
 
+import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -54,4 +55,24 @@ public interface AccessStatusService {
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     public String getEmbargoFromItem(Context context, Item item) throws SQLException;
+
+    /**
+     * Calculate the access status for a Bitstream while considering the forever embargo date threshold.
+     *
+     * @param context the DSpace context
+     * @param bitstream the bitstream
+     * @return an access status value
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    public String getAccessStatus(Context context, Bitstream bitstream) throws SQLException;
+
+    /**
+     * Retrieve embargo information for the bitstream
+     *
+     * @param context the DSpace context
+     * @param bitstream the bitstream to check for embargo information
+     * @return an embargo date
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    public String getEmbargoFromBitstream(Context context, Bitstream bitstream) throws SQLException;
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
@@ -8,8 +8,12 @@
 package org.dspace.access.status;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 
 import org.apache.logging.log4j.Logger;
@@ -17,15 +21,20 @@ import org.dspace.AbstractUnitTest;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.BundleService;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.InstallItemService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Constants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,6 +49,8 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
     private Collection collection;
     private Community owningCommunity;
     private Item item;
+    private Bundle bundle;
+    private Bitstream bitstream;
 
     protected CommunityService communityService =
             ContentServiceFactory.getInstance().getCommunityService();
@@ -47,6 +58,10 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
             ContentServiceFactory.getInstance().getCollectionService();
     protected ItemService itemService =
             ContentServiceFactory.getInstance().getItemService();
+    protected BundleService bundleService =
+            ContentServiceFactory.getInstance().getBundleService();
+    protected BitstreamService bitstreamService =
+            ContentServiceFactory.getInstance().getBitstreamService();
     protected WorkspaceItemService workspaceItemService =
             ContentServiceFactory.getInstance().getWorkspaceItemService();
     protected InstallItemService installItemService =
@@ -71,6 +86,10 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
             collection = collectionService.create(context, owningCommunity);
             item = installItemService.installItem(context,
                     workspaceItemService.create(context, collection, true));
+            bundle = bundleService.create(context, item, Constants.CONTENT_BUNDLE_NAME);
+            bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+            bitstream.setName(context, "primary");
             context.restoreAuthSystemState();
         } catch (AuthorizeException ex) {
             log.error("Authorization Error in init", ex);
@@ -78,6 +97,9 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
         } catch (SQLException ex) {
             log.error("SQL Error in init", ex);
             fail("SQL Error in init: " + ex.getMessage());
+        } catch (IOException ex) {
+            log.error("IO Error in init", ex);
+            fail("IO Error in init: " + ex.getMessage());
         }
     }
 
@@ -92,6 +114,16 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
     @Override
     public void destroy() {
         context.turnOffAuthorisationSystem();
+        try {
+            bitstreamService.delete(context, bitstream);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            bundleService.delete(context, bundle);
+        } catch (Exception e) {
+            // ignore
+        }
         try {
             itemService.delete(context, item);
         } catch (Exception e) {
@@ -108,6 +140,8 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
             // ignore
         }
         context.restoreAuthSystemState();
+        bitstream = null;
+        bundle = null;
         item = null;
         collection = null;
         owningCommunity = null;
@@ -122,5 +156,23 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
     public void testGetAccessStatus() throws Exception {
         String status = accessStatusService.getAccessStatus(context, item);
         assertNotEquals("testGetAccessStatus 0", status, DefaultAccessStatusHelper.UNKNOWN);
+    }
+
+    @Test
+    public void testGetEmbargoFromItem() throws Exception {
+        String embargo = accessStatusService.getEmbargoFromItem(context, item);
+        assertNull("testGetEmbargoFromItem 0", embargo);
+    }
+
+    @Test
+    public void testGetAccessStatusFromBitstream() throws Exception {
+        String status = accessStatusService.getAccessStatus(context, bitstream);
+        assertNotEquals("testGetAccessStatusFromBitstream 0", status, DefaultAccessStatusHelper.UNKNOWN);
+    }
+
+    @Test
+    public void testGetEmbargoFromBitstream() throws Exception {
+        String embargo = accessStatusService.getEmbargoFromBitstream(context, bitstream);
+        assertNull("testGetEmbargoFromBitstream 0", embargo);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -9,6 +9,7 @@ package org.dspace.access.status;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
@@ -209,6 +210,18 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
     }
 
     /**
+     * Test for a null bitstream
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithNullBitstream() throws Exception {
+        String status = helper.getAccessStatusFromBitstream(context, null, threshold);
+        assertThat("testWithNullBitstream 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        String embargoDate = helper.getEmbargoFromBitstream(context, null, threshold);
+        assertNull("testWithNullBitstream 1", embargoDate);
+    }
+
+    /**
      * Test for an item with no bundle
      * @throws java.lang.Exception passed through.
      */
@@ -246,6 +259,10 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         context.restoreAuthSystemState();
         String status = helper.getAccessStatusFromItem(context, itemWithBitstream, threshold);
         assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        String bitstreamStatus = helper.getAccessStatusFromBitstream(context, bitstream, threshold);
+        assertThat("testWithBitstream 1", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        String bitstreamEmbargoDate = helper.getEmbargoFromBitstream(context, bitstream, threshold);
+        assertNull("testWithBitstream 2", bitstreamEmbargoDate);
     }
 
     /**
@@ -275,6 +292,10 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
         assertThat("testWithEmbargo 1", embargoDate, equalTo(policy.getStartDate().toString()));
+        String bitstreamStatus = helper.getAccessStatusFromBitstream(context, bitstream, threshold);
+        assertThat("testWithEmbargo 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        String bitstreamEmbargoDate = helper.getEmbargoFromBitstream(context, bitstream, threshold);
+        assertThat("testWithEmbargo 3", bitstreamEmbargoDate, equalTo(policy.getStartDate().toString()));
     }
 
     /**
@@ -302,6 +323,10 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         context.restoreAuthSystemState();
         String status = helper.getAccessStatusFromItem(context, itemWithDateRestriction, threshold);
         assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        String bitstreamStatus = helper.getAccessStatusFromBitstream(context, bitstream, threshold);
+        assertThat("testWithDateRestriction 1", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        String bitstreamEmbargoDate = helper.getEmbargoFromBitstream(context, bitstream, threshold);
+        assertNull("testWithDateRestriction 2", bitstreamEmbargoDate);
     }
 
     /**
@@ -374,7 +399,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         context.turnOffAuthorisationSystem();
         Bundle bundle = bundleService.create(context, itemWithPrimaryAndMultipleBitstreams,
                 Constants.CONTENT_BUNDLE_NAME);
-        bitstreamService.create(context, bundle,
+        Bitstream otherBitstream = bitstreamService.create(context, bundle,
                 new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         Bitstream primaryBitstream = bitstreamService.create(context, bundle,
                 new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
@@ -394,6 +419,12 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
         assertThat("testWithPrimaryAndMultipleBitstreams 1", embargoDate, equalTo(policy.getStartDate().toString()));
+        String primaryBitstreamStatus = helper.getAccessStatusFromBitstream(context, primaryBitstream, threshold);
+        assertThat("testWithPrimaryAndMultipleBitstreams 2", primaryBitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        String otherBitstreamStatus = helper.getAccessStatusFromBitstream(context, otherBitstream, threshold);
+        assertThat("testWithPrimaryAndMultipleBitstreams 3", otherBitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
     }
 
     /**
@@ -425,5 +456,8 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
         assertThat("testWithNoPrimaryAndMultipleBitstreams 1", embargoDate, equalTo(null));
+        String otherBitstreamStatus = helper.getAccessStatusFromBitstream(context, anotherBitstream, threshold);
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 2", otherBitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -291,11 +292,13 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         String status = helper.getAccessStatusFromItem(context, itemWithEmbargo, threshold);
         assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertThat("testWithEmbargo 1", embargoDate, equalTo(policy.getStartDate().toString()));
+        assertThat("testWithEmbargo 1", embargoDate,
+                equalTo(new SimpleDateFormat("yyyy-MM-dd").format(policy.getStartDate())));
         String bitstreamStatus = helper.getAccessStatusFromBitstream(context, bitstream, threshold);
         assertThat("testWithEmbargo 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
         String bitstreamEmbargoDate = helper.getEmbargoFromBitstream(context, bitstream, threshold);
-        assertThat("testWithEmbargo 3", bitstreamEmbargoDate, equalTo(policy.getStartDate().toString()));
+        assertThat("testWithEmbargo 3", bitstreamEmbargoDate,
+                equalTo(new SimpleDateFormat("yyyy-MM-dd").format(policy.getStartDate())));
     }
 
     /**
@@ -418,7 +421,8 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         String status = helper.getAccessStatusFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
         assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
-        assertThat("testWithPrimaryAndMultipleBitstreams 1", embargoDate, equalTo(policy.getStartDate().toString()));
+        assertThat("testWithPrimaryAndMultipleBitstreams 1", embargoDate,
+                equalTo(new SimpleDateFormat("yyyy-MM-dd").format(policy.getStartDate())));
         String primaryBitstreamStatus = helper.getAccessStatusFromBitstream(context, primaryBitstream, threshold);
         assertThat("testWithPrimaryAndMultipleBitstreams 2", primaryBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/MetadataBitstreamWrapperConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/MetadataBitstreamWrapperConverter.java
@@ -7,9 +7,15 @@
  */
 package org.dspace.app.rest.converter;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.access.status.DefaultAccessStatusHelper;
+import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.MetadataBitstreamWrapperRest;
 import org.dspace.app.rest.model.wrapper.MetadataBitstreamWrapper;
 import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -24,6 +30,8 @@ import org.springframework.stereotype.Component;
 public class MetadataBitstreamWrapperConverter implements DSpaceConverter<MetadataBitstreamWrapper,
         MetadataBitstreamWrapperRest> {
 
+    private static final Logger log = LogManager.getLogger(MetadataBitstreamWrapperConverter.class);
+
     @Lazy
     @Autowired
     private ConverterService converter;
@@ -31,6 +39,9 @@ public class MetadataBitstreamWrapperConverter implements DSpaceConverter<Metada
 
     @Autowired
     private BitstreamConverter bitstreamConverter;
+
+    @Autowired
+    private AccessStatusService accessStatusService;
 
     @Override
     public MetadataBitstreamWrapperRest convert(MetadataBitstreamWrapper modelObject, Projection projection) {
@@ -45,7 +56,30 @@ public class MetadataBitstreamWrapperConverter implements DSpaceConverter<Metada
         bitstreamWrapperRest.setHref(modelObject.getHref());
         bitstreamWrapperRest.setFormat(modelObject.getFormat());
         bitstreamWrapperRest.setCanPreview(modelObject.isCanPreview());
+        setAccessStatus(bitstreamWrapperRest, modelObject);
         return bitstreamWrapperRest;
+    }
+
+    /**
+     * Populate the access status/embargo date for this bitstream. Failures here must never break
+     * the surrounding file listing - same fail-closed intent as the standalone
+     * BitstreamAccessStatusLinkRepository, just inline since this endpoint returns a flat DTO
+     * rather than a HAL link.
+     */
+    private void setAccessStatus(MetadataBitstreamWrapperRest bitstreamWrapperRest,
+                                  MetadataBitstreamWrapper modelObject) {
+        try {
+            Context context = ContextUtil.obtainCurrentRequestContext();
+            String status = accessStatusService.getAccessStatus(context, modelObject.getBitstream());
+            bitstreamWrapperRest.setStatus(status);
+            if (DefaultAccessStatusHelper.EMBARGO.equals(status)) {
+                bitstreamWrapperRest.setEmbargoDate(
+                    accessStatusService.getEmbargoFromBitstream(context, modelObject.getBitstream()));
+            }
+        } catch (Exception e) {
+            log.warn("Unable to compute access status for bitstream {}",
+                modelObject.getBitstream().getID(), e);
+        }
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessStatusRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessStatusRest.java
@@ -18,6 +18,7 @@ public class AccessStatusRest implements RestModel {
     public static final String NAME = "accessStatus";
 
     String status;
+    String embargoDate;
 
     @Override
     @JsonProperty(access = Access.READ_ONLY)
@@ -33,10 +34,12 @@ public class AccessStatusRest implements RestModel {
 
     public AccessStatusRest() {
         setStatus(null);
+        setEmbargoDate(null);
     }
 
     public AccessStatusRest(String status) {
         setStatus(status);
+        setEmbargoDate(null);
     }
 
     public String getStatus() {
@@ -45,5 +48,13 @@ public class AccessStatusRest implements RestModel {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getEmbargoDate() {
+        return embargoDate;
+    }
+
+    public void setEmbargoDate(String embargoDate) {
+        this.embargoDate = embargoDate;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -31,6 +31,10 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
         @LinkRest(
                 name = BitstreamRest.CHECKSUM,
                 method = "getChecksum"
+        ),
+        @LinkRest(
+                name = BitstreamRest.ACCESS_STATUS,
+                method = "getAccessStatus"
         )
 })
 public class BitstreamRest extends DSpaceObjectRest {
@@ -42,6 +46,7 @@ public class BitstreamRest extends DSpaceObjectRest {
     public static final String FORMAT = "format";
     public static final String THUMBNAIL = "thumbnail";
     public static final String CHECKSUM = "checksum";
+    public static final String ACCESS_STATUS = "accessStatus";
 
     private String bundleName;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/MetadataBitstreamWrapperRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/MetadataBitstreamWrapperRest.java
@@ -29,6 +29,8 @@ public class MetadataBitstreamWrapperRest extends BaseObjectRest<String> {
     private String format;
     private String href;
     private boolean canPreview;
+    private String status;
+    private String embargoDate;
 
     public MetadataBitstreamWrapperRest(String name, String description, long fileSize, String checksum,
                                         List<FileInfo> fileInfo, String format, String href, boolean canPreview) {
@@ -107,6 +109,22 @@ public class MetadataBitstreamWrapperRest extends BaseObjectRest<String> {
 
     public void setChecksum(String checksum) {
         this.checksum = checksum;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getEmbargoDate() {
+        return embargoDate;
+    }
+
+    public void setEmbargoDate(String embargoDate) {
+        this.embargoDate = embargoDate;
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
@@ -16,10 +16,10 @@ import javax.servlet.http.HttpServletRequest;
 import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.AccessStatusRest;
-import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.projection.Projection;
-import org.dspace.content.Item;
-import org.dspace.content.service.ItemService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -28,36 +28,37 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 /**
- * Link repository for calculating the access status of an Item
+ * Link repository for calculating the access status of a Bitstream,
+ * including the embargo date.
  */
-@Component(ItemRest.CATEGORY + "." + ItemRest.NAME + "." + ItemRest.ACCESS_STATUS)
-public class ItemAccessStatusLinkRepository extends AbstractDSpaceRestRepository
+@Component(BitstreamRest.CATEGORY + "." + BitstreamRest.NAME + "." + BitstreamRest.ACCESS_STATUS)
+public class BitstreamAccessStatusLinkRepository extends AbstractDSpaceRestRepository
     implements LinkRestRepository {
 
     @Autowired
-    ItemService itemService;
+    BitstreamService bitstreamService;
 
     @Autowired
     AccessStatusService accessStatusService;
 
-    @PreAuthorize("hasPermission(#itemId, 'ITEM', 'READ')")
+    @PreAuthorize("hasPermission(#bitstreamId, 'BITSTREAM', 'METADATA_READ')")
     public AccessStatusRest getAccessStatus(@Nullable HttpServletRequest request,
-                                            UUID itemId,
+                                            UUID bitstreamId,
                                             @Nullable Pageable optionalPageable,
                                             Projection projection) {
         try {
             Context context = obtainContext();
-            Item item = itemService.find(context, itemId);
-            if (item == null) {
-                throw new ResourceNotFoundException("No such item: " + itemId);
+            Bitstream bitstream = bitstreamService.find(context, bitstreamId);
+            if (bitstream == null) {
+                throw new ResourceNotFoundException("No such bitstream: " + bitstreamId);
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
-            String accessStatus = accessStatusService.getAccessStatus(context, item);
-            if (accessStatus.equals(DefaultAccessStatusHelper.EMBARGO)) {
-                String embargoDate = accessStatusService.getEmbargoFromItem(context, item);
+            String status = accessStatusService.getAccessStatus(context, bitstream);
+            if (status.equals(DefaultAccessStatusHelper.EMBARGO)) {
+                String embargoDate = accessStatusService.getEmbargoFromBitstream(context, bitstream);
                 accessStatusRest.setEmbargoDate(embargoDate);
             }
-            accessStatusRest.setStatus(accessStatus);
+            accessStatusRest.setStatus(status);
             return accessStatusRest;
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
@@ -54,7 +54,7 @@ public class BitstreamAccessStatusLinkRepository extends AbstractDSpaceRestRepos
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
             String status = accessStatusService.getAccessStatus(context, bitstream);
-            if (status.equals(DefaultAccessStatusHelper.EMBARGO)) {
+            if (DefaultAccessStatusHelper.EMBARGO.equals(status)) {
                 String embargoDate = accessStatusService.getEmbargoFromBitstream(context, bitstream);
                 accessStatusRest.setEmbargoDate(embargoDate);
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
@@ -53,7 +53,7 @@ public class ItemAccessStatusLinkRepository extends AbstractDSpaceRestRepository
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
             String accessStatus = accessStatusService.getAccessStatus(context, item);
-            if (accessStatus.equals(DefaultAccessStatusHelper.EMBARGO)) {
+            if (DefaultAccessStatusHelper.EMBARGO.equals(accessStatus)) {
                 String embargoDate = accessStatusService.getEmbargoFromItem(context, item);
                 accessStatusRest.setEmbargoDate(embargoDate);
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataBitstreamRestRepository.java
@@ -419,6 +419,11 @@ public class MetadataBitstreamRestRepository extends DSpaceRestRepository<Metada
             return true;
         } catch (MissingLicenseAgreementException e) {
             return false;
+        } catch (AuthorizeException e) {
+            // The requesting user (e.g. anonymous) doesn't have READ on this bitstream at all -
+            // e.g. it's under embargo. Same "can't preview" outcome as the license case above;
+            // this used to propagate uncaught and 500 the entire file listing for the item.
+            return false;
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
+import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.app.rest.matcher.BitstreamFormatMatcher;
 import org.dspace.app.rest.matcher.BitstreamMatcher;
 import org.dspace.app.rest.matcher.BundleMatcher;
@@ -2927,6 +2928,53 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                      .content(patchBody)
                                      .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void findAccessStatusForBitstreamBadRequestTest() throws Exception {
+        getClient().perform(get("/api/core/bitstreams/{uuid}/accessStatus", "1"))
+                   .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findAccessStatusForBitstreamNotFoundTest() throws Exception {
+        // Unlike the item-level accessStatus link (gated on plain 'READ'), the bitstream-level link is
+        // gated on 'METADATA_READ' (see BitstreamMetadataReadPermissionEvaluatorPlugin), whose evaluator
+        // denies permission outright when the target bitstream cannot be resolved, so an anonymous request
+        // never reaches the controller's not-found check and instead gets a 401.
+        UUID fakeUUID = UUID.randomUUID();
+        getClient().perform(get("/api/core/bitstreams/{uuid}/accessStatus", fakeUUID))
+                   .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findAccessStatusForBitstreamTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1")
+                                           .build();
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                           .withTitle("Test item 1")
+                                           .build();
+        String bitstreamContent = "ThisIsSomeDummyText";
+        Bitstream bitstream = null;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream = BitstreamBuilder.createBitstream(context, publicItem1, is)
+                                        .withName("Bitstream")
+                                        .withDescription("Description")
+                                        .withMimeType("text/plain")
+                                        .build();
+        }
+        context.restoreAuthSystemState();
+
+        // Bitstream access status should still be accessible by anonymous request
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/accessStatus"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.type", is("accessStatus")))
+            .andExpect(jsonPath("$.status", is(DefaultAccessStatusHelper.OPEN_ACCESS)));
     }
 
     public boolean bitstreamExists(String token, Bitstream ...bitstreams) throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataBitstreamRestRepositoryIT.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -22,6 +23,7 @@ import java.sql.SQLException;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.app.util.Util;
 import org.dspace.authorize.service.AuthorizeService;
@@ -124,9 +126,37 @@ public class MetadataBitstreamRestRepositoryIT extends AbstractControllerIntegra
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].checksum")
                         .value(Matchers.containsInAnyOrder(Matchers.containsString(bts.getChecksum()))))
                 .andExpect(jsonPath("$._embedded.metadatabitstreams[*].href")
-                        .value(Matchers.containsInAnyOrder(Matchers.containsString(url))));
+                        .value(Matchers.containsInAnyOrder(Matchers.containsString(url))))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[*].status")
+                        .value(Matchers.containsInAnyOrder(DefaultAccessStatusHelper.OPEN_ACCESS)))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[0].embargoDate").value(nullValue()));
 
 
+    }
+
+    @Test
+    public void findByHandleEmbargoedBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bitstream embargoedBitstream;
+        String bitstreamContent = "ThisIsSomeEmbargoedText";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            embargoedBitstream = BitstreamBuilder.createBitstream(context, publicItem, is)
+                    .withName("Embargoed Bitstream")
+                    .withDescription("Embargoed description")
+                    .withMimeType("application/x-gzip")
+                    .withEmbargoPeriod("3 months")
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        getClient().perform(get(METADATABITSTREAM_SEARCH_BY_HANDLE_ENDPOINT)
+                        .param("handle", publicItem.getHandle())
+                        .param("fileGrpType", FILE_GRP_TYPE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[?(@.name == '" + embargoedBitstream.getName()
+                        + "')].status", Matchers.contains(DefaultAccessStatusHelper.EMBARGO)))
+                .andExpect(jsonPath("$._embedded.metadatabitstreams[?(@.name == '" + embargoedBitstream.getName()
+                        + "')].embargoDate", Matchers.contains(notNullValue())));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
@@ -103,7 +103,8 @@ public class BitstreamMatcher {
                 "bundle",
                 "format",
                 "thumbnail",
-                "checksum"
+                "checksum",
+                "accessStatus"
         );
     }
 
@@ -117,7 +118,8 @@ public class BitstreamMatcher {
                 "format",
                 "self",
                 "thumbnail",
-                "checksum"
+                "checksum",
+                "accessStatus"
         );
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/model/AccessStatusRestTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/model/AccessStatusRestTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test the AccessStatusRestTest class
+ * Test the AccessStatusRest class
  */
 public class AccessStatusRestTest {
 
@@ -35,5 +35,16 @@ public class AccessStatusRestTest {
     public void testAccessStatusIsNotNullAfterStatusSet() throws Exception {
         accessStatusRest.setStatus(DefaultAccessStatusHelper.UNKNOWN);
         assertNotNull(accessStatusRest.getStatus());
+    }
+
+    @Test
+    public void testEmbargoDateIsNullBeforeEmbargoDateSet() throws Exception {
+        assertNull(accessStatusRest.getEmbargoDate());
+    }
+
+    @Test
+    public void testEmbargoDateIsNotNullAfterEmbargoDateSet() throws Exception {
+        accessStatusRest.setEmbargoDate("2050-01-01");
+        assertNotNull(accessStatusRest.getEmbargoDate());
     }
 }


### PR DESCRIPTION
## Problem
The bitstream-level embargo badge on the frontend (dataquest-dev/dspace-angular#1378 for ZCU-PUB; ZCU-DATA frontend work still pending) needs to know a restricted bitstream's embargo end date. This endpoint doesn't exist on `customer/zcu-data` (same gap as `customer/zcu-pub`, fixed there by #1377 - this is the same fix applied to the sibling customer branch).

Backend portion of dataquest-dev/dspace-customers#823 (ZCU-DATA).

## Root cause
Same as #1377: never ported from the DSpace 9.x line (where it already exists, e.g. `customer/mendelu`) to the 7.x line. `zcu-data` and `zcu-pub` share the same DSpace 7.6.1 version family and, for the touched files, byte-identical source - confirmed via diff before making this change.

## Change set
Identical in shape to #1377 (cherry-picked cleanly onto `customer/zcu-data` - the underlying files matched exactly, no adaptation needed beyond the base branch):
- `dspace-api`: `AccessStatusHelper` / `DefaultAccessStatusHelper` / `AccessStatusServiceImpl` / `AccessStatusService` — `getAccessStatusFromBitstream` / `getEmbargoFromBitstream`.
- `dspace-server-webapp`: `AccessStatusRest` gains `embargoDate`; `BitstreamRest` gains the `ACCESS_STATUS` link; new `BitstreamAccessStatusLinkRepository`; `ItemAccessStatusLinkRepository` also populates `embargoDate` now (DTO consistency, same as #1377).
- REST contract: `GET /server/api/core/bitstreams/{id}/accessStatus` -> `{status, embargoDate}`.

## Test evidence
```
mvn checkstyle:check -pl dspace-api                  -> BUILD SUCCESS, no violations
mvn checkstyle:check -pl dspace-server-webapp         -> BUILD SUCCESS, no violations
mvn test -pl dspace-api -DskipUnitTests=false -Dtest=AccessStatusServiceTest,DefaultAccessStatusHelperTest
                                                       -> Tests run: 16, Failures: 0, Errors: 0
mvn test -pl dspace-server-webapp -DskipUnitTests=false -Dtest=AccessStatusRestTest
                                                       -> Tests run: 4, Failures: 0, Errors: 0
mvn verify -pl dspace-server-webapp -Dit.test=BitstreamRestRepositoryIT
                                                       -> Tests run: 56, Failures: 0, Errors: 0, Skipped: 1 (pre-existing @Ignore, unrelated)
```

## Risk & rollback
Low risk, same as #1377: additive REST surface only. Revert is a straight `git revert`.

## Notes / assumptions
- Companion PR: #1377 (same fix, `customer/zcu-pub`).
- The ZCU-DATA frontend does not yet consume this endpoint - its Item View file listing goes through a different, CLARIN-specific component (`clarin-files-section`/`file-description`) that doesn't reuse `file-download-link`/`AccessStatusBadgeComponent` at all. That's tracked separately as its own frontend task; this backend endpoint is ready whenever that lands.
