### PR TITLE
[Port to dtq-dev] Issue dspace-customers#903: stop ItemConverter writing to the DB on every item GET

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -50,6 +50,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -179,6 +180,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Autowired
     private VersionHistoryService versionHistoryService;
+
+    @Autowired(required = true)
+    private ClarinItemService clarinItemService;
 
     @Autowired(required = true)
     ClarinMatomoBitstreamTracker matomoBitstreamTracker;
@@ -686,6 +690,11 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         if (item.isMetadataModified() || item.isModified()) {
+            // Derive dc.date.issued from local.approximateDate.issued when metadata changes
+            if (item.isMetadataModified()) {
+                clarinItemService.updateItemDatesMetadata(context, item);
+            }
+
             // Set the last modified date
             item.setLastModified(new Date());
 

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -229,10 +229,11 @@ public class ClarinItemServiceImpl implements ClarinItemService {
             return;
         }
 
-        // Skip the write when dc.date.issued already holds the derived value
+        // Skip the write only when dc.date.issued already holds exactly the single derived value.
+        // A multi-valued field must still be normalized down to the single derived value.
         List<MetadataValue> currentDateIssued =
                 itemService.getMetadata(item, "dc", "date", "issued", Item.ANY, false);
-        if (CollectionUtils.isNotEmpty(currentDateIssued)
+        if (currentDateIssued.size() == 1
                 && derivedDate.equals(currentDateIssued.get(0).getValue())) {
             return;
         }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinItemServiceImpl.java
@@ -223,12 +223,32 @@ public class ClarinItemServiceImpl implements ClarinItemService {
             return;
         }
 
+        String derivedDate = deriveDateIssuedFromApproximateDate(item);
+        if (derivedDate == null) {
+            log.debug("Cannot update item dates metadata because the approximate date is empty.");
+            return;
+        }
+
+        // Skip the write when dc.date.issued already holds the derived value
+        List<MetadataValue> currentDateIssued =
+                itemService.getMetadata(item, "dc", "date", "issued", Item.ANY, false);
+        if (CollectionUtils.isNotEmpty(currentDateIssued)
+                && derivedDate.equals(currentDateIssued.get(0).getValue())) {
+            return;
+        }
+
+        // Clear the current `dc.date.issued` metadata and set it to the derived value
+        itemService.clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
+        itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY, derivedDate);
+    }
+
+    @Override
+    public String deriveDateIssuedFromApproximateDate(Item item) {
         List<MetadataValue> approximatedDates =
                 itemService.getMetadata(item, "local", "approximateDate", "issued", Item.ANY, false);
 
         if (CollectionUtils.isEmpty(approximatedDates) || StringUtils.isBlank(approximatedDates.get(0).getValue())) {
-            log.debug("Cannot update item dates metadata because the approximate date is empty.");
-            return;
+            return null;
         }
 
         // Get the approximate date value from the metadata
@@ -239,21 +259,11 @@ public class ClarinItemServiceImpl implements ClarinItemService {
         // Trim the list of years - remove leading and trailing whitespaces
         listOfYearValues.replaceAll(String::trim);
 
-        try {
-            // Clear the current `dc.date.issued` metadata
-            itemService.clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
-
-            // Update the `dc.date.issued` metadata with a new value: `0000` or the last year from the sequence
-            if (CollectionUtils.isNotEmpty(listOfYearValues) && isListOfNumbers(listOfYearValues)) {
-                // Take the last year from the list of years and add it to the `dc.date.issued` metadata
-                itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY,
-                        getLastNumber(listOfYearValues));
-            } else {
-                // Add the `0000` value to the `dc.date.issued` metadata
-                itemService.addMetadata(context, item, "dc", "date", "issued", Item.ANY, NO_YEAR);
-            }
-        } catch (SQLException e) {
-            log.error("Cannot remove `dc.date.issued` metadata because: {}", e.getMessage());
+        // `0000` when the approximate date is not a list of numbers, otherwise the last year in the sequence
+        if (CollectionUtils.isNotEmpty(listOfYearValues) && isListOfNumbers(listOfYearValues)) {
+            return getLastNumber(listOfYearValues);
+        } else {
+            return NO_YEAR;
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/ClarinItemService.java
@@ -102,4 +102,16 @@ public interface ClarinItemService {
      */
     void updateItemDatesMetadata(Context context, Item item) throws SQLException;
 
+    /**
+     * Derive the display value for {@code dc.date.issued} from the item's
+     * {@code local.approximateDate.issued} metadata, without touching the database.
+     * Returns the last year for a numeric sequence (e.g. "1938, 1945" -&gt; "1945"),
+     * {@code "0000"} for a non-numeric approximate value, or {@code null} when no
+     * approximate date is present.
+     *
+     * @param item the item to derive the date from
+     * @return the derived {@code dc.date.issued} value, or {@code null} if none applies
+     */
+    String deriveDateIssuedFromApproximateDate(Item item);
+
 }

--- a/dspace-api/src/test/java/org/dspace/content/clarin/ClarinItemServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/clarin/ClarinItemServiceImplTest.java
@@ -1,0 +1,146 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.clarin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Pure unit tests for {@link ClarinItemServiceImpl}: the {@code dc.date.issued} derivation
+ * from {@code local.approximateDate.issued}, and the normalization guard in
+ * {@code updateItemDatesMetadata}. Fully mocked — no DSpace kernel or database.
+ *
+ * @author dataquest
+ */
+public class ClarinItemServiceImplTest {
+
+    private ItemService itemService;
+    private ClarinItemServiceImpl clarinItemService;
+    private Item item;
+    private Context context;
+
+    @Before
+    public void setUp() {
+        itemService = mock(ItemService.class);
+        item = mock(Item.class);
+        context = mock(Context.class);
+        clarinItemService = new ClarinItemServiceImpl();
+        ReflectionTestUtils.setField(clarinItemService, "itemService", itemService);
+    }
+
+    private MetadataValue mv(String value) {
+        MetadataValue metadataValue = mock(MetadataValue.class);
+        when(metadataValue.getValue()).thenReturn(value);
+        return metadataValue;
+    }
+
+    private void mockApproximateDate(String value) {
+        List<MetadataValue> values = value == null ? Collections.emptyList() : Collections.singletonList(mv(value));
+        when(itemService.getMetadata(item, "local", "approximateDate", "issued", Item.ANY, false))
+                .thenReturn(values);
+    }
+
+    private void mockCurrentDateIssued(List<MetadataValue> values) {
+        when(itemService.getMetadata(item, "dc", "date", "issued", Item.ANY, false)).thenReturn(values);
+    }
+
+    // ---- deriveDateIssuedFromApproximateDate (pure, no DB) ----
+
+    @Test
+    public void derive_returnsNull_whenNoApproximateDate() {
+        mockApproximateDate(null);
+        assertNull(clarinItemService.deriveDateIssuedFromApproximateDate(item));
+    }
+
+    @Test
+    public void derive_returnsNull_whenApproximateDateBlank() {
+        mockApproximateDate("   ");
+        assertNull(clarinItemService.deriveDateIssuedFromApproximateDate(item));
+    }
+
+    @Test
+    public void derive_returnsNoYear_whenNonNumeric() {
+        mockApproximateDate("spring 1945");
+        assertEquals("0000", clarinItemService.deriveDateIssuedFromApproximateDate(item));
+    }
+
+    @Test
+    public void derive_returnsLastYear_whenNumericSequence() {
+        mockApproximateDate("1938, 1945, 2022");
+        assertEquals("2022", clarinItemService.deriveDateIssuedFromApproximateDate(item));
+    }
+
+    @Test
+    public void derive_returnsSingleYear() {
+        mockApproximateDate("1990");
+        assertEquals("1990", clarinItemService.deriveDateIssuedFromApproximateDate(item));
+    }
+
+    // ---- updateItemDatesMetadata: skip-write / normalization guard ----
+
+    @Test
+    public void update_skipsWrite_whenSingleValueAlreadyDerived() throws SQLException {
+        mockApproximateDate("2022");
+        mockCurrentDateIssued(Collections.singletonList(mv("2022")));
+
+        clarinItemService.updateItemDatesMetadata(context, item);
+
+        verify(itemService, never()).clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
+        verify(itemService, never()).addMetadata(context, item, "dc", "date", "issued", Item.ANY, "2022");
+    }
+
+    @Test
+    public void update_normalizesMultiValue_evenWhenFirstMatchesDerived() throws SQLException {
+        // Regression guard: a multi-valued dc.date.issued must still be collapsed to the single derived value,
+        // even if the first stored value already equals the derived one.
+        mockApproximateDate("2022");
+        mockCurrentDateIssued(Arrays.asList(mv("2022"), mv("1999")));
+
+        clarinItemService.updateItemDatesMetadata(context, item);
+
+        verify(itemService).clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
+        verify(itemService).addMetadata(context, item, "dc", "date", "issued", Item.ANY, "2022");
+    }
+
+    @Test
+    public void update_writes_whenSingleValueDiffers() throws SQLException {
+        mockApproximateDate("2022");
+        mockCurrentDateIssued(Collections.singletonList(mv("1900")));
+
+        clarinItemService.updateItemDatesMetadata(context, item);
+
+        verify(itemService).clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
+        verify(itemService).addMetadata(context, item, "dc", "date", "issued", Item.ANY, "2022");
+    }
+
+    @Test
+    public void update_skips_whenApproximateDateEmpty() throws SQLException {
+        mockApproximateDate(null);
+
+        clarinItemService.updateItemDatesMetadata(context, item);
+
+        verify(itemService, never()).clearMetadata(context, item, "dc", "date", "issued", Item.ANY);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.converter;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -18,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.MetadataValueList;
+import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.content.Item;
@@ -27,7 +29,6 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.clarin.ClarinItemService;
 import org.dspace.core.Context;
 import org.dspace.discovery.IndexableObject;
-import org.dspace.services.model.Request;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
@@ -53,18 +54,6 @@ public class ItemConverter
 
     @Override
     public ItemRest convert(Item obj, Projection projection) {
-        Context context = null;
-        Request currentRequest = requestService.getCurrentRequest();
-        if (currentRequest != null) {
-            context = ContextUtil.obtainContext(currentRequest.getHttpServletRequest());
-        }
-        try {
-            clarinItemService.updateItemDatesMetadata(context, obj);
-        } catch (SQLException e) {
-            log.error("Error updating item dates metadata", e);
-            throw new RuntimeException(e);
-        }
-
         ItemRest item = super.convert(obj, projection);
         item.setInArchive(obj.isArchived());
         item.setDiscoverable(obj.isDiscoverable());
@@ -77,7 +66,38 @@ public class ItemConverter
             item.setEntityType(entityTypes.get(0).getValue());
         }
 
+        // Override dc.date.issued on the REST DTO with the value derived from
+        // local.approximateDate.issued. Display-only: it does not modify the entity or the database.
+        overrideDateIssuedFromApproximateDate(obj, item);
+
         return item;
+    }
+
+    /**
+     * If the item has a {@code local.approximateDate.issued} value, override {@code dc.date.issued}
+     * on the REST DTO using {@link ClarinItemService#deriveDateIssuedFromApproximateDate(Item)}.
+     * Display-only (no database writes); skipped when {@code dc.date.issued} is hidden.
+     */
+    private void overrideDateIssuedFromApproximateDate(Item source, ItemRest target) {
+        String derivedValue = clarinItemService.deriveDateIssuedFromApproximateDate(source);
+        if (derivedValue == null) {
+            return;
+        }
+
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        try {
+            if (metadataExposureService.isHidden(context, "dc", "date", "issued", source)) {
+                return;
+            }
+        } catch (SQLException e) {
+            log.error("Error checking metadata visibility for dc.date.issued", e);
+            return;
+        }
+
+        MetadataValueRest dateRest = new MetadataValueRest(derivedValue);
+        dateRest.setConfidence(-1);
+        dateRest.setPlace(0);
+        target.getMetadata().getMap().put("dc.date.issued", Collections.singletonList(dateRest));
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.converter;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -96,8 +95,8 @@ public class ItemConverter
 
         MetadataValueRest dateRest = new MetadataValueRest(derivedValue);
         dateRest.setConfidence(-1);
-        dateRest.setPlace(0);
-        target.getMetadata().getMap().put("dc.date.issued", Collections.singletonList(dateRest));
+        // MetadataRest#put normalizes place and keeps Arrays.asList semantics consistent with other fields
+        target.getMetadata().put("dc.date.issued", dateRest);
     }
 
     /**


### PR DESCRIPTION
## Problem
Every REST `GET` of an item triggered database writes. `ItemConverter.convert()` — invoked during read-only serialization — called `ClarinItemService.updateItemDatesMetadata()`, which does `clearMetadata`/`addMetadata`. This caused Hibernate dirty-checking and DB writes on read (rolled back by `DSpaceRequestContextFilter.abort()`), plus per-request log noise, on every item GET.

Port of dataquest-dev/dspace-customers#903 (**item 1** of a 6-item umbrella). Source: `customer/zcu-data` `24f31c330d` — cherry-pick conflicted (see below), applied as an adapted port.

## Root cause
Date-derivation (turn `local.approximateDate.issued` into `dc.date.issued`) is a **write** that was being run from a **read** path so that stale DB values would still display correctly. The write belongs in `update()`; the display correction belongs on the DTO.

## Change set
Split derivation (pure) from persistence (write):
- `ClarinItemService` (interface) — add `deriveDateIssuedFromApproximateDate(Item)`.
- `ClarinItemServiceImpl` — extract the parsing into `deriveDateIssuedFromApproximateDate()` (returns the derived year, `"0000"`, or `null`); `updateItemDatesMetadata()` delegates to it and writes only when the stored value differs — skipping the write only when `dc.date.issued` already holds **exactly one** value equal to the derived one (multi-valued fields are still normalized to the single derived value). **Kept dtq-dev's `log.debug`** for the empty-approximate-date case (the WARN→DEBUG change already landed on dtq-dev via `84e9f3a2c2`; the source commit still had `log.warn`, which is why the cherry-pick conflicted here).
- `ItemServiceImpl.update()` — call `clarinItemService.updateItemDatesMetadata()` inside the existing `isMetadataModified()` guard, so the date is derived and persisted only when metadata actually changes (PATCH/PUT).
- `ItemConverter.convert()` — remove the write-on-read call; instead override `dc.date.issued` on the `ItemRest` DTO from the derived value via `MetadataRest#put` (display-only, honouring `metadataExposureService.isHidden`). No entity mutation, no DB write.

## Review updates (`b238a0b397`)
Both Copilot review comments addressed and unit coverage added:
- **Skip-guard** (`ClarinItemServiceImpl`) — skip the write only for a single already-derived value; a multi-valued `dc.date.issued` is still collapsed to the single derived value (was skipping on a first-value match).
- **DTO write** (`ItemConverter`) — build the derived value via `MetadataRest#put` (place normalization + `Arrays.asList` semantics, consistent with other fields) instead of `getMap().put(Collections.singletonList(...))`; dropped the manual `setPlace(0)` and the now-unused `Collections` import.
- **Tests** — new `ClarinItemServiceImplTest` (9 pure-Mockito unit tests) covering derivation (empty / blank / non-numeric / sequence / single) and the skip/normalize guard.

## Validation
```
mvn -pl dspace-api           checkstyle:check                            -> 0 violations
mvn -pl dspace-server-webapp checkstyle:check                            -> 0 violations
mvn -pl dspace-server-webapp -am compile                                 -> BUILD SUCCESS
mvn -pl dspace-api -DskipUnitTests=false -Dtest=ClarinItemServiceImplTest test
                                                                         -> Tests run: 9, Failures: 0
```
The no-write property is covered **structurally** (the converter no longer calls `updateItemDatesMetadata`) plus the unit-level skip/normalize guard. Full-context runtime (docker / DSpace test-kernel) is not bootstrappable in this environment. CI exercises the approximate-date **display** path via `ItemRestRepositoryIT` — note those ITs assert the displayed value; they are not a dedicated "no DB write on GET" assertion.

## Risk & rollback
Touches core CLARIN item serialization and `ItemServiceImpl.update()`. For the standard read/display path, behaviour is preserved: items with `local.approximateDate.issued` still show the derived `dc.date.issued` in REST responses, and the value is now persisted on metadata change (previously the read-path write was always rolled back, so nothing was ever persisted). Regression focus: approximate-date handling. Revert = single commit.

## Behaviour notes
- With `local.approximateDate.issued` present it is authoritative: any metadata-modifying `update()` (PATCH/PUT) derives and overwrites `dc.date.issued`, so a client-supplied `dc.date.issued` is replaced. This matches what the REST API already displayed.
- Non-numeric approximate dates normalize to `"0000"`.
- Existing items are normalized on their **next** metadata edit only (no backfill migration); non-REST consumers (OAI-PMH, Solr) read the stored value — unchanged from before this PR.

## Notes / assumptions
Conflict resolution kept dtq-dev-side changes (the `log.debug` downgrade). The four-file split matches the source commit's intent; the display-only override reuses the shared derivation rather than duplicating parsing.
