### PR TITLE
JCU/fix(access-status): report a file's embargo to privileged users too

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -915,7 +915,7 @@ access.status.embargo.forever.day = 1
 # This configuration doesn't impact the calculation for OAI-PMH. The XOAI plugin will always
 # calculate the status with the "anonymous" type.
 access.status.for-user.item = anonymous
-access.status.for-user.bitstream = current
+access.status.for-user.bitstream = anonymous
 
 # implementation of access status helper plugin - replace with local implementation if applicable
 # This default access status helper provides an item status based on the policies of the primary


### PR DESCRIPTION
Companion to dataquest-dev/dspace-angular#1439, which turns the embargo label on in the Item View.
With that alone, an **administrator sees no label** — which is backwards, since the people curating
the repository are the ones who need to know an embargo exists and when it ends.

## Why

`dspace.cfg` ships two settings that decide *whose* permissions the access status describes:

```
access.status.for-user.item = anonymous
access.status.for-user.bitstream = current
```

`current` computes a bitstream's status for the current user (`AccessStatusServiceImpl` →
`getAccessStatusFromBitstream(context, bitstream, forever_date, bitstreamCalculationType)`), so
anyone who *can* read the file — administrators, editors, anyone a policy lets in early — is told
`open.access`. The frontend renders the label only when an `embargoDate` comes back, so they get
nothing.

Note the asymmetry: the item-level setting one line above is already `anonymous`, and XOAI always
calculates the status anonymously regardless of either setting. `current` was the odd one out.

## Verified

Local Docker DSpace 9.3 with the JCU configuration. Bitstream with an anonymous READ policy starting
`2030-01-01`:

| | anonymous | administrator |
|---|---|---|
| `current` (before) | `embargo` / `2030-01-01` | `open.access` / `null` |
| `anonymous` (after) | `embargo` / `2030-01-01` | **`embargo` / `2030-01-01`** |

```
GET /server/api/core/bitstreams/e144905d-…/accessStatus
```

In the UI, with dataquest-dev/dspace-angular#1439 applied, the Item View then shows
`Embargo until 2030-01-01` next to the file when logged in as `admin@jcu.cz`, where before it showed
the plain filename.

## Scope

This changes **what is reported, not who can read what**. Authorisation is untouched — the
administrator could always download the file and still can; they are now simply told it is under
embargo. The one trade-off: a logged-in user who was granted early access sees `Embargo until …` on
a file they can open. The file still opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
