### PR TITLE
SAV/Prevent an admin from deleting their own account

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -371,6 +371,14 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
             throw new AuthorizeException(
                     "You must be an admin to delete an EPerson");
         }
+        // Admin cannot delete himself/herself
+        if (!context.ignoreAuthorization()) {
+            EPerson currentUser = context.getCurrentUser();
+            if (currentUser != null && ePerson.getID().equals(currentUser.getID())) {
+                throw new IllegalStateException(
+                        "You, as admin user, cannot delete yourself");
+            }
+        }
         // Get all workflow-related groups that the current EPerson belongs to
         Set<Group> workFlowGroups = getAllWorkFlowGroups(context, ePerson);
         for (Group group: workFlowGroups) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -375,7 +375,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
         } catch (EmptyWorkflowGroupException e) {
             throw new RESTEmptyWorkflowGroupException(e);
         } catch (IllegalStateException e) {
-            throw new UnprocessableEntityException(e.getMessage(), e);
+            throw new DSpaceBadRequestException(e.getMessage(), e);
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -1127,6 +1127,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void deleteYourselfForbidden() throws Exception {
+        // login as admin
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // Deleting yourself is forbidden
+        getClient(adminToken).perform(delete("/api/eperson/epersons/" + admin.getID()))
+                .andExpect(status().isBadRequest());
+
+        // Verify the admin is still here
+        getClient(adminToken).perform(get("/api/eperson/epersons/" + admin.getID()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     public void deleteViolatingWorkFlowConstraints() throws Exception {
         // We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
Backport of dataquest-dev/DSpace#1306 (`68463d490f`) from `dtq-dev` onto `customer/sav`.

`EPersonServiceImpl.delete()` now refuses to delete the EPerson that is the current context user (unless authorization is being ignored, e.g. CLI/consumers), and `EPersonRestRepository` maps that `IllegalStateException` to a **400 Bad Request** carrying the message, so the UI can show a friendly notification instead of a generic failure.

**Verified locally:** `mvn -o checkstyle:check -pl dspace-api,dspace-server-webapp` clean; `mvn -o compile -pl dspace-api` clean.

Refs dataquest-dev/dspace-customers#855

Frontend counterpart: dataquest-dev/dspace-angular#1444 — the two must ship together.

---

## How this was verified

### Automated — runs on this PR
The change ships with an integration test that drives the **real REST API**:
`EPersonRestRepositoryIT#deleteYourselfForbidden` logs in as an administrator, calls
`DELETE /api/eperson/epersons/{own-id}`, asserts **400**, then asserts the account still exists.

The **Run Integration Tests** CI job is green on this PR, and its log shows the class executing:

```
Tests run: 93, Failures: 0, Errors: 0, Skipped: 0 - in org.dspace.app.rest.EPersonRestRepositoryIT
```

The base branch has **92** `@Test` methods in that class — the 93rd is this one.
Locally: `mvn -o checkstyle:check -pl dspace-api,dspace-server-webapp` → 0 violations.

### Manual — on a live instance
Throwaway DSpace 9.3 stack (own DB / Solr / assetstore, REST on :8091), logged in as an administrator:

| Backend | Request | Result |
| --- | --- | --- |
| **without** the fix | `DELETE /server/api/eperson/epersons/<own uuid>` | `204`, and a follow-up `GET` → `404`. **The admin deleted their own account.** |
| **with** the fix | the same request | `400 Bad Request`, follow-up `GET` → `200`. **The account survives.** |
| **with** the fix | delete a *different* EPerson | still works — row disappears from the list |

The live run above was done on the JCU 9.3 pair. This branch carries a **byte-identical** patch — `git patch-id --stable` = `56b872c32d89` on both — and its own **Run Integration Tests** job is green.

### Reviewer note — the message does not reach the client
The source commit intended to "allow client to see the error message", but the 400 body is DSpace's generic
`{"status":400,"error":"Bad Request","message":"An exception has occurred"}` — the text
*"You, as admin user, cannot delete yourself"* never reaches the browser, because
`DSpaceBadRequestException` is annotated `@ResponseStatus(reason = "Bad Request")`.

This does **not** weaken the fix: the deletion is refused server-side either way, and the frontend does not
depend on that string (it decides from its own identity check). Flagging it so nobody later builds on the
assumption that the message is visible.
