### PR TITLE
JCU/Enable vanilla ORCID authority control (SolrAuthority)

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -135,6 +135,31 @@ choices.plugin.dc.language.iso = common_iso_languages
 choices.presentation.dc.language.iso = select
 authority.controlled.dc.language.iso = true
 
+# Keep the test environment on the VANILLA authority / ORCID configuration.
+#
+# The JCU deployment enables vanilla ORCID authority control in
+# dspace/config/modules/authority.cfg and points dspace/config/modules/orcid.cfg
+# at the production ORCID endpoints. The upstream test suite asserts the vanilla
+# defaults instead, and tests that need authority control set these properties
+# themselves at runtime (see DiscoveryRestControllerIT, SubmissionFormsControllerIT).
+
+# Restore the single-entry plugin list. With SolrAuthorAuthority registered,
+# Discovery resolves author facet labels through the authority core and renders
+# the raw authority key instead of the author name
+# (DiscoveryRestControllerIT.discoverFacetsAuthorWithAuthority*).
+plugin.named.org.dspace.content.authority.ChoiceAuthority = org.dspace.content.authority.EPersonAuthority = EPersonAuthority
+
+# ItemTest asserts dc.contributor.author carries no authority key.
+# This must be an explicit 'false': MetadataAuthorityServiceImpl reads it with
+# getBooleanProperty(key, true), so an empty value would leave authority control ON.
+authority.controlled.dc.contributor.author = false
+
+# AuthenticationRestControllerIT.testOrcidLoginURL and OrcidExternalSourcesIT
+# assert the ORCID sandbox host.
+orcid.domain-url = https://sandbox.orcid.org
+orcid.api-url = https://api.sandbox.orcid.org/v3.0
+orcid.public-url = https://pub.sandbox.orcid.org/v3.0
+
 ###########################################
 #  PROPERTIES USED TO TEST CONFIGURATION  #
 #  PROPERTY EXPOSURE VIA REST             #

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -815,7 +815,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, qaeventsdelete, ldnmessage
+event.dispatcher.default.consumers = authority, versioning, discovery, eperson, qaeventsdelete, ldnmessage
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher

--- a/dspace/config/modules/authority.cfg
+++ b/dspace/config/modules/authority.cfg
@@ -40,10 +40,10 @@ authority.minconfidence = ambiguous
 
 # Configuration settings for ORCID based authority control.
 # Uncomment the lines below to enable configuration
-#choices.plugin.dc.contributor.author = SolrAuthorAuthority
-#choices.presentation.dc.contributor.author = authorLookup
-#authority.controlled.dc.contributor.author = true
-#authority.author.indexer.field.1=dc.contributor.author
+choices.plugin.dc.contributor.author = SolrAuthorAuthority
+choices.presentation.dc.contributor.author = authorLookup
+authority.controlled.dc.contributor.author = true
+authority.author.indexer.field.1=dc.contributor.author
 
 ##
 ## This sets the lowest confidence level at which a metadata value is included
@@ -75,8 +75,8 @@ authority.minconfidence = ambiguous
 # org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 #Uncomment to enable ORCID authority control
-#plugin.named.org.dspace.content.authority.ChoiceAuthority = \
-# org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
+plugin.named.org.dspace.content.authority.ChoiceAuthority = \
+ org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 plugin.named.org.dspace.content.authority.ChoiceAuthority = \
 org.dspace.content.authority.EPersonAuthority = EPersonAuthority

--- a/dspace/config/modules/orcid.cfg
+++ b/dspace/config/modules/orcid.cfg
@@ -14,12 +14,12 @@ orcid.disconnection.remain-sync = true
 #------------------------------------------------------------------#
 
 # ORCID API (https://github.com/ORCID/ORCID-Source/tree/master/orcid-api-web#endpoints)
-orcid.domain-url= https://sandbox.orcid.org
+orcid.domain-url = https://orcid.org
 orcid.authorize-url = ${orcid.domain-url}/oauth/authorize
 orcid.revoke-url = ${orcid.domain-url}/oauth/revoke
 orcid.token-url = ${orcid.domain-url}/oauth/token
-orcid.api-url = https://api.sandbox.orcid.org/v3.0
-orcid.public-url = https://pub.sandbox.orcid.org/v3.0
+orcid.api-url = https://pub.orcid.org/v3.0
+orcid.public-url = https://pub.orcid.org/v3.0
 orcid.redirect-url = ${dspace.server.url}/api/authn/orcid
 
 # ORCID Credentials

--- a/dspace/config/spring/api/orcid-authority-services.xml
+++ b/dspace/config/spring/api/orcid-authority-services.xml
@@ -15,7 +15,6 @@
 
     <bean id="dspace.DSpaceAuthorityIndexer" class="org.dspace.authority.indexer.DSpaceAuthorityIndexer"/>
 
-<!--
     <alias name="OrcidSource" alias="AuthoritySource"/>
     <bean name="OrcidSource" class="org.dspace.authority.orcid.Orcidv3SolrAuthorityImpl">
         <property name="clientId" value="${orcid.application-client-id}" />
@@ -23,12 +22,11 @@
         <property name="OAUTHUrl" value="${orcid.token-url}" />
         <property name="orcidRestConnector" ref="orcidRestConnector"/>
     </bean>
- -->
  
     <bean name="AuthorityTypes" class="org.dspace.authority.AuthorityTypes">
         <property name="types">
             <list>
-                <!-- <bean class="org.dspace.authority.orcid.Orcidv3AuthorityValue"/> -->
+                <bean class="org.dspace.authority.orcid.Orcidv3AuthorityValue"/>
                 <bean class="org.dspace.authority.PersonAuthorityValue"/>
             </list>
         </property>


### PR DESCRIPTION
## References

* Upstream documentation: [ORCID Authority (DSDOC9x)](https://wiki.lyrasis.org/spaces/DSDOC9x/pages/379125966/ORCID+Authority)
* No REST Contract PR needed — no endpoint is added or changed.

## Description

Enables ORCID authority control for `dc.contributor.author` on JCU using the **vanilla DSpace 9.3 path** (`org.dspace.content.authority.SolrAuthority` + `Orcidv3SolrAuthorityImpl`). Configuration only — no Java, no new classes, nothing fork-specific.

Context: an earlier attempt used `org.dspace.content.authority.SimpleORCIDAuthority`, which is a **fork-only class that does not exist on this branch** (it reached `dtq-dev-9-base` only with #1339, after `customer/jcu` was cut). That produced `PluginInstantiationException: Cannot load plugin class` and took `/api/discover/browses` down with a 500 — `BrowseIndexRestRepository.findAll` calls `getChoiceAuthoritiesNames()`, so a broken plugin config kills the browse endpoint, not just the author lookup.

## List of changes in this PR

**`dspace/config/modules/authority.cfg`**
* Uncomment L43–46 in place: `choices.plugin` / `choices.presentation` / `authority.controlled` / `authority.author.indexer.field.1` for `dc.contributor.author`.
* Uncomment L78–79, the shipped `SolrAuthority = SolrAuthorAuthority` named-plugin entry.
* **The existing `EPersonAuthority` entry at L81–82 is deliberately left untouched.** Two occurrences of the same key inside one `.cfg` file accumulate into an array — same mechanism as the seven `plugin.named.org.dspace.app.mediafilter.FormatFilter` lines in `dspace.cfg` L495–501, read through `LegacyPluginServiceImpl#getArrayProperty`. So both authorities stay registered. Writing this key into `local.cfg` instead would *replace* the list (`config-definition.xml` L18–19 puts `local.cfg` ahead of `dspace.cfg` in an `<override>` block) and silently drop `EPersonAuthority`.

**`dspace/config/dspace.cfg`** (L818)
* `event.dispatcher.default.consumers = authority, versioning, discovery, eperson, qaeventsdelete, ldnmessage`
* `authority` is placed **first**, before `discovery`: `Dispatcher` holds consumers in a `LinkedHashMap` and `BasicDispatcher` calls `end()` in config order. `AuthorityConsumer.end()` mints the authority keys; `IndexEventConsumer.end()` writes to Solr. Reversed, the first Discovery document for a new item is written before the key exists.
* The other five consumers are kept. The wiki's `authority, versioning, discovery, eperson` line is DSpace-6 vintage and would silently drop `qaeventsdelete` and `ldnmessage`.
* `event.consumer.authority.class` / `.filters` (L852–854) already existed — the consumer was declared but never activated.

**`dspace/config/modules/orcid.cfg`**
* `orcid.domain-url`, `orcid.api-url`, `orcid.public-url`: sandbox → production. `orcid.token-url` derives from `domain-url`, so it follows automatically — and it is the `OAUTHUrl` of the authority bean. Leaving `domain-url` on sandbox while setting `api-url` to production would POST production credentials at `sandbox.orcid.org/oauth/token`, leave the token null and make every lookup silently return nothing.
* `orcid.api-url` is set to the **public** API (`pub.orcid.org`) — a free Public API client is sufficient, per the wiki.
* Credentials are **not** committed (see deployment steps).

**`dspace/config/spring/api/orcid-authority-services.xml`**
* Activate the `OrcidSource` alias + `Orcidv3SolrAuthorityImpl` bean.
* Activate `<bean class="org.dspace.authority.orcid.Orcidv3AuthorityValue"/>` in the `AuthorityTypes` list. **Both are required.** Without the alias, `SolrAuthority#addExternalResults` takes the else branch and only logs `external source for authority not configured` — you get local Solr hits only, i.e. nothing on an empty core. Without the `AuthorityTypes` entry, `AuthorityTypes#getEmptyAuthorityValue("orcid")` falls through to a bare `new AuthorityValue()`, so the ORCID id is dropped on archive with no exception and no log line.
* `ref="orcidRestConnector"` resolves to `external-services.xml` L272–274, which exists on this branch — verified, the context boots.

## Deployment steps (not in git)

Config is baked into the backend image — `docker-compose-rest.yml` mounts only the assetstore, there is no `/dspace/config` bind mount and no `local.cfg`. So this PR must be merged and a new image built and pulled; an in-container edit is destroyed by the next `docker compose up -d`.

1. **ORCID credentials** — register a free Public API client and set them as env vars in the runner overlay (`/opt/dspace-envs/<INSTANCE>/`), not in git. `.` maps to `__P__` and `-` maps to `__D__`:
   ```
   orcid__P__application__D__client__D__id: <APP-...>
   orcid__P__application__D__client__D__secret: <secret>
   ```
   Env vars outrank cfg files, so verify the overlay does not already set any `orcid.*` / `choices.*` / `event.dispatcher.*` key.
2. Merge → `.github/workflows/docker.yml` builds on push to `customer/*` → redeploy. Note the deploy runs `up -d --no-build`, so a SHA-pinned `DSPACE_VER` in the overlay would silently reuse the old image.
3. **Restart the backend.** None of this hot-reloads: `ChoiceAuthorityServiceImpl` and `MetadataAuthorityServiceImpl` cache at init, `LegacyPluginServiceImpl` caches named plugins, `DSpaceAuthorityIndexer` reads `authority.author.indexer.field.N` once at Spring init, and the Spring XML is only read at startup.
4. **Do not run `dspace index-authority`** as part of this change. It is not a read-only reindex: it wipes the authority core, iterates every item, mints a UUID for each distinct authorless `dc.contributor.author` value and writes it back via `itemService.update()`. If it is ever wanted, take a `pg_dump` of `metadatavalue` first and rehearse on a restore. The consumer populates the core going forward without it.
5. `dspace index-discovery -b` after the first authority-bearing items exist — `authority.controlled` changes the shape of indexed author values.

## Instructions for reviewers / how to test

Baseline before the change: `GET /server/api/submission/vocabularies/SolrAuthorAuthority` returns **400** (plugin not registered).

After deploy:
```bash
# 1. plugin registered
curl -s "$BASE/submission/vocabularies/SolrAuthorAuthority" | jq '{name, scrollable, hierarchical}'   # 200

# 2. the actual smoke test - ORCID hits carry a 'will be generated::orcid::' authority
curl -s "$BASE/submission/vocabularies/SolrAuthorAuthority/entries?filter=Bollini&size=20" \
  | jq '[._embedded.entries[]? | select(.authority // "" | startswith("will be generated::orcid::"))] | length'   # > 0

# 3. both authorities survived
docker exec <backend> /dspace/bin/dspace dsprop -p plugin.named.org.dspace.content.authority.ChoiceAuthority
#    must list BOTH SolrAuthorAuthority and EPersonAuthority
docker exec <backend> /dspace/bin/dspace dsprop -p event.dispatcher.default.consumers
docker exec <backend> /dspace/bin/dspace dsprop -p orcid.api-url        # must not contain 'sandbox'

# 4. authority Solr core reachable (it is precreated by the compose entrypoint)
docker exec <backend> curl -sf 'http://dspacesolr:8983/solr/authority/select?q=*:*&rows=0' || echo MISSING

# 5. silent-failure detector - all of these must be empty
docker logs <backend> 2>&1 | grep -iE \
  'Skipping invalid configuration for choices.plugin|external source for authority not configured|Cannot retrieve ORCID access token|An error occurs querying authority solr core'
```
Then submit an item and type ≥3 characters into the author field: suggestions should appear inline with an ORCID badge, and the stored value should carry an authority key and confidence.

## Known limitations, deliberately out of scope

* **`choices.presentation = authorLookup` is currently inert.** `SubmissionFormConverter#getPresentation` maps `authorLookup` → `lookup-name` only for `<input-type>name</input-type>`; every live JCU form ships `onebox` (`traditionalpageone` L61, `publicationStep` L258). The value is kept because it is what upstream ships. You still get the inline typeahead and the authority key is still stored — switching to the modal lookup means changing `submission-forms.xml`, which is a UX decision, so it is not in this PR. (`openairePublicationPageoneForm` L861 is already `name`, but no collection maps to an openaire submission-process, so nothing changes there.)
* **Free-text authors keep working** — `authority.required.dc.contributor.author` is left at its default `false`.
* **The consumer rewrites the displayed author name** to the ORCID profile's canonical `Family, Given` form when an ORCID entry is picked. That is inherent to the feature, flagged so it is not a surprise.
* Two vanilla 9.3 defects were found while verifying this and are **not** fixed here, to keep the change pure config:
  * `OrcidRestConnector#isSuccessful` is `statusCode >= 200 || statusCode <= 299` — a tautology, so an ORCID 401/403 never raises; it surfaces as `Unable to unmarshall orcid message` instead.
  * `SolrAuthority` emits a lowercase `or` in its query (upstream fixed on `main` in #10528, never backported to `dspace-9_x`). Harmless on Solr 9.8 because `handleSelect="true"` supplies `df`, but SOLR-17742 removes `handleSelect` in Solr 10 and every author lookup would then 400.

## Rollback

Revert the merge and redeploy. The only stateful effect until `index-authority` is run is that newly submitted items carry authority keys in `metadatavalue.authority`; those are inert once the plugin is gone.

## Checklist

- [x] Created against the correct branch (`customer/jcu` — customer-specific deployment config).
- [x] Small in size (4 config files).
- [x] No Java changes, so no Checkstyle/Javadoc/unit-test impact.
- [x] Includes details on how to test it.
- [x] No new libraries/dependencies.
- [x] No REST API changes → no REST Contract PR.
- [x] New configuration documented in the PR itself.
