### PR TITLE
[Port to dtq-dev] Issue dspace-customers#903: harden LDAP auth (email fallback, groupmap guard, logging)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -756,11 +756,11 @@ public class LDAPAuthentication implements AuthenticationMethod {
             // groupmap contains the mapping of LDAP groups to DSpace groups
             // outer loop with the DSpace groups
             while (groupMap != null) {
-                String t[] = groupMap.split(":");
-                if (t.length < 2) {
+                String t[] = groupMap.split(":", 2);
+                if (t.length < 2 || StringUtils.isBlank(t[0]) || StringUtils.isBlank(t[1])) {
                     log.error(LogHelper.getHeader(context, "assignGroups",
                         "malformed groupmap entry at index " + groupmapIndex + ": " + groupMap +
-                        " - missing ':' separator"));
+                        " - expected '<ldapSearchFragment>:<dspaceGroupName>' with both parts non-empty"));
                     groupMap = configurationService.getProperty(
                             "authentication-ldap.login.groupmap." + ++groupmapIndex);
                     continue;

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -391,8 +391,9 @@ public class LDAPAuthentication implements AuthenticationMethod {
     private void setEpersonAttributes(Context context, EPerson eperson, SpeakerToLDAP ldap,
                                       Optional<String> netid, String email) throws SQLException {
 
-        // Set the e-mail: prefer the LDAP-provided address, otherwise the one the user logged in with,
-        // so an EPerson is never persisted with a null e-mail.
+        // Set the e-mail: prefer the LDAP-provided address, otherwise fall back to the
+        // login e-mail when one was supplied. If neither is available, the existing
+        // e-mail is left unchanged.
         if (StringUtils.isNotEmpty(ldap.ldapEmail)) {
             eperson.setEmail(ldap.ldapEmail);
         } else if (StringUtils.isNotEmpty(email)) {
@@ -746,7 +747,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
      */
     private void assignGroups(String dn, ArrayList<String> group, Context context) {
         if (StringUtils.isNotBlank(dn)) {
-            log.info(LogHelper.getHeader(context, "assignGroups", "dn=" + dn));
+            log.debug(LogHelper.getHeader(context, "assignGroups", "dn=" + dn));
             int groupmapIndex = 1;
             String groupMap = configurationService.getProperty("authentication-ldap.login.groupmap." + groupmapIndex);
             boolean cmp;

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -322,7 +322,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
                             log.info(LogHelper.getHeader(context,
                                                           "type=ldap-login", "type=ldap_but_already_email"));
                             context.turnOffAuthorisationSystem();
-                            setEpersonAttributes(context, eperson, ldap, Optional.of(netid));
+                            setEpersonAttributes(context, eperson, ldap, Optional.of(netid), email);
                             ePersonService.update(context, eperson);
                             context.dispatchEvents();
                             context.restoreAuthSystemState();
@@ -339,7 +339,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
                                 try {
                                     context.turnOffAuthorisationSystem();
                                     eperson = ePersonService.create(context);
-                                    setEpersonAttributes(context, eperson, ldap, Optional.of(netid));
+                                    setEpersonAttributes(context, eperson, ldap, Optional.of(netid), email);
                                     eperson.setCanLogIn(true);
                                     authenticationService.initEPerson(context, request, eperson);
                                     ePersonService.update(context, eperson);
@@ -382,9 +382,21 @@ public class LDAPAuthentication implements AuthenticationMethod {
      */
     private void setEpersonAttributes(Context context, EPerson eperson, SpeakerToLDAP ldap, Optional<String> netid)
         throws SQLException {
+        setEpersonAttributes(context, eperson, ldap, netid, null);
+    }
 
+    /**
+     * Update eperson's attributes, falling back to the supplied login e-mail when LDAP has none.
+     */
+    private void setEpersonAttributes(Context context, EPerson eperson, SpeakerToLDAP ldap,
+                                      Optional<String> netid, String email) throws SQLException {
+
+        // Set the e-mail: prefer the LDAP-provided address, otherwise the one the user logged in with,
+        // so an EPerson is never persisted with a null e-mail.
         if (StringUtils.isNotEmpty(ldap.ldapEmail)) {
             eperson.setEmail(ldap.ldapEmail);
+        } else if (StringUtils.isNotEmpty(email)) {
+            eperson.setEmail(email);
         }
         if (StringUtils.isNotEmpty(ldap.ldapGivenName)) {
             eperson.setFirstName(context, ldap.ldapGivenName);
@@ -734,7 +746,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
      */
     private void assignGroups(String dn, ArrayList<String> group, Context context) {
         if (StringUtils.isNotBlank(dn)) {
-            System.out.println("dn:" + dn);
+            log.info(LogHelper.getHeader(context, "assignGroups", "dn=" + dn));
             int groupmapIndex = 1;
             String groupMap = configurationService.getProperty("authentication-ldap.login.groupmap." + groupmapIndex);
             boolean cmp;
@@ -744,6 +756,15 @@ public class LDAPAuthentication implements AuthenticationMethod {
             // outer loop with the DSpace groups
             while (groupMap != null) {
                 String t[] = groupMap.split(":");
+                if (t.length < 2) {
+                    log.error(LogHelper.getHeader(context, "assignGroups",
+                        "malformed groupmap entry at index " + groupmapIndex + ": " + groupMap +
+                        " - missing ':' separator"));
+                    groupMap = configurationService.getProperty(
+                            "authentication-ldap.login.groupmap." + ++groupmapIndex);
+                    continue;
+                }
+
                 String ldapSearchString = t[0];
                 String dspaceGroupName = t[1];
 


### PR DESCRIPTION
## Problem
Three defects in LDAP authentication (`LDAPAuthentication.java`):
1. A first-time LDAP login whose LDAP record has no `mail` attribute creates/updates an `EPerson` with a **null** e-mail, even when the user typed a valid e-mail to log in.
2. A `groupmap` config entry missing its `:` separator throws `ArrayIndexOutOfBoundsException` and aborts group assignment.
3. The distinguished name is dumped to stdout via `System.out.println("dn:" + dn)` instead of the logger.

Port of dataquest-dev/dspace-customers#903 (item 2). Only the `LDAPAuthentication.java` hunks are ported; the customer's `authentication-ldap.cfg` / Dockerfile changes stay on `customer/vsb-tuo`.

### Source provenance (verified by diff, not commit message)
The issue's item 2 cites `b64b7859b4`, `40e30e6fdd`, `1047f4d787`, but only one of those touches this file:
- **e-mail fallback** → `customer/vsb-tuo` `40e30e6fdd`.
- **groupmap guard + stdout→log** → `customer/vsb-tuo` `a097b030b1` ("Added logs to see more info about ldap error") — not listed in the issue; the two cited siblings `b64b7859b4` (`authentication.cfg`) and `1047f4d787` (Dockerfile) are config-only and out of scope.

## Root cause
1. `setEpersonAttributes()` set the e-mail only from `ldap.ldapEmail`; when that was empty there was no fallback to the address the user authenticated with.
2. `assignGroups()` did `String t[] = groupMap.split(":"); … t[1]` with no length check.
3. Debug leftover writing to stdout.

## Change set
`LDAPAuthentication.java` only:
- Add an overload `setEpersonAttributes(context, eperson, ldap, netid, email)`; when `ldap.ldapEmail` is empty, fall back to the supplied `email`. The effective fix is in the self-register/create branch (a freshly created `EPerson` otherwise persists with a null mail); the already-registered-by-mail branch also passes it (harmless — that record was just looked up by that e-mail). The original 4-arg signature delegates with `null`, so other callers are unchanged.
- In `assignGroups()`, guard the `groupmap` entry parse: split on the first `:` (`split(":", 2)`) and skip the entry (log an error naming the index, `continue` to the next `groupmap.<n>`) when it has fewer than 2 fields **or** either part is blank. This stops the original `ArrayIndexOutOfBoundsException` and also rejects an empty search fragment such as `:group`, which would otherwise match every DN and assign the mapped group to all LDAP users.
- Replace `System.out.println("dn:" + dn)` with `log.debug(LogHelper.getHeader(context, "assignGroups", "dn=" + dn))` — DEBUG (not INFO) to match the existing `got DN` line and keep a semi-sensitive DN off the default log level.

Not ported: the source's verbose per-iteration `log.info` array-dump lines (debug scaffolding) — omitted per `reference/coding-standards.md` (no narration logging). Only the functional guard + a single dn log line are kept. This accounts for the smaller diff vs the customer commits.

## Review addressed (commit `640f46bd88`)
- DN log lowered `INFO` → `DEBUG` (Copilot: DN at INFO is semi-sensitive / verbose).
- Reworded the `setEpersonAttributes` e-mail comment to match the code — the method leaves the e-mail unchanged when neither LDAP nor the login address supplies one; the non-null guarantee for the create paths lives in the caller (lines 302–318), not this method.
- Both Copilot review threads resolved. No behavior change.

## Test evidence
```
$ mvn -pl dspace-api checkstyle:check   -> 0 violations, BUILD SUCCESS
$ mvn -pl dspace-api compile            -> BUILD SUCCESS
```
LDAP first-login (e-mail fallback path) is not reproducible in the local stack (no LDAP directory server), so per `docker-setup` §7 that part is stated, not faked. The **groupmap guard is pure config-string parsing and is unit-testable without LDAP** — a focused test for the malformed-entry case is a reasonable follow-up (see open point below).

Behaviour delta:
1. e-mail fallback fills a previously-null `EPerson.mail` in the create path;
2. a `groupmap` entry with no `:` now logs an error and is skipped instead of throwing `ArrayIndexOutOfBoundsException`;
3. the dn is logged via `LogHelper` at DEBUG, not printed to stdout.

## Risk & rollback
Confined to LDAP login. The e-mail fallback only fills a value that was previously null; the groupmap guard only adds a skip on malformed config; the log line replaces stdout. Revert = drop the two commits on this branch.

## Open points (non-blocking)
- No automated test lands with this port. The login/e-mail paths need a directory server, but the **groupmap guard does not** — a unit test for the malformed-`groupmap` case is the one gap worth closing (tracked as follow-up rather than expanding this PR's scope).
- Tracking issue is cross-repo (`dspace-customers#903`), so GitHub's development section cannot auto-link it; the reference above is the trace. A status/provenance note is posted on #903.

## Notes / assumptions
LDAP directory config is customer-specific and intentionally left on `customer/vsb-tuo`.
