### PR TITLE
Keep embed params out of subresource self links

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -20,9 +20,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -813,8 +815,8 @@ public class RestResourceController implements InitializingBean {
                     }
 
                     Link link = null;
-                    String querystring = request.getQueryString();
-                    if (querystring != null && querystring.length() > 0) {
+                    String querystring = removeEmbedParamsFromQueryString(request.getQueryString());
+                    if (StringUtils.isNotEmpty(querystring)) {
                         link = linkTo(this.getClass(), apiCategory, model).slash(uuid)
                             .slash(subpath + '?' + querystring).withSelfRel();
                     } else {
@@ -1024,6 +1026,29 @@ public class RestResourceController implements InitializingBean {
      * @param parameters
      * @return encoded uriString containing request parameters without embed parameter
      */
+    /**
+     * Remove the "embed" and "embed.*" parameters from a raw query string.
+     *
+     * Embedding a subresource doesn't change which resource was requested, so it doesn't belong in
+     * that resource's self link. The collection and search endpoints already leave these out, via
+     * {@link #getEncodedParameterStringFromRequestParams}; this does the same for the subresource
+     * lists, which build their self link from the raw query string. The remaining parameters are
+     * passed through untouched, so the client's own encoding is preserved.
+     *
+     * @param querystring the raw query string, may be null
+     * @return the query string without embed parameters, empty if nothing is left
+     */
+    private String removeEmbedParamsFromQueryString(String querystring) {
+        if (StringUtils.isEmpty(querystring)) {
+            return "";
+        }
+        return Arrays.stream(StringUtils.split(querystring, '&'))
+                     .filter(param -> !StringUtils.equals(param, "embed")
+                         && !StringUtils.startsWith(param, "embed=")
+                         && !StringUtils.startsWith(param, "embed."))
+                     .collect(Collectors.joining("&"));
+    }
+
     private String getEncodedParameterStringFromRequestParams(
             @RequestParam MultiValueMap<String, Object> parameters) {
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
@@ -223,6 +223,29 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void getItemBundlesSelfLinkHasNoEmbedParams() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        bundle1 = BundleBuilder.createBundle(context, item).withName("testname").build();
+
+        context.restoreAuthSystemState();
+
+        // embedding a subresource doesn't change which resource was requested, so the embed params
+        // must not end up in its self link - the other params must survive untouched
+        getClient().perform(get("/api/core/items/" + item.getID() + "/bundles")
+                       .param("embed", "primaryBitstream")
+                       .param("embed.size", "bitstreams=5")
+                       .param("size", "10"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$._links.self.href",
+                           Matchers.containsString("/api/core/items/" + item.getID() + "/bundles")))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.not(Matchers.containsString("embed"))))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("size=10")))
+        ;
+    }
+
+    @Test
     public void createBundleWithoutMetadata() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         BundleRest bundleRest = new BundleRest();


### PR DESCRIPTION
## References

* Related to dataquest-dev/dspace-customers#862 and dataquest-dev/dspace-angular#1415 (the frontend side)
* Upstream: DSpace/DSpace issue 8577 — open since 2022-11-09, `good first issue`, never fixed
* Upstream PR 3105 (issue 3062) fixed exactly this, but only for the collection endpoints
* No REST Contract PR needed — no endpoint or field changes, and the contract already states the self link should not carry parameters that don't affect the resource

## Description

Subresource list endpoints put the request's `embed` parameters into their own `self` link, so
`/items/<uuid>/bundles?embed=primaryBitstream` reports a self link that isn't the resource that was
requested. Collection and search endpoints already exclude them; this does the same for subresources.

## Instructions for Reviewers

`RestResourceController.findRelInternal` builds the self link from the **raw** query string:

```java
String querystring = request.getQueryString();
link = linkTo(this.getClass(), apiCategory, model).slash(uuid)
    .slash(subpath + '?' + querystring).withSelfRel();
```

The collection (`findAllInternal`) and search (`executeSearchMethods`) paths instead go through
`getEncodedParameterStringFromRequestParams`, which drops `embed` and `embed.*`. That helper was
added by PR 3105 to fix issue 3062 — but it was never wired into the subresource path, which is why
issue 8577 is still open.

List of changes in this PR:

* Added `removeEmbedParamsFromQueryString`, and used it in `findRelInternal`. It filters out only
  `embed` and `embed.*` and passes every other parameter through **verbatim** — no re-encoding, so a
  client's own percent-encoding is preserved.
* Added `BundleRestRepositoryIT.getItemBundlesSelfLinkHasNoEmbedParams`, asserting the self link
  keeps `size=10` and no longer contains `embed`.

**How to test:**

```
GET /api/core/items/<uuid>/bundles?embed=primaryBitstream&size=10
```

Before: `"self": ".../bundles?embed=primaryBitstream&size=10"`
After:  `"self": ".../bundles?size=10"`

A real DSpace 9.1 instance returns this for an item page load, which is what the frontend reports as
"The response for … has the self link … These don't match":

```
.../bundles?embed=primaryBitstream&embed=bitstreams/format&embed.size=bitstreams=5
```

Worth a reviewer's attention: when every parameter was an `embed` one, the self link now has no query
string at all — that is the intended result, and it is what the collection endpoints already do.

## Checklist

- [ ] My PR is **created against the `main` branch** of code — no: fork PR, base is `dtq-dev`. The
  same change applies to upstream `main`; a patch is prepared separately for a human to submit.
- [x] My PR is **small in size** (2 files, one 12-line private method plus a 1-line call site change).
- [x] My PR **follows all coding best practices** based on the Code Conventions Guide.
- [x] My PR **passes Checkstyle** validation (`mvn -pl dspace-server-webapp checkstyle:check`, exit 0).
- [x] My PR **includes Javadoc** for the new private method.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** — the IT is
  written, but **it has not been executed**: DSpace's test harness needs a configured `dspace.dir`,
  which this machine doesn't have (`dspace-api` tests fail the same way on an untouched checkout).
  The filter logic itself was verified in `jshell` against the real query strings, including that
  `embedded=x` is *not* stripped. Someone with a working test environment should run the IT.
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies — none.
- [ ] If my PR modifies REST API endpoints — it doesn't add or remove any; it changes the value of an
  existing `self` link, which the REST Contract already describes as not carrying parameters that
  can't affect the resource.
