### PR TITLE
[Port to dtq-dev] Issue dspace-customers#903: drop hardcoded public. schema prefix from CLARIN migrations

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.2_2022.07.28__Upgrade_to_Lindat_Clarin_schema.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.2_2022.07.28__Upgrade_to_Lindat_Clarin_schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE license_definition (
     required_info varchar(256)
 );
 
-ALTER TABLE public.license_definition OWNER TO dspace;
+ALTER TABLE license_definition OWNER TO dspace;
 
 --
 -- Name: license_definition_license_id_seq; Type: SEQUENCE; Schema: public; Owner: dspace
@@ -44,7 +44,7 @@ CREATE SEQUENCE license_definition_license_id_seq
     NO MINVALUE
     CACHE 1;
 
-ALTER TABLE public.license_definition_license_id_seq OWNER TO dspace;
+ALTER TABLE license_definition_license_id_seq OWNER TO dspace;
 
 --
 -- Name: license_definition_license_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace
@@ -65,7 +65,7 @@ CREATE TABLE license_label (
 );
 
 
-ALTER TABLE public.license_label OWNER TO dspace;
+ALTER TABLE license_label OWNER TO dspace;
 
 --
 -- Name: license_label_extended_mapping; Type: TABLE; Schema: public; Owner: dspace; Tablespace:
@@ -77,7 +77,7 @@ CREATE TABLE license_label_extended_mapping (
     label_id integer
 );
 
-ALTER TABLE public.license_label_extended_mapping OWNER TO dspace;
+ALTER TABLE license_label_extended_mapping OWNER TO dspace;
 
 --
 -- Name: license_label_extended_mapping_mapping_id_seq; Type: SEQUENCE; Schema: public; Owner: dspace
@@ -91,7 +91,7 @@ CREATE SEQUENCE license_label_extended_mapping_mapping_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.license_label_extended_mapping_mapping_id_seq OWNER TO dspace;
+ALTER TABLE license_label_extended_mapping_mapping_id_seq OWNER TO dspace;
 
 --
 -- Name: license_label_extended_mapping_mapping_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace
@@ -118,7 +118,7 @@ CREATE SEQUENCE license_label_label_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.license_label_label_id_seq OWNER TO dspace;
+ALTER TABLE license_label_label_id_seq OWNER TO dspace;
 
 --
 -- Name: license_label_label_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace
@@ -144,7 +144,7 @@ CREATE TABLE license_resource_mapping (
 );
 
 
-ALTER TABLE public.license_resource_mapping OWNER TO dspace;
+ALTER TABLE license_resource_mapping OWNER TO dspace;
 
 --
 -- Name: license_resource_mapping_mapping_id_seq; Type: SEQUENCE; Schema: public; Owner: dspace
@@ -158,7 +158,7 @@ CREATE SEQUENCE license_resource_mapping_mapping_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.license_resource_mapping_mapping_id_seq OWNER TO dspace;
+ALTER TABLE license_resource_mapping_mapping_id_seq OWNER TO dspace;
 
 --
 -- Name: license_resource_mapping_mapping_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace
@@ -186,7 +186,7 @@ CREATE TABLE license_resource_user_allowance (
     token varchar(256)
 );
 
-ALTER TABLE public.license_resource_user_allowance OWNER TO dspace;
+ALTER TABLE license_resource_user_allowance OWNER TO dspace;
 
 --
 -- Name: license_resource_user_allowance_transaction_id_seq; Type: SEQUENCE; Schema: public; Owner: dspace
@@ -199,7 +199,7 @@ CREATE SEQUENCE license_resource_user_allowance_transaction_id_seq
     NO MINVALUE
     CACHE 1;
 
-ALTER TABLE public.license_resource_user_allowance_transaction_id_seq OWNER TO dspace;
+ALTER TABLE license_resource_user_allowance_transaction_id_seq OWNER TO dspace;
 
 --
 -- Name: license_resource_user_allowance_transaction_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace
@@ -224,7 +224,7 @@ CREATE TABLE user_registration (
     confirmation boolean DEFAULT true
 );
 
-ALTER TABLE public.user_registration OWNER TO dspace;
+ALTER TABLE user_registration OWNER TO dspace;
 
 CREATE SEQUENCE user_registration_user_registration_id_seq
     START WITH 1
@@ -233,7 +233,7 @@ CREATE SEQUENCE user_registration_user_registration_id_seq
     NO MINVALUE
     CACHE 1;
 
-ALTER TABLE public.user_registration_user_registration_id_seq OWNER TO dspace;
+ALTER TABLE user_registration_user_registration_id_seq OWNER TO dspace;
 
 --
 -- Name: user_registration_user_registration_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace
@@ -254,7 +254,7 @@ CREATE TABLE user_metadata (
 );
 
 
-ALTER TABLE public.user_metadata OWNER TO dspace;
+ALTER TABLE user_metadata OWNER TO dspace;
 
 --
 -- Name: user_metadata_user_metadata_id_seq; Type: SEQUENCE; Schema: public; Owner: dspace
@@ -268,7 +268,7 @@ CREATE SEQUENCE user_metadata_user_metadata_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.user_metadata_user_metadata_id_seq OWNER TO dspace;
+ALTER TABLE user_metadata_user_metadata_id_seq OWNER TO dspace;
 
 --
 -- Name: user_metadata_user_metadata_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2024.08.05__Added_Preview_Tables.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2024.08.05__Added_Preview_Tables.sql
@@ -19,7 +19,7 @@ CREATE TABLE previewcontent (
    size varchar(256)
 );
 
-ALTER TABLE public.previewcontent OWNER TO dspace;
+ALTER TABLE previewcontent OWNER TO dspace;
 
 --
 -- Name: previewcontent_previewcontent_id_seq; Type: SEQUENCE; Schema: public; Owner: dspace
@@ -32,7 +32,7 @@ CREATE SEQUENCE previewcontent_previewcontent_id_seq
     NO MINVALUE
     CACHE 1;
 
-ALTER TABLE public.previewcontent_previewcontent_id_seq OWNER TO dspace;
+ALTER TABLE previewcontent_previewcontent_id_seq OWNER TO dspace;
 
 --
 -- Name: previewcontent_previewcontent_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: dspace
@@ -64,7 +64,7 @@ CREATE TABLE preview2preview (
     name varchar(2000)
 );
 
-ALTER TABLE public.preview2preview OWNER TO dspace;
+ALTER TABLE preview2preview OWNER TO dspace;
 
 --
 -- Name: preview2preview_pkey; Type: CONSTRAINT; Schema: public; Owner: dspace; Tablespace:


### PR DESCRIPTION
## Problem
Two CLARIN Flyway migrations hardcode the `public.` schema prefix in their `ALTER TABLE … OWNER TO dspace` statements. Instances whose DSpace tables live in a non-`public` schema cannot run these migrations.

Port of dataquest-dev/dspace-customers#903 (item 5). Source: `customer/vsb-tuo` `e2fb08358e`.

## Root cause
`ALTER TABLE public.<name> OWNER TO dspace` binds the statement to the `public` schema instead of the connection's `search_path`. Dropping the qualifier lets each statement resolve against whatever schema the DSpace role actually uses.

## Change set
- `V7.2_2022.07.28__Upgrade_to_Lindat_Clarin_schema.sql` — 14 `ALTER TABLE public.X` → `ALTER TABLE X`.
- `V7.6_2024.08.05__Added_Preview_Tables.sql` — 3 `ALTER TABLE public.X` → `ALTER TABLE X`.

Only the `public.`-qualified `ALTER TABLE` statements change; `-- … Schema: public` comments are untouched. The unrelated `bitstore.xml` hunk in the source commit (`BitstreamStorageServiceImpl` → `SyncBitstreamStorageServiceImpl`) is **excluded** — it is a storage-bean swap unrelated to schema qualification, and `dtq-dev` already uses `SyncBitstreamStorageServiceImpl`.

## Test evidence
```
Static: git diff = 17 insertions / 17 deletions across the two migration files,
each an `ALTER TABLE public.X` -> `ALTER TABLE X` removal (no other lines touched;
`-- Schema: public` comments and legit `ALTER TABLE handle/...` statements unchanged).

Runtime before/after was NOT captured locally in this environment: the docker daemon is unavailable and the DSpace test-kernel cannot bootstrap in a standalone single-module run here (a pre-existing `ReportResultService` bean-wiring gap outside the full assembly, unrelated to this change -- it reproduces on a clean checkout). Runtime validation is delegated to this PR's CI Integration suite, which builds the full Spring context.
```

## Risk & rollback — ⚠️ FLYWAY CHECKSUM, NEEDS HUMAN REVIEW
These are **already-applied migrations**, so editing their content changes their Flyway checksum. Instances that already ran V7.2 / V7.6 with the old text will fail `flyway validate` on next startup unless a `flyway repair` is run there. Please confirm before merge:
- New / non-`public`-schema installs: safe and required (statements now resolve correctly).
- Existing `public`-schema installs (dtq-dev/ufal): will need a one-time `flyway repair` (checksum re-baseline). No data change — only the recorded checksum.

Per `reference/backend-stack.md`, Flyway migrations are append-only; this edit is an intentional, reviewed exception matching the customer report's "unconditionally safe" assessment for the affected instances. Flagging explicitly rather than assuming.

## Required upgrade step (existing installs)
Any instance that already ran V7.2 / V7.6 (dtq-dev, ufal, downstream CLARIN) must run a **one-time** Flyway repair after deploying this change, so the recorded checksums are re-baselined to the edited files:

```bash
./dspace database repair
```

This rewrites only the checksums in the `flyway_schema_history` table — no schema or data change. Without it, the next startup that carries any pending migration fails `flyway validate` on V7.2 / V7.6. Fresh installs need no action.

## Notes / assumptions
Pure DDL-qualifier change; no schema/data semantics change.

