### PR TITLE
test: de-flake scheduled ITs (test-planted handle collisions, leaked bitstream formats, stale Solr searcher)

### DIFF
--- a/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Random;
 
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -58,7 +57,9 @@ import org.junit.Test;
 public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
     private static final String TASK_NAME = "checkhandles";
 
-    private static final String HANDLE_COLLECTION = "123456789/" + randomString();
+    // Non-numeric suffix the handle sequence can never mint, unique to this class so it cannot
+    // clash with leftover handle rows of other tests either.
+    private static final String HANDLE_COLLECTION = "123456789/handle-checker-test";
 
     private static final String HANDLE_ITEM1 = HANDLE_COLLECTION + "-1";
     private static final String HANDLE_ITEM2 = HANDLE_COLLECTION + "-2";
@@ -279,11 +280,5 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
 
     private List<MetadataValue> getIdentifierUris(Item item) {
         return itemService.getMetadata(item, "dc", "identifier", "uri", Item.ANY);
-    }
-
-    private static String randomString() {
-        Random r = new Random();
-        // Generate random integers in range 1000 to 1999
-        return String.valueOf(1000 + r.nextInt(1000));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Random;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;
@@ -44,7 +43,9 @@ import org.junit.Test;
 public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
     private static final String TASK_NAME = "requiredmetadata";
 
-    private static final String HANDLE_COLLECTION = "123456789/" + randomString();
+    // Non-numeric suffix the handle sequence can never mint, unique to this class so it cannot
+    // clash with leftover handle rows of other tests either.
+    private static final String HANDLE_COLLECTION = "123456789/required-metadata-test";
     private static final String HANDLE_ITEM1 = HANDLE_COLLECTION + "-1";
     private static final String HANDLE_ITEM2 = HANDLE_COLLECTION + "-2";
     private static final String HANDLE_ITEM3 = HANDLE_COLLECTION + "-3";
@@ -152,12 +153,6 @@ public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
 
     private static String successResultForItem(Item item) {
         return "Item: " + item.getHandle() + " has all required fields";
-    }
-
-    private static String randomString() {
-        Random r = new Random();
-        // Generate random integers in range 1000 to 1999
-        return String.valueOf(1000 + r.nextInt(1000));
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowFactoryTest.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowFactoryTest.java
@@ -70,7 +70,9 @@ public class XmlWorkflowFactoryTest extends AbstractUnitTest {
             this.owningCommunity = communityService.create(null, context);
             this.mappedCollection =
                     this.collectionService.create(context, owningCommunity, "123456789/workflow-test-1");
-            this.nonMappedCollection = this.collectionService.create(context, owningCommunity, "123456789/999");
+            // Non-numeric suffix so the handle sequence can never mint a colliding handle
+            this.nonMappedCollection =
+                    this.collectionService.create(context, owningCommunity, "123456789/workflow-test-2");
             //we need to commit the changes so we don't block the table for testing
             context.restoreAuthSystemState();
         } catch (SQLException e) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
@@ -21,7 +21,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,7 +38,9 @@ import org.dspace.core.I18nUtil;
 import org.dspace.eperson.EPerson;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -56,7 +57,8 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
     @Autowired
     private BitstreamFormatConverter bitstreamFormatConverter;
 
-    private final int DEFAULT_AMOUNT_FORMATS = 95;
+    @Rule
+    public TestName testName = new TestName();
 
     @Test
     public void findAllPaginationTest() throws Exception {
@@ -136,7 +138,7 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
     @Test
     public void createAdminAccess() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
+        BitstreamFormatRest bitstreamFormatRest = this.createMockBitstreamRest();
 
         //Create bitstream format
         String token = getAuthToken(admin.getEmail(), password);
@@ -145,10 +147,15 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
         AtomicReference<Integer> idRef = new AtomicReference<>();
         try {
 
+            // Capture the id right after the status check, so the format is cleaned up even when
+            // a later assertion in this test fails.
             MvcResult mvcResult = getClient(token).perform(post("/api/core/bitstreamformats/")
                                                   .content(mapper.writeValueAsBytes(bitstreamFormatRest))
                                                                    .contentType(contentType))
                                                   .andExpect(status().isCreated())
+                                                  .andDo(result -> idRef
+                                                          .set(read(result.getResponse().getContentAsString(),
+                                                                  "$.id")))
                                                   .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
                                                   .andReturn();
 
@@ -168,13 +175,13 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
                                                              bitstreamFormatRest.getMimetype(),
                                                              bitstreamFormatRest.getDescription(),
                                                              bitstreamFormatRest.getShortDescription())
-                       )))
-                       .andDo(result -> idRef
-                               .set(read(result.getResponse().getContentAsString(), "$.id")));
+                       )));
 
         } finally {
-            // Delete the created community (cleanup after ourselves!)
-            BitstreamFormatBuilder.deleteBitstreamFormat(idRef.get());
+            // Delete the created bitstream format (cleanup after ourselves!)
+            if (idRef.get() != null) {
+                BitstreamFormatBuilder.deleteBitstreamFormat(idRef.get());
+            }
         }
 
 
@@ -183,8 +190,9 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
     @Test
     public void createNonValidSupportLevel() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
+        BitstreamFormatRest bitstreamFormatRest = this.createMockBitstreamRest();
         bitstreamFormatRest.setSupportLevel("NONVALID SUPPORT LVL");
+        int totalFormatsBefore = currentTotalFormats();
         //Attempt to create bitstream with a non-valid support lvl
         String token = getAuthToken(admin.getEmail(), password);
         getClient(token).perform(post("/api/core/bitstreamformats/")
@@ -194,13 +202,14 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
         // Check that no new bitstreamformat was created
         getClient().perform(get("/api/core/bitstreamformats/"))
                    .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(DEFAULT_AMOUNT_FORMATS)));
+                   .andExpect(jsonPath("$.page.totalElements", is(totalFormatsBefore)));
     }
 
     @Test
     public void createNoAccess() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
+        BitstreamFormatRest bitstreamFormatRest = this.createMockBitstreamRest();
+        int totalFormatsBefore = currentTotalFormats();
 
         //Try to create bitstreamFormat without auth token
         getClient(null).perform(post("/api/core/bitstreamformats/")
@@ -210,13 +219,14 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
         // Check that no new bitstreamformat was created
         getClient().perform(get("/api/core/bitstreamformats/"))
                    .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(DEFAULT_AMOUNT_FORMATS)));
+                   .andExpect(jsonPath("$.page.totalElements", is(totalFormatsBefore)));
     }
 
     @Test
     public void createNonAdminAccess() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
+        BitstreamFormatRest bitstreamFormatRest = this.createMockBitstreamRest();
+        int totalFormatsBefore = currentTotalFormats();
         context.turnOffAuthorisationSystem();
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
@@ -234,13 +244,14 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
         // Check that no new bitstreamformat was created
         getClient().perform(get("/api/core/bitstreamformats/"))
                    .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(DEFAULT_AMOUNT_FORMATS)));
+                   .andExpect(jsonPath("$.page.totalElements", is(totalFormatsBefore)));
     }
 
     @Test
     public void createAlreadyExisting() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(true);
+        BitstreamFormatRest bitstreamFormatRest = this.createMockBitstreamRest();
+        int totalFormatsBefore = currentTotalFormats();
 
         // Capture the Id of the created BitstreamFormat (see andDo() below)
         AtomicReference<Integer> idRef = new AtomicReference<>();
@@ -264,12 +275,14 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
             // Check that the new bitstreamformat was created only once
             getClient().perform(get("/api/core/bitstreamformats/"))
                        .andExpect(status().isOk())
-                       .andExpect(jsonPath("$.page.totalElements", is(DEFAULT_AMOUNT_FORMATS + 1)));
+                       .andExpect(jsonPath("$.page.totalElements", is(totalFormatsBefore + 1)));
 
 
         } finally {
-            // Delete the created community (cleanup after ourselves!)
-            BitstreamFormatBuilder.deleteBitstreamFormat(idRef.get());
+            // Delete the created bitstream format (cleanup after ourselves!)
+            if (idRef.get() != null) {
+                BitstreamFormatBuilder.deleteBitstreamFormat(idRef.get());
+            }
         }
     }
 
@@ -645,19 +658,25 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
                    )));
     }
 
-    private BitstreamFormatRest createRandomMockBitstreamRest(boolean withRand) {
+    /**
+     * Short descriptions are unique in the format registry, so derive them from the test method
+     * name: deterministic and collision-free, unlike the random numbers used before.
+     */
+    private BitstreamFormatRest createMockBitstreamRest() {
         BitstreamFormatRest bitstreamFormatRest = new BitstreamFormatRest();
-        String random = null;
-        if (withRand) {
-            Random rand = new Random();
-            random = String.valueOf(rand.nextInt(100) + 1);
-        }
-        bitstreamFormatRest.setShortDescription("Test short" + random);
+        bitstreamFormatRest.setShortDescription("Test short " + testName.getMethodName());
         bitstreamFormatRest.setDescription("Full description of Test short");
         bitstreamFormatRest.setMimetype("text/plain");
         bitstreamFormatRest.setSupportLevel("KNOWN");
         bitstreamFormatRest.setInternal(false);
         bitstreamFormatRest.setExtensions(Arrays.asList("txt", "asc"));
         return bitstreamFormatRest;
+    }
+
+    private int currentTotalFormats() throws Exception {
+        String response = getClient().perform(get("/api/core/bitstreamformats/"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return read(response, "$.page.totalElements");
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PreviewContentServiceImplIT.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.IOUtils;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BitstreamFormatBuilder;
 import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -33,7 +34,6 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.PreviewContent;
-import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.PreviewContentService;
 import org.dspace.util.FileInfo;
 import org.junit.After;
@@ -46,8 +46,6 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
 
     @Autowired
     PreviewContentService previewContentService;
-    @Autowired
-    BitstreamFormatService bitstreamFormatService;
 
     PreviewContent previewContent0;
     PreviewContent previewContent1;
@@ -256,11 +254,15 @@ public class PreviewContentServiceImplIT extends AbstractControllerIntegrationTe
         BitstreamBuilder.deleteBitstream(tarXzFileWithIncorrectMimeType.getID());
 
         // removing custom mime type format created for tarXGzipFile and tgzFileWithGzipMimeType files
-        if (customMimeTypeFormat != null) {
-            bitstreamFormatService.delete(context, customMimeTypeFormat);
-        }
+        Integer customMimeTypeFormatId = customMimeTypeFormat == null ? null : customMimeTypeFormat.getID();
 
         super.destroy();
+
+        // Must run in its own Context after super.destroy(): a delete through the shared test
+        // context is never committed here, which leaked one format row per test.
+        if (customMimeTypeFormatId != null) {
+            BitstreamFormatBuilder.deleteBitstreamFormat(customMimeTypeFormatId);
+        }
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -403,6 +403,10 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
             .contentType(contentType))
                                 .andExpect(status().isCreated());
 
+        // Commit the view event waiting for a new searcher so it is visible to the report query
+        // below (same race and fix as in topCountriesReport_Community_Visited).
+        StatisticsServiceFactory.getInstance().getSolrLoggerService().commit();
+
         // And request that collection's TotalVisits stat report
         getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))


### PR DESCRIPTION
## References
* Continues the de-flake series #1321, #1344, #1346
* Handle randomization history: ufal/clarin-dspace#1273
* Failing scheduled runs: 32009094158, 31883563801, 31653657025 (dspace-api); 31147975599, 31873509292, 30976733926 (dspace-server-webapp)

## Description
Scheduled integration-test builds on `dtq-dev` fail intermittently (~1 in 5 runs), each time in a different test. This PR removes the three sources of cross-test interference behind those failures. Test-only changes, no production code touched.

## Instructions for Reviewers

List of changes in this PR:
* `RequiredMetadataIT`, `ItemHandleCheckerIT`: the explicit collection handle is a deterministic non-numeric suffix (e.g. `123456789/required-metadata-test`) instead of `123456789/<1000 + Random.nextInt(1000)>`. Handle rows survive object deletion and `handle_seq` reaches 1000+ late in the module run, so the random handle was intermittently re-minted by the sequence and killed whichever test was minting at that moment (`Unique index or primary key violation ... PUBLIC.HANDLE ... '123456789/1154'`, session left MARKED_ROLLBACK). A non-numeric suffix can never be produced by the sequence; per-class constants keep the ufal/clarin-dspace#1273 protection against cross-class handle reuse. `XmlWorkflowFactoryTest` gets the same treatment for its `123456789/999`.
* `PreviewContentServiceImplIT`: the custom bitstream format is deleted by id in its own `Context` after `super.destroy()`. The previous delete went through the shared test context, where it is never committed, leaking one registry row per test (13 total) and breaking `BitstreamFormatRestRepositoryIT` count assertions whenever class scan order put Preview first.
* `BitstreamFormatRestRepositoryIT`: short descriptions derived from the test method name instead of `Random` (also removes the accidental `"Test shortnull"`), the created format id is captured on the POST so the finally-block cleans up even when a later assertion fails, and count assertions compare against a baseline read at test start instead of the hardcoded registry size.
* `StatisticsRestRepositoryIT#totalVisitsReport_Item_Visited`: an explicit statistics-core commit (waitSearcher=true) between posting the view event and querying the report, as `topCountriesReport_Community_Visited` already does. The report could otherwise read a stale Solr searcher and see 0 views. The same pattern exists in the other view-then-assert tests of this class; only the one observed failing is changed here.

To reproduce the two main failures on `dtq-dev` (both verified in Docker, `maven:3.9-eclipse-temurin-11`, CI flags):
* Pin the explicit handle in `RequiredMetadataIT.randomString()` to `"20"` and run `mvn -pl dspace-api verify -DskipIntegrationTests=false -Dit.test=RequiredMetadataIT,SubscribeServiceIT` - fails with the exact CI signature. With this PR the planted handle is gone and the same selection is green.
* `mvn -pl dspace-server-webapp verify -DskipIntegrationTests=false -Dit.test=PreviewContentServiceImplIT,BitstreamFormatRestRepositoryIT -Dfailsafe.runOrder=reversealphabetical` - 4 failures (totalElements 95 vs 108). With this PR: green.

Notes:
* The mint path itself (`HandleServiceImpl.createId`) still trusts the sequence blindly; hardening it (skip suffixes whose handle already exists) would also cover production minting after handle imports, and is prepared as a possible follow-up PR.
* The IT job's `-Dfailsafe.rerunFailingTestsCount=2` is ignored by maven-failsafe-plugin 2.22.x (it reads `surefire.rerunFailingTestsCount`), so IT reruns never actually ran; the one-line workflow fix comes separately.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).