### PR TITLE
[Port to dtq-dev] Log unparsable-PDF filter-media errors as WARN, not ERROR

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -8,6 +8,7 @@
 package org.dspace.app.mediafilter;
 
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.logging.log4j.Logger;
@@ -78,6 +79,13 @@ public class PDFBoxThumbnail extends MediaFilter {
             buf = renderer.renderImage(0);
         } catch (InvalidPasswordException ex) {
             log.error("PDF is encrypted. Cannot create thumbnail (item: {})", currentItem::getHandle);
+            return null;
+        } catch (IOException ex) {
+            // A malformed/non-standard PDF (bad %PDF- header, missing xref, truncated file, etc.)
+            // is a data-quality issue in the source bitstream, not a DSpace fault. Skip the
+            // thumbnail instead of failing the whole filter-media run.
+            log.warn("PDF could not be parsed by PDFBox. Cannot create thumbnail (item: {}): {}",
+                    currentItem::getHandle, ex::getMessage);
             return null;
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
@@ -85,10 +85,13 @@ public class TikaTextExtractionFilter
             tika.setMaxStringLength(maxChars); // Tell Tika the maximum number of characters to extract
             extractedText = tika.parseToString(source);
         } catch (IOException e) {
-            System.err.format("Unable to extract text from bitstream in Item %s%n", currentItem.getID().toString());
-            e.printStackTrace(System.err);
-            log.error("Unable to extract text from bitstream in Item {}", currentItem.getID().toString(), e);
-            throw e;
+            // A malformed/non-standard source file (e.g. a PDF with a corrupt header, missing
+            // xref, or truncated content) is a data-quality issue in the bitstream, not a
+            // DSpace fault. Skip text extraction for it instead of failing the whole
+            // filter-media run.
+            log.warn("Unable to extract text from bitstream in Item {}: {}",
+                    currentItem.getHandle(), e.getMessage());
+            return null;
         } catch (OutOfMemoryError oe) {
             System.err.format("OutOfMemoryError occurred when extracting text from bitstream in Item %s. " +
                 "You may wish to enable 'textextractor.use-temp-file'.%n", currentItem.getID().toString());


### PR DESCRIPTION
## Problem description
The nightly `filter-media` job logs thousands of ERROR lines (~4,655/night on the source instance) when it meets malformed/corrupt PDFs: `PDFBoxThumbnail` and `TikaTextExtractionFilter` let the parse `IOException` escape, and `MediaFilterServiceImpl` re-logs it at ERROR, tripping log-based alerting even though the job already skips the file and continues.

## Analysis
Cherry-pick of `customer/TUL` commit 7035a4c417a22cdd3d426ea5e73158fb2583ebeb. Both filters now catch the parse `IOException`, log at WARN with the item handle, and return null so the bitstream is skipped cleanly. The diff matches the TUL commit except one context line (`dtq-dev` has `e.printStackTrace(System.err)`).

Known limits, same as on TUL: an assetstore read `IOException` on these two paths is downgraded too, and the `textextractor.use-temp-file` Tika path still throws on a corrupt PDF. Vanilla has no fix for this on any branch.

### Manual Testing (if applicable)
- [ ] Added to testing scenarios (dspace-customers issue 55)

### Copilot review
- [ ] Requested review from Copilot