### PR TITLE
[Port to dtq-dev] Issue dspace-customers#903: fix SWORDv2 item double-delete with WorkflowManagerDefault

### DIFF
--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.UUID;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -25,6 +26,7 @@ import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
+import org.dspace.event.Event;
 import org.dspace.workflow.WorkflowItem;
 import org.dspace.workflow.WorkflowItemService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
@@ -755,14 +757,19 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             WorkflowTools wft = new WorkflowTools();
             if (wft.isItemInWorkspace(swordContext.getContext(), item)) {
                 WorkspaceItem wsi = wft.getWorkspaceItem(context, item);
-                workspaceItemService.deleteWrapper(context, wsi);
+                workspaceItemService.deleteAll(context, wsi);
+                // the item is deleted in the above call
             } else if (wft.isItemInWorkflow(context, item)) {
                 WorkflowItem wfi = wft.getWorkflowItem(context, item);
                 workflowItemService.deleteWrapper(context, wfi);
             }
 
-            // then delete the item
-            itemService.delete(context, item);
+            // then delete the item, but only if it hasn't already been deleted by the methods above.
+            // the delete method is called in `workspaceItemService.deleteAll(context, wsi);`,
+            // so it should not be called again here, as that would throw an exception.
+            if (!isItemAlreadyDeleted(context, item.getID())) {
+                itemService.delete(context, item);
+            }
         } catch (SQLException | IOException e) {
             throw new DSpaceSwordException(e);
         } catch (AuthorizeException e) {
@@ -787,5 +794,21 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             "Location resolves to item with handle: " + item.getHandle());
 
         return item;
+    }
+
+    /**
+     * Check if the item is already deleted in the context.
+     */
+    private boolean isItemAlreadyDeleted(Context context, UUID itemUUID) {
+        if (context.getEvents() == null) {
+            return false;
+        }
+
+        for (Event event : context.getEvents()) {
+            if (event.getEventType() == Event.DELETE && event.getSubjectID().equals(itemUUID)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -797,7 +797,9 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
     }
 
     /**
-     * Check if the item is already deleted in the context.
+     * Returns true if a DELETE event for this item is already queued on the context
+     * (i.e. the item was deleted earlier in this transaction), so the caller can skip
+     * a second {@code itemService.delete()} that would otherwise fail.
      */
     private boolean isItemAlreadyDeleted(Context context, UUID itemUUID) {
         if (context.getEvents() == null) {
@@ -805,7 +807,9 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
         }
 
         for (Event event : context.getEvents()) {
-            if (event.getEventType() == Event.DELETE && event.getSubjectID().equals(itemUUID)) {
+            if (event.getEventType() == Event.DELETE
+                    && event.getSubjectType() == Constants.ITEM
+                    && itemUUID.equals(event.getSubjectID())) {
                 return true;
             }
         }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -757,16 +757,15 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             WorkflowTools wft = new WorkflowTools();
             if (wft.isItemInWorkspace(swordContext.getContext(), item)) {
                 WorkspaceItem wsi = wft.getWorkspaceItem(context, item);
-                workspaceItemService.deleteAll(context, wsi);
-                // the item is deleted in the above call
+                // remove only the workspace wrapper row; the item itself is deleted below.
+                workspaceItemService.deleteWrapper(context, wsi);
             } else if (wft.isItemInWorkflow(context, item)) {
                 WorkflowItem wfi = wft.getWorkflowItem(context, item);
                 workflowItemService.deleteWrapper(context, wfi);
             }
 
-            // then delete the item, but only if it hasn't already been deleted by the methods above.
-            // the delete method is called in `workspaceItemService.deleteAll(context, wsi);`,
-            // so it should not be called again here, as that would throw an exception.
+            // then delete the item, unless an upstream method already queued its deletion
+            // in this transaction (safety net against a double itemService.delete()).
             if (!isItemAlreadyDeleted(context, item.getID())) {
                 itemService.delete(context, item);
             }


### PR DESCRIPTION
## Summary
Adds a defensive guard to the SWORDv2 edit-media DELETE path (`ContainerManagerDSpace.doContainerDelete`) so the underlying `Item` is deleted at most once per transaction, even if an upstream method deletes it first. The workspace and workflow branches keep base's `deleteWrapper()` shape; only the final `itemService.delete()` is now guarded.

Relates to dataquest-dev/dspace-customers#903 (item 3).

## Background
Issue #903 (item 3) tracked a SWORDv2 item double-delete originally fixed on `dtq-dev` by `f79e7043fc` ("UFAL/Copy SWORDv2 fixes #957"). That historical bug came from `workspaceItemService.deleteAll()` (which deletes the item itself) followed by an **unguarded** `itemService.delete()`. The #1031 7.6.5 upgrade merge reverted the workspace path to `deleteWrapper()` + a single `itemService.delete()`, which is already double-delete-safe by construction — so **the current `dtq-dev` base does not double-delete on any path** (verified by trace and confirmed independently in review).

## Change set
`ContainerManagerDSpace.java` only:
- Add `isItemAlreadyDeleted(context, uuid)` — scans `context.getEvents()` for a pending `Event.DELETE` on `Constants.ITEM`, and guards the final `itemService.delete()` so it runs at most once.
- Add imports `java.util.UUID`, `org.dspace.event.Event` (and use `org.dspace.core.Constants`).
- Workspace and workflow branches keep `deleteWrapper()` — **unchanged from base**.

> An earlier revision of this PR switched the workspace path to `deleteAll()` + the guard; that was **reverted per review** (Copilot + integrator review). `deleteAll()` imposed a stricter admin-or-submitter authorization gate (which can only *narrow* authorization, never enable a delete) and reintroduced the very double-delete the guard then had to cancel. Keeping `deleteWrapper()` is simpler, matches base and the sibling workflow branch, and avoids the auth regression.

## Effect
**Behaviour-neutral vs base by design.** Nothing on the SWORDv2 delete path currently deletes the item before the final `itemService.delete()`, so the guard acts purely as a **safety net** — it changes behaviour only if a future upstream change deletes the item within the same transaction. The two pre-existing integration tests (`Swordv2IT.testDeleteWorkspaceManagerDefault`, `testDeleteWorkflowManagerDefault`) exercise the delete path and should remain green on both base and this branch.

## Validation
```
$ mvn -pl dspace-swordv2 checkstyle:check
0 Checkstyle violations -> BUILD SUCCESS
$ mvn -pl dspace-swordv2 -am compile
BUILD SUCCESS
```
Runtime integration tests are delegated to CI (docker unavailable locally).

## Risk & rollback
Isolated to the SWORDv2 delete path; the guard is inert in normal operation. Revert = single commit.
