### PR TITLE
Expose buildVersion on REST root — serving side (#813)

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -10,6 +10,9 @@ package org.dspace.app.rest.converter;
 import static org.dspace.app.util.Util.getSourceVersion;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.RootRest;
 import org.dspace.services.ConfigurationService;
@@ -39,8 +42,37 @@ public class RootConverter {
             rootRest.setDspaceServer(dspaceUrl);
         }
         rootRest.setDspaceVersion("DSpace " + getSourceVersion());
+        rootRest.setBuildVersion(getBuildVersion());
         return rootRest;
     }
 
+    /**
+     * Read the build version from the `build.version.file.path` property
+     *
+     * @return content of the version file
+     */
+    private String getBuildVersion() {
+        String bVersionFilePath = configurationService.getProperty("build.version.file.path");
 
+        if (StringUtils.isBlank(bVersionFilePath)) {
+            return "Unknown";
+        }
+
+        StringBuilder buildVersion = new StringBuilder();
+        try {
+            FileReader fileReader = new FileReader(bVersionFilePath);
+            BufferedReader bufferedReader = new BufferedReader(fileReader);
+
+            String line;
+            // Read each line from the file until the end of the file is reached
+            while ((line = bufferedReader.readLine()) != null) {
+                buildVersion.append(line);
+            }
+
+        } catch (IOException e) {
+            // Empty - do not log anything
+        }
+
+        return buildVersion.toString();
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -9,10 +9,11 @@ package org.dspace.app.rest.converter;
 
 import static org.dspace.app.util.Util.getSourceVersion;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.RootRest;
 import org.dspace.services.ConfigurationService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RootRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RootRest.java
@@ -22,6 +22,7 @@ public class RootRest extends RestAddressableModel {
     private String dspaceName;
     private String dspaceServer;
     private String dspaceVersion;
+    private String buildVersion;
 
     public String getCategory() {
         return CATEGORY;
@@ -76,6 +77,14 @@ public class RootRest extends RestAddressableModel {
         this.dspaceVersion = dspaceVersion;
     }
 
+    public String getBuildVersion() {
+        return buildVersion;
+    }
+
+    public void setBuildVersion(String buildVersion) {
+        this.buildVersion = buildVersion;
+    }
+
     @Override
     public boolean equals(Object object) {
         return (object instanceof RootRest &&
@@ -85,6 +94,7 @@ public class RootRest extends RestAddressableModel {
                                .append(this.getDspaceUI(), ((RootRest) object).getDspaceUI())
                                .append(this.getDspaceName(), ((RootRest) object).getDspaceName())
                                .append(this.getDspaceServer(), ((RootRest) object).getDspaceServer())
+                               .append(this.getBuildVersion(), ((RootRest) object).getBuildVersion())
                                .isEquals());
     }
 
@@ -97,6 +107,7 @@ public class RootRest extends RestAddressableModel {
             .append(this.getDspaceName())
             .append(this.getDspaceUI())
             .append(this.getDspaceServer())
+            .append(this.getBuildVersion())
             .toHashCode();
     }
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -42,6 +42,10 @@ dspace.ui.url = http://localhost:4000
 dspace.name = DSpace Jihočeské Univerzity v Českých Budějovicích
 dspace.shortname = DSpace
 
+### The build version is stored in the specific file (issue #813) ###
+### Exposed as `buildVersion` on the REST root endpoint (/server/api). ###
+build.version.file.path = ${dspace.dir}/config/VERSION_D.txt
+
 # Assetstore configurations have moved to config/modules/assetstore.cfg
 # and config/spring/api/bitstore.xml.
 # Additional storage options (e.g. Amazon S3) are available in `assetstore.cfg`


### PR DESCRIPTION
## What & why (issue #813)

Expose **which commit is currently deployed** as `buildVersion` on the REST root endpoint (`/server/api`), matching `dtq-dev`.

The Docker build already generated `dspace/config/VERSION_D.txt` (via `docker.yml` + `reusable-docker-build.yml`), but nothing exposed it. This adds the **serving side** for DSpace 9.

## Changes

- `dspace/config/dspace.cfg` — `build.version.file.path` points at the generated file.
- `RootConverter` reads the file into `RootRest.buildVersion`; `RootRest` gains the `buildVersion` field (getter/setter, equals/hashCode).
- `dspace/config/VERSION_D.txt` — empty placeholder (overwritten at build).

## Verification

- `dspace-server-webapp` compiles.
- `buildVersion` appears on `GET /server/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
