### PR TITLE
[Port to dtq-dev] Issue dspace-customers#903: make REST root version prefix configurable

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -44,7 +44,8 @@ public class RootConverter {
         } else {
             rootRest.setDspaceServer(dspaceUrl);
         }
-        String versionPrefix = configurationService.getProperty("dspace.version.prefix", "DSpace");
+        String versionPrefix = StringUtils.defaultIfBlank(
+                configurationService.getProperty("dspace.version.prefix", "DSpace"), "DSpace");
         rootRest.setDspaceVersion(versionPrefix + " " + getSourceVersion());
         rootRest.setBuildVersion(getBuildVersion());
         return rootRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -44,7 +44,8 @@ public class RootConverter {
         } else {
             rootRest.setDspaceServer(dspaceUrl);
         }
-        rootRest.setDspaceVersion("DSpace " + getSourceVersion());
+        String versionPrefix = configurationService.getProperty("dspace.version.prefix", "DSpace");
+        rootRest.setDspaceVersion(versionPrefix + " " + getSourceVersion());
         rootRest.setBuildVersion(getBuildVersion());
         return rootRest;
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -45,6 +45,7 @@ public class RootConverterTest {
         when(configurationService.getProperty("dspace.name")).thenReturn("dspacename");
         when(configurationService.getProperty("dspace.server.url")).thenReturn(serverURL);
         when(configurationService.getProperty("dspace.server.ssr.url", serverURL)).thenReturn(serverSSRURL);
+        when(configurationService.getProperty("dspace.version.prefix", "DSpace")).thenReturn("DSpace");
 
     }
 
@@ -84,5 +85,16 @@ public class RootConverterTest {
         assertEquals("dspacename", rootRest.getDspaceName());
         assertEquals(serverSSRURL, rootRest.getDspaceServer());
         assertEquals("DSpace " + Util.getSourceVersion(), rootRest.getDspaceVersion());
+    }
+
+    @Test
+    public void testConfigurableVersionPrefix() throws Exception {
+        when(configurationService.getProperty("dspace.version.prefix", "DSpace")).thenReturn("CLARIN-DSpace");
+        request.setScheme("https");
+        request.setServerName("dspace-rest");
+        request.setServerPort(443);
+        request.setRequestURI("/server/api");
+        RootRest rootRest = rootConverter.convert(request);
+        assertEquals("CLARIN-DSpace " + Util.getSourceVersion(), rootRest.getDspaceVersion());
     }
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -42,6 +42,11 @@ dspace.ui.url = http://localhost:4000
 dspace.name = DSpace at My University
 dspace.shortname = DSpace
 
+# Prefix for the version string exposed at the REST root (/server/api), rendered by the UI as
+# the HTML <meta name="Generator"> value. Defaults to "DSpace" when unset; CLARIN/customer
+# deployments may set e.g. "CLARIN-DSpace".
+# dspace.version.prefix = DSpace
+
 # Assetstore configurations have moved to config/modules/assetstore.cfg
 # and config/spring/api/bitstore.xml.
 # Additional storage options (e.g. Amazon S3) are available in `assetstore.cfg`


### PR DESCRIPTION
## Problem
The version string exposed at the REST root (`GET /server/api` → `dspaceVersion`, rendered by the UI as `<meta name="Generator">`) is hardcoded to the `"DSpace "` prefix in `RootConverter`. CLARIN deployments need the `"CLARIN-DSpace"` identity, which was introduced by #985 and then accidentally dropped by the #1031 7.6.5 upgrade merge. Hardcoding it back would mis-brand the nine non-customer branches that should read `"DSpace"`.

Port of dataquest-dev/dspace-customers#903 (item 6). References `customer/lindat` `563ef4f366`/`0fea1de43c` for where the CLARIN prefix lived; reimplemented as a configurable property rather than a hardcode.

## Root cause
`RootConverter.convert()` built the version string as the literal `"DSpace " + getSourceVersion()`, so the prefix could only be changed by forking the converter per deployment — which is exactly what caused the identity to be lost across a merge.

## Change set
- `RootConverter.java` — read the prefix from a new `dspace.version.prefix` property, defaulting to `"DSpace"`, with a blank-value guard: `StringUtils.defaultIfBlank(configurationService.getProperty("dspace.version.prefix", "DSpace"), "DSpace")`. `getProperty(key, default)` only returns the default when the key is *absent*, so the `defaultIfBlank` wrapper also collapses a present-but-empty value back to `"DSpace"` (avoids a malformed leading-space version string). Behaviour is byte-for-byte unchanged unless a deployment sets a non-blank prefix.
- `dspace.cfg` — document the new property (commented-out default) next to `dspace.name`.
- `RootConverterTest.java` — stub the new property in `setUp` (existing assertions unchanged) and add `testConfigurableVersionPrefix`, asserting a `"CLARIN-DSpace"` override.

Scope: this PR makes only the REST-root generator string configurable (item 6's target). Other DSpace-branded surfaces (AIP/METS agent name, OpenAIRE `User-Agent`) remain hardcoded and are out of scope. The `dtq-dev` `HttpServletRequest`/`dspace.server.ssr.url` SSR-URL logic in `RootConverter` is untouched.

## Test evidence
```
$ mvn -pl dspace-server-webapp test -Dtest=RootConverterTest -DskipUnitTests=false
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 — in org.dspace.app.rest.converter.RootConverterTest
BUILD SUCCESS
  (5 = 4 existing REST-root tests, still green with the default "DSpace" prefix,
   + new testConfigurableVersionPrefix asserting a "CLARIN-DSpace" override)

$ mvn -pl dspace-server-webapp checkstyle:check
You have 0 Checkstyle violations.
BUILD SUCCESS
```
Note: the blank/absent fallback path is not yet covered by a dedicated test (the tests mock the 2-arg `getProperty` overload directly).

## Risk & rollback
Minimal. Default path is unchanged (`"DSpace"`). Revert = single commit revert; the config property is inert when unset.

## Notes / assumptions
Property name `dspace.version.prefix` chosen to sit alongside `dspace.name`/`dspace.shortname`. CLARIN branches opt in via `local.cfg` (`dspace.version.prefix = CLARIN-DSpace`); no code fork required going forward.

**Follow-up (not in this PR):** `customer/lindat` still hardcodes `"CLARIN-DSpace " + getSourceVersion()` in its `RootConverter` and sets `dspace.version.prefix` nowhere. Until it is migrated to consume the new property (drop the hardcode + set the value in cfg), this PR restores the CLARIN identity on zero deployments and the next `dtq-dev` → `lindat` merge will conflict on the same line again. That migration should be tracked as a separate task under dataquest-dev/dspace-customers#903.
