### PR TITLE
MENDELU/fix(logging): write dspace.log inside the container again

### DIFF
--- a/dspace/config/log4j2-container.xml
+++ b/dspace/config/log4j2-container.xml
@@ -1,21 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Logging configuration for DSpace container (matches log4j2.xml but to console, removing file refs & most comments) -->
+<!-- Logging configuration for DSpace container.
+
+     Writes [dspace.dir]/log/dspace.log exactly like log4j2.xml does outside of a container, and
+     mirrors the same events to stdout so that "docker logs" keeps working. Point the container at
+     this file with the LOGGING_CONFIG environment variable (see docker-compose-rest.yml).
+
+     NOTE: /dspace/log only survives a container recreate when it is mounted as a volume. -->
 <Configuration strict='true'
                xmlns='http://logging.apache.org/log4j/2.0/config'>
 
     <Properties>
+        <!-- Log file directory. "dspace.dir" is fixed to /dspace in the image (see Dockerfile),
+             so the log directory is /dspace/log. Override with the DSPACE_LOG_DIR env variable
+             when the container installs DSpace somewhere else. -->
+        <Property name='log.dir'>${env:DSPACE_LOG_DIR:-/dspace/log}</Property>
+
+        <!-- Log level for all DSpace-specific code (org.dspace.*)
+             Possible values (from most to least info):
+	     DEBUG, INFO, WARN, ERROR, FATAL -->
         <Property name='loglevel.dspace'>INFO</Property>
+
+        <!-- Log level for other third-party tools/APIs used by DSpace
+             Possible values (from most to least info):
+	     DEBUG, INFO, WARN, ERROR, FATAL -->
         <Property name='loglevel.other'>INFO</Property>
+
+        <!-- Level of the copy that is echoed to the container console ("docker logs").
+             dspace.log always receives everything; raise this to WARN, or set it to OFF, to keep
+             the container output small once dspace.log is being collected. -->
+        <Property name='loglevel.console'>${env:DSPACE_LOG_CONSOLE_LEVEL:-INFO}</Property>
     </Properties>
 
     <Appenders>
         <!-- A1 is for most DSpace activity -->
         <Appender name='A1'
-                  type='Console'
+                  filePattern='${log.dir}/dspace.log-%d{yyyy-MM-dd}'
+                  type='RollingFile'
+                  fileName='${log.dir}/dspace.log'
 
         >
+            <!-- NOTE: The %equals patterns are providing a default value of "unknown" if "correlationID" or
+                 "requestID" are not currently set in the ThreadContext. -->
             <Layout type='PatternLayout'
                     pattern='%d %-5p %equals{%X{correlationID}}{}{unknown} %equals{%X{requestID}}{}{unknown} %c @ %m%n'/>
+            <policies>
+                <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
+            </policies>
+            <!-- Sample deletion policy:  keep last 30 archived files
+            <DefaultRolloverStrategy>
+                <Delete basePath='${log.dir}'>
+                    <IfFileName glob='dspace.log-*'/>
+                    <IfAccumulatedFileCount exceeds='30'/>
+                </Delete>
+            </DefaultRolloverStrategy>
+            -->
+        </Appender>
+
+        <!-- STDOUT echoes A1 to the container console, so that "docker logs" is not blind -->
+        <Appender name='STDOUT'
+                  type='Console'>
+            <Layout type='PatternLayout'
+                    pattern='%d %-5p %equals{%X{correlationID}}{}{unknown} %equals{%X{requestID}}{}{unknown} %c @ %m%n'/>
+            <Filters>
+                <Filter type='ThresholdFilter'
+                        level='${loglevel.console}'/>
+            </Filters>
         </Appender>
 
         <!-- A2 is for the checksum checker -->
@@ -33,6 +82,7 @@
                 level='${loglevel.dspace}'
                 additivity='false'>
             <AppenderRef ref='A1'/>
+            <AppenderRef ref='STDOUT'/>
         </Logger>
 
         <!-- The checksum checker -->
@@ -60,6 +110,7 @@
         <!-- Anything not a part of DSpace -->
         <Root level='${loglevel.other}'>
             <AppenderRef ref='A1'/>
+            <AppenderRef ref='STDOUT'/>
         </Root>
     </Loggers>
 </Configuration>

--- a/dspace/config/log4j2-container.xml
+++ b/dspace/config/log4j2-container.xml
@@ -34,7 +34,7 @@
     <Appenders>
         <!-- A1 is for most DSpace activity -->
         <Appender name='A1'
-                  filePattern='${log.dir}/dspace.log-%d{yyyy-MM-dd}'
+                  filePattern='${log.dir}/dspace.log-%d{yyyy-MM-dd}.gz'
                   type='RollingFile'
                   fileName='${log.dir}/dspace.log'
 
@@ -46,10 +46,12 @@
             <policies>
                 <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
             </policies>
-            <!-- Sample deletion policy:  keep last 30 archived files
+            <!-- Rolled-over files are gzipped, because filePattern ends in ".gz" - same as
+                 customer/vsb-tuo. Nothing is deleted automatically; uncomment below to keep
+                 only the last 30 archives.
             <DefaultRolloverStrategy>
                 <Delete basePath='${log.dir}'>
-                    <IfFileName glob='dspace.log-*'/>
+                    <IfFileName glob='dspace.log-*.gz'/>
                     <IfAccumulatedFileCount exceeds='30'/>
                 </Delete>
             </DefaultRolloverStrategy>


### PR DESCRIPTION
## Problem

Everything DSpace logs comes out as **container stdout**, and `[dspace.dir]/log/dspace.log` is never created. Anything that expects `dspace.log` — support tickets, `grep`-based debugging, log shipping, the reflex of every DSpace admin — has nothing to read, and the entire history disappears the moment the container is recreated.

## Cause

The backend container is started with

```yaml
LOGGING_CONFIG: ${LOGGING_CONFIG:-/dspace/config/log4j2-container.xml}
```

(`docker/docker-compose-rest.yml` in `dataquest-dev/dspace-angular`, and the same line in this repo's `docker-compose.yml`). Spring Boot maps `LOGGING_CONFIG` → `logging.config` and hands that file to Log4j2.

`log4j2-container.xml` is **console-only by design** upstream — its own header says *"matches log4j2.xml but to console, removing file refs"*. Both of its appenders are `type='Console'`. So the file destination is not misconfigured, it simply does not exist in that config. Note this is *only* the Spring Boot webapp: `log4j2-cli.xml` is untouched and already writes `dspace-cli.log` / `checker.log`, which is why `/dspace/log` exists in the container but has no `dspace.log` in it.

## Fix

`log4j2-container.xml` now carries the same `RollingFile` appender as `log4j2.xml` — `dspace.log` with daily `dspace.log-yyyy-MM-dd` rollover and the identical pattern layout — and echoes the same events to stdout through a separate appender, so **`docker logs dspace` keeps working exactly as it does today**. Nothing that works now stops working; the missing half starts working.

| | before | after |
|---|---|---|
| `/dspace/log/dspace.log` | never created | full log, daily rollover |
| `docker logs dspace` | full log | same, tunable via env |
| log levels / checker appender | — | unchanged |

Two knobs, both optional:

- **`DSPACE_LOG_DIR`** — log directory, default `/dspace/log`. That is where `dspace.dir` points in the image (`Dockerfile`: `ENV dspace__P__dir=/dspace`), so the default is correct as shipped.
- **`DSPACE_LOG_CONSOLE_LEVEL`** — level of the stdout copy, default `INFO` (i.e. current behaviour). Set it to `WARN` or `OFF` to stop duplicating everything into the Docker json-file log once `dspace.log` is being collected. `dspace.log` always receives everything regardless.

Log levels, the checksum-checker appender and the blocked `org.dspace.*` loggers are deliberately left alone.

## Verification

Tested against **log4j-core 2.25.4** — the version pinned in `pom.xml` (`<log4j.version>2.25.4</log4j.version>`) — by loading the config the way Spring Boot's `Log4J2LoggingSystem` does (`ConfigurationFactory.getInstance().getConfiguration(ctx, source)` from the file URI), then logging through the real DSpace logger names:

- `dspace.log` is created and receives `org.dspace.*` **and** root events, with the `correlationID` / `requestID` defaults rendering as `unknown` exactly as in `log4j2.xml`.
- The stdout copy matches the file line for line.
- `org.dspace.checker` still goes to its own console appender with the bare `%m%n` layout; `org.dspace.services` INFO is still blocked while ERROR passes — the level config survives untouched.
- `DSPACE_LOG_CONSOLE_LEVEL=WARN` drops INFO from stdout while `dspace.log` keeps it.
- With `DSPACE_LOG_DIR` unset, the `/dspace/log` default resolves and the file is written there.
- The config parses with **no log4j status warnings or errors** — worth stating explicitly, because this file is `strict='true'` and a parse failure would silently fall back to a default console config.

## Follow-up (required for this to be useful in production)

`/dspace/log` is still in the container's writable layer, so `dspace.log` is wiped on every recreate — i.e. exactly when you redeploy after an incident. The matching volume goes in `dataquest-dev/dspace-angular` `customer/mendelu`; see the companion PR. This PR is safe and correct on its own, it just cannot make the file outlive the container by itself.

Also worth a look after merge: if the deploy overlay on the MENDELU host (the Mendelu deploy directory) pins `LOGGING_CONFIG` to something else, it will win over the compose default and this change will have no effect there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Fleet context.** Identical change to the one on `customer/jcu` (dataquest-dev/DSpace#1391) — the file was byte-identical on both branches, so both now carry the same config. These are the only two branches affected: every 7.x customer branch (vsb-tuo, lindat, uk, sav, zcu-pub, zcu-data, TUL) sets no `LOGGING_CONFIG` at all and already mounts a log volume. The v6→v9 upgrade re-imported upstream's compose and lost that customisation, which is why exactly the two v9 branches — jcu 9.3 and mendelu 9.1 — regressed.

Note this cannot be fixed by simply deleting the `LOGGING_CONFIG` line the way the 7.x branches do. DSpace's own default is `logging.config = ${dspace.dir}/config/log4j2.xml` (`application.properties:128`), but `dspace.dir=${dspace.dir}` is still an unresolved placeholder in the built artifact — it is supplied via JNDI or `-Ddspace.dir` in a Tomcat deployment, and neither is set in the container image. Removing the line would leave the placeholder unresolvable rather than restore file logging, which is precisely why upstream points containers at an explicit config file.
