### PR TITLE
JCU/fix(config): set the repository name and JCU e-mail addresses

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -39,8 +39,6 @@ dspace.server.ssr.url = ${dspace.server.url}
 dspace.ui.url = http://localhost:4000
 
 # Name of the site
-# Value carried over from the DSpace 6.3 instance (dspace.jcu.cz) so that OAI-PMH harvesters
-# keep seeing the same repository name across the migration.
 dspace.name = DSpace Jihočeské Univerzity v Českých Budějovicích
 dspace.shortname = DSpace
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -39,7 +39,9 @@ dspace.server.ssr.url = ${dspace.server.url}
 dspace.ui.url = http://localhost:4000
 
 # Name of the site
-dspace.name = DSpace at My University
+# Value carried over from the DSpace 6.3 instance (dspace.jcu.cz) so that OAI-PMH harvesters
+# keep seeing the same repository name across the migration.
+dspace.name = DSpace Jihočeské Univerzity v Českých Budějovicích
 dspace.shortname = DSpace
 
 # Assetstore configurations have moved to config/modules/assetstore.cfg
@@ -155,7 +157,7 @@ mail.server.port = 25
 
 # From address for mail
 # All mail from the DSpace site will use this 'from' address
-mail.from.address = dspace-noreply@myu.edu
+mail.from.address = dspace-noreply@jcu.cz
 
 # Name of a pre-configured Session object to be fetched from a directory.
 # This overrides the Session settings above.  If none can be found, then DSpace
@@ -166,15 +168,15 @@ mail.from.address = dspace-noreply@myu.edu
 # When feedback is submitted via the Feedback form, it is sent to this address
 # Currently limited to one recipient!
 # if this property is empty or commented out, feedback form is disabled
-feedback.recipient = dspace-help@myu.edu
+feedback.recipient = dspace@rt.jcu.cz
 
 # General site administration (Webmaster) e-mail
 # System notifications/reports and other sysadmin emails are sent to this address
-mail.admin = dspace-help@myu.edu
+mail.admin = dspace@rt.jcu.cz
 mail.admin.name = DSpace Administrator
 
 # Helpdesk E-mail
-mail.helpdesk = ${mail.admin}
+mail.helpdesk = obd@rt.jcu.cz
 mail.helpdesk.name = Help Desk
 
 # Recipient for server errors and alerts (defaults to mail.admin)


### PR DESCRIPTION
Fixes **H3** from the dataquest-dev/dspace-customers#853 review.

## Problem, confirmed on production today

```
$ curl -s "https://dspace-new.jcu.cz/server/oai/request?verb=Identify"
  <repositoryName>DSpace at My University</repositoryName>
  <adminEmail>dspace-help@myu.edu</adminEmail>

$ curl -s https://dspace-new.jcu.cz/server/api
  dspaceName: DSpace at My University
```

and an anonymous visitor on `/statistics` reads *"Statistics for DSpace at My University"*.

Both are the untouched defaults from `dspace.cfg` (lines 42 and 175). OAI-PMH is harvested by
OpenAIRE, BASE, CORE and Theses.cz, so the repository is currently being registered under a
placeholder name with a contact address that does not exist.

## Where the values come from

Nothing is invented. All five are read verbatim out of the `local.cfg` of the **DSpace 6.3 instance
being migrated** (`dspace.jcu.cz`):

| key | before (DSpace default) | after (JCU 6.3 value) |
|---|---|---|
| `dspace.name` | `DSpace at My University` | `DSpace Jihočeské Univerzity v Českých Budějovicích` |
| `mail.admin` | `dspace-help@myu.edu` | `dspace@rt.jcu.cz` |
| `mail.helpdesk` | `${mail.admin}` | `obd@rt.jcu.cz` |
| `feedback.recipient` | `dspace-help@myu.edu` | `dspace@rt.jcu.cz` |
| `mail.from.address` | `dspace-noreply@myu.edu` | `dspace-noreply@jcu.cz` |

Keeping the old name also means the OAI harvesters that already know the 6.3 instance see the same
repository name across the migration.

`handle.prefix` was checked too — the new instance already has `20.500.14390`, matching 6.3. ✔

## Why `dspace.cfg` and not `local.cfg`

`local.cfg` is the generic DSpace answer, but the convention in this repository is the branch:
`customer/mendelu` and `customer/vsb-tuo` both set `dspace.name` **and** the whole mail block in
`dspace/config/dspace.cfg`, and `customer/jcu` already carries CitacePRO, `themed.by.*` and an event
consumer there. Putting it on the branch makes it reviewable, versioned and self-deploying.

Nothing here is a secret — a repository name and role addresses. Credentials stay in `local.cfg` on
the host.

## Verified

Local Docker DSpace 9.3 with the dev-only `dspace__P__name` compose override removed, so the value in
`dspace.cfg` is what actually takes effect:

```
GET /server/oai/request?verb=Identify
  <repositoryName>DSpace Jihočeské Univerzity v Českých Budějovicích</repositoryName>
  <adminEmail>dspace@rt.jcu.cz</adminEmail>

GET /server/api
  dspaceName: DSpace Jihočeské Univerzity v Českých Budějovicích

/statistics, anonymous
  "Statistics for DSpace Jihočeské Univerzity v Českých Budějovicích"
```

**Diacritics survive the `.cfg` round trip** — worth checking explicitly, because DSpace sets no
explicit encoding on its Commons Configuration reader and this is the first customer value with
Czech characters in it (mendelu and vsb-tuo are plain ASCII). The file is UTF-8 without BOM and the
raw response bytes are valid UTF-8, no mojibake:

```
... 4a69686f c48d 6573 6b c3a9 ... c48c 6573 6b c3bd 6368 ...
    Jiho      č   esk    é          Č   esk    ý  ch
```

## ⚠ Required when deploying: purge the OAI cache

`oai.cache.enabled = true`, and the cached `Identify` response lives on disk in
`${dspace.dir}/var/oai/requests/`. **It survives a restart.** Without purging it OAI keeps serving
`DSpace at My University` while REST and the UI already show the new name — I hit exactly this during
verification:

```bash
/dspace/bin/dspace oai clean-cache
```

## Deliberately not in this PR

- **`mail.server`** is still `smtp.example.com`. `customer/mendelu` and `customer/vsb-tuo` set theirs
  in `dspace.cfg`; the 6.3 config used `mail.server = localhost`, which is almost certainly not right
  for the new host. Correcting the addresses stops the leak into OAI and the UI, but mail will not be
  delivered until whoever owns the server sets a working relay. Worth a separate ticket.
- **`mail.admin.name` / `mail.helpdesk.name`** are still `DSpace Administrator` / `Help Desk`. They
  appear in outgoing mail and are customer-facing wording, so I did not invent Czech versions.
- **The name still contains "DSpace"**, which pulls against **H4** (banner *Repozitář publikací*,
  `repository.title` *Institucionální digitální repozitář*, prefix *IDR ::*). This PR takes the
  conservative option — restore what JCU already ran — precisely so that the branding decision can be
  made in H4 without OAI being wrong in the meantime. If H4 concludes the repository should stop
  naming the product, this is a one-line follow-up.
- Also worth noting for whoever picks up H4: the current value has a capital `U` in *Univerzity*,
  while the institution is *Jihočeská univerzita*. Copied as-is on purpose; correcting it is a
  customer decision, not a migration decision.

## Evidence

Screenshots:

- `H3-1-before-oai-identify-default-name.png`
<img width="1120" height="760" alt="H3-1-before-oai-identify-default-name" src="https://github.com/user-attachments/assets/a58f302c-26d2-442c-804d-9092e31bfebc" />

- `H3-2-before-local-statistics-dspace-at-my-university.png`
<img width="1120" height="760" alt="H3-2-before-local-statistics-dspace-at-my-university" src="https://github.com/user-attachments/assets/3e97911e-8be0-4c33-8dd1-8e2f388c7eaf" />

- `H3-5-after-dspace-cfg-statistics-jcu-name.png`
<img width="1120" height="760" alt="H3-5-after-dspace-cfg-statistics-jcu-name" src="https://github.com/user-attachments/assets/5dcda225-0607-477a-b85d-3091714654bd" />

- `H3-6-after-dspace-cfg-oai-and-rest.png`
<img width="1120" height="760" alt="H3-6-after-dspace-cfg-oai-and-rest" src="https://github.com/user-attachments/assets/8d680a4a-a0d2-46c8-9545-3edbe4b95648" />
